### PR TITLE
update readme and install section in pdf manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Asterix is a package to simulate high-contrast imaging correction algorithms wit
 
 Please find the latest documentation (pdf file) here : https://www.dropbox.com/s/wjiwci2r6yzudvj/asterix.pdf?dl=1
 
-Due to the continually developing nature of this package, we recommend you use the current version of the code on GitHub and keep it updated.
+Due to the continually developing nature of this package, we recommend you use the current version of the code on GitHub and keep it updated frequently.
 
 ## Installation
 
@@ -19,8 +19,8 @@ $ cd Asterix
 $ conda env create --file environment.yml
 ```
 
-Install Asterix into this conda environment:
+Then install Asterix into this conda environment:
 ```bash
 $ conda activate asterix
-$ python setup.py develop
+$ pip install -e '.'
 ```

--- a/source/conf.py
+++ b/source/conf.py
@@ -20,7 +20,7 @@ sys.path.append('/Users/jmazoyer/GitProjects/my_projects/Asterix/Asterix/')
 
 project = 'Asterix'
 copyright = '2021, Johan Mazoyer, Axel Potier, Raphaël Galicher'
-author = 'Johan Mazoyer, Axel Potier, Raphaël Galicher'
+author = 'Johan Mazoyer, Iva Laginja, Axel Potier, Raphaël Galicher'
 
 # The full version, including alpha/beta/rc tags
 # release = 'v2.0'

--- a/source/index.rst
+++ b/source/index.rst
@@ -9,7 +9,7 @@ focus on focal plane wavefront sensing and correction algorithms.
 
 Asterix is publicaly available on `GitHub <https://github.com/johanmazoyer/Asterix>`_ and all contributions are welcome!
 
-The development of Asterix is led by Johan Mazoyer with major contributions Axel Potier 
+The development of Asterix is led by Johan Mazoyer with major contributions Axel Potier, Iva Laginja, 
 and Raphaël Galicher from LESIA (Paris Observatory)
 
 

--- a/source/install.rst
+++ b/source/install.rst
@@ -19,20 +19,9 @@ will hinder the use of Asterx and/or on your other projects.
 First download and install miniconda3:
 https://docs.conda.io/en/latest/miniconda.html
 
-You can now create an environement for installing Asterix:
-
-    $ conda create --name asterix-env python=3.8 numpy scipy astropy matplotlib configobj
-
-This will automatically create a python environement with only the required python packages for Asterix, at their
-latest stable version. Before installing Asterix and everytime you want to use it you need to activate this environement:
-
-    $ conda activate asterix-env
-
-
 You can use the very useful `Conda Cheat Sheet <https://docs.conda.io/projects/conda/en/4.6.0/_downloads/52a95608c49671267e40c689e0bc00ca/conda-cheatsheet.pdf>`_
 which lists the most common conda command lines you can use.
  
-
 Install Asterix
 -----------------
 
@@ -44,19 +33,19 @@ developer version, clone the Asterix repository :
 
     $ git clone https://github.com/johanmazoyer/Asterix.git
 
-This clones the repository using HTTPS authentication. Once the repository is cloned onto your computer, ``cd Asterix`` into it.
-If you are using a specific environement for Asterix (see previous section), now is the time to Activate it:
-    
-    $ conda activate asterix-env
+This clones the repository using HTTPS authentication. Once the repository is cloned onto your computer, ``cd Asterix`` into it. 
+Then type:
 
-Run the setup file:
+    $ conda env create --file environment.yml
+
+This will automatically create a python environement named ``asterix`` with only the required python packages for Asterix, at their
+latest stable version. Before installing Asterix and everytime you want to use it, you need to activate this environement:
+
+    $ conda activate asterix
+
+Run the setup file to install Asterix:
 
     $ pip install -e '.'
-
-If you use multiple versions/environements of python, you will need to do this with each version of python
-(this should not apply to most people).
-
-
 
 
 Dependencies


### PR DESCRIPTION
Edited by @ivalaginja : Always good to provide a basic description with a PR! :)

Deprecation of `setuptools` command line functionality was introduced here: https://github.com/pypa/setuptools/pull/2824
And a summary of what is happening is given here: https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html