### PR TITLE
Unify class names in OpticalSystem module

### DIFF
--- a/Asterix/Main_THD.py
+++ b/Asterix/Main_THD.py
@@ -99,16 +99,16 @@ def runthd2(parameter_file,
     Labview_dir = os.path.join(Data_dir, "Labview") + os.path.sep
 
     # Initialize thd:
-    entrance_pupil = OptSy.pupil(modelconfig,
+    entrance_pupil = OptSy.Pupil(modelconfig,
                                  PupType=modelconfig['filename_instr_pup'],
                                  angle_rotation=modelconfig['entrance_pup_rotation'],
                                  Model_local_dir=Model_local_dir)
 
-    DM1 = OptSy.deformable_mirror(modelconfig, DMconfig, Name_DM='DM1', Model_local_dir=Model_local_dir)
+    DM1 = OptSy.DeformableMirror(modelconfig, DMconfig, Name_DM='DM1', Model_local_dir=Model_local_dir)
 
-    DM3 = OptSy.deformable_mirror(modelconfig, DMconfig, Name_DM='DM3', Model_local_dir=Model_local_dir)
+    DM3 = OptSy.DeformableMirror(modelconfig, DMconfig, Name_DM='DM3', Model_local_dir=Model_local_dir)
 
-    corono = OptSy.coronagraph(modelconfig, Coronaconfig, Model_local_dir=Model_local_dir)
+    corono = OptSy.Coronagraph(modelconfig, Coronaconfig, Model_local_dir=Model_local_dir)
     # and then just concatenate
     thd2 = OptSy.Testbed([entrance_pupil, DM1, DM3, corono], ["entrancepupil", "DM1", "DM3", "corono"])
 

--- a/Asterix/Optical_System_functions.py
+++ b/Asterix/Optical_System_functions.py
@@ -1035,7 +1035,7 @@ class coronagraph(Optical_System):
             self.perfect_coro = True
 
         else:
-            raise Exception("this coronagrpah mode does not exists yet")
+            raise Exception(f"The requested coronagraph mode '{self.corona_type}' does not exists.")
 
         self.lyot_pup = pupil(modelconfig,
                               prad=self.prad * coroconfig["diam_lyot_in_m"] / self.diam_pup_in_m,
@@ -1051,7 +1051,7 @@ class coronagraph(Optical_System):
             if coroconfig["bool_overwrite_perfect_coro"] is False:
                 self.perfect_coro = False
 
-        if self.perfect_coro == True:
+        if self.perfect_coro is True:
 
             if coroconfig["filename_instr_apod"] == "Clear":
                 # We need a round pupil only to measure the response
@@ -1068,14 +1068,14 @@ class coronagraph(Optical_System):
                         entrance_EF=pup_for_perfect_coro.EF_through(wavelength=wave_here),
                         wavelength=wave_here)
             else:
-                # In this case we have an coronagrpah entrance pupil
-                # do a propagation once with self.perfect_Lyot_pupil = 0 to
-                # measure the Lyot pupil that will be removed after
+                # In this case we have a coronagraph entrance pupil.
+                # Do a propagation once with self.perfect_Lyot_pupil = 0 to
+                # measure the Lyot pupil that will be removed after.
                 self.perfect_Lyot_pupil = [0] * self.nb_wav
                 for i, wave_here in enumerate(self.wav_vec):
                     self.perfect_Lyot_pupil[i] = self.EF_through(wavelength=wave_here)
 
-        #initialize the max and sum of PSFs for the normalization to contrast
+        # Initialize the max and sum of PSFs for the normalization to contrast
         self.measure_normalization()
 
     def EF_through(self,

--- a/Asterix/Optical_System_functions.py
+++ b/Asterix/Optical_System_functions.py
@@ -32,7 +32,7 @@ class OpticalSystem:
 
     def __init__(self, modelconfig):
         """ --------------------------------------------------
-        Initialize Optical_System objects
+        Initialize OpticalSystem objects
         AUTHOR : Johan Mazoyer
 
         Parameters
@@ -84,14 +84,14 @@ class OpticalSystem:
             int(self.wavelength_0 * 1e9)) + "_resFP" + str(round(self.Science_sampling, 2)) + "_dimFP" + str(
                 int(self.dimScience))
 
-    #We define functions that all Optical_System object can use.
+    #We define functions that all OpticalSystem object can use.
     # These can be overwritten for a subclass if need be
 
     def EF_through(self, entrance_EF=1., save_all_planes_to_fits=False, dir_save_all_planes=None, **kwargs):
         """ --------------------------------------------------
         Propagate the electric field from entrance pupil to exit pupil
 
-        NEED TO BE DEFINED FOR ALL Optical_System
+        NEED TO BE DEFINED FOR ALL OpticalSystem subclasses
 
         AUTHOR : Johan Mazoyer
 
@@ -111,7 +111,7 @@ class OpticalSystem:
                             directory to save all plane in fits
                                 if save_all_planes_to_fits = True
         **kwargs: 
-            other parameters can be passed for Optical_System objects EF_trough functions
+            other parameters can be passed for OpticalSystem objects EF_trough functions
 
         Returns
         ------
@@ -678,13 +678,13 @@ class OpticalSystem:
 class Pupil(OpticalSystem):
     """ --------------------------------------------------
     initialize and describe the behavior of single pupil
-    pupil is a sub class of Optical_System.
+    pupil is a sub class of OpticalSystem.
 
     Obviously you can define your pupil
     without that with 2d arrray multiplication (this is a fairly simple object).
 
-    The main advantage of defining them using Optical_System is that you can
-    use default Optical_System functions to obtain PSF, transmission, etc...
+    The main advantage of defining them using OpticalSystem is that you can
+    use default OpticalSystem functions to obtain PSF, transmission, etc...
     and concatenate them with other elements
 
     AUTHOR : Johan Mazoyer
@@ -705,7 +705,7 @@ class Pupil(OpticalSystem):
         ----------
         modelconfig : dict
                     general configuration parameters (sizes and dimensions)
-                        to initialize Optical_System class
+                        to initialize OpticalSystem class
 
         prad : float
             Default is the pupil radius in the parameter file (self.prad)
@@ -735,7 +735,7 @@ class Pupil(OpticalSystem):
                     and can save to save time
 
         -------------------------------------------------- """
-        # Initialize the Optical_System class and inherit properties
+        # Initialize the OpticalSystem class and inherit properties
         super().__init__(modelconfig)
 
         if (Model_local_dir is not None) and not os.path.exists(Model_local_dir):
@@ -879,7 +879,7 @@ class Pupil(OpticalSystem):
 
         -------------------------------------------------- """
 
-        # call the Optical_System super function to check and format the variable entrance_EF
+        # call the OpticalSystem super function to check and format the variable entrance_EF
         entrance_EF = super().EF_through(entrance_EF=entrance_EF)
         if wavelength is None:
             wavelength = self.wavelength_0
@@ -911,7 +911,7 @@ class Pupil(OpticalSystem):
 class Coronagraph(OpticalSystem):
     """ --------------------------------------------------
     initialize and describe the behavior of a coronagraph system (from apod plane to the Lyot plane)
-    coronagraph is a sub class of Optical_System.
+    coronagraph is a sub class of OpticalSystem.
 
     AUTHOR : Johan Mazoyer
 
@@ -937,7 +937,7 @@ class Coronagraph(OpticalSystem):
 
         -------------------------------------------------- """
 
-        # Initialize the Optical_System class and inherit properties
+        # Initialize the OpticalSystem class and inherit properties
         super().__init__(modelconfig)
 
         if (Model_local_dir is not None) and not os.path.exists(Model_local_dir):
@@ -1120,7 +1120,7 @@ class Coronagraph(OpticalSystem):
 
         -------------------------------------------------- """
 
-        # call the Optical_System super function to check and format the variable entrance_EF
+        # call the OpticalSystem super function to check and format the variable entrance_EF
         entrance_EF = super().EF_through(entrance_EF=entrance_EF)
 
         if wavelength is None:
@@ -1496,7 +1496,7 @@ class DeformableMirror(OpticalSystem):
     """ --------------------------------------------------
     initialize and describe the behavior of a deformable mirror
     (in pupil plane or out of pupil plane)
-    coronagraph is a sub class of Optical_System.
+    coronagraph is a sub class of OpticalSystem.
 
 
     AUTHOR : Johan Mazoyer
@@ -1529,7 +1529,7 @@ class DeformableMirror(OpticalSystem):
         
         -------------------------------------------------- """
 
-        # Initialize the Optical_System class and inherit properties
+        # Initialize the OpticalSystem class and inherit properties
         super().__init__(modelconfig)
 
         if not os.path.exists(Model_local_dir):
@@ -1641,7 +1641,7 @@ class DeformableMirror(OpticalSystem):
 
         -------------------------------------------------- """
 
-        # call the Optical_System super function to check
+        # call the OpticalSystem super function to check
         # and format the variable entrance_EF
         entrance_EF = super().EF_through(entrance_EF=entrance_EF)
 
@@ -2108,7 +2108,7 @@ class Testbed(OpticalSystem):
             print("")
             raise Exception("list of systems and list of names need to be of the same size")
 
-        # Initialize the Optical_System class and inherit properties
+        # Initialize the OpticalSystem class and inherit properties
         super().__init__(list_os[0].modelconfig)
 
         init_string = self.string_os

--- a/Asterix/Optical_System_functions.py
+++ b/Asterix/Optical_System_functions.py
@@ -19,11 +19,11 @@ model_dir = os.path.join(Asterix_root, "Model") + os.path.sep
 
 class OpticalSystem:
     """ --------------------------------------------------
-    Super class Optical_System allows to pass parameters to all sub class.
-    We can then creat blocks inside this super class. An Optical_System start and
+    Super class OpticalSystem allows passing parameters to all subclasses.
+    We can then creat blocks inside this super class. An OpticalSystem start and
     end in the pupil plane.
     The entrance and exit pupil plane must always of the same size (dim_overpad_pupil)
-    With these convention, they can be easily assemble to create complex optical systems.
+    With these conventions, they can be easily assemble to create complex optical systems.
 
 
     AUTHOR : Johan Mazoyer
@@ -2085,9 +2085,9 @@ class Testbed(OpticalSystem):
 
     def __init__(self, list_os, list_os_names):
         """ --------------------------------------------------
-        This function allow you to concatenates Optical_System obsjects to create a testbed:
+        This function allows you to concatenate OpticalSystem objects to create a testbed:
         parameter:
-            list_os:        list of Optical_System
+            list_os:        list of OpticalSystem instances
                             all the systems must have been defined with
                             the same modelconfig or it will send an error.
                             The list order is form the first optics system to the last in the

--- a/Asterix/Optical_System_functions.py
+++ b/Asterix/Optical_System_functions.py
@@ -17,9 +17,6 @@ Asterix_root = os.path.dirname(os.path.realpath(__file__)) + os.path.sep
 model_dir = os.path.join(Asterix_root, "Model") + os.path.sep
 
 
-##############################################
-##############################################
-### Optical_System
 class OpticalSystem:
     """ --------------------------------------------------
     Super class Optical_System allows to pass parameters to all sub class.
@@ -678,9 +675,6 @@ class OpticalSystem:
         return entrance_EF
 
 
-##############################################
-##############################################
-### PUPIL
 class Pupil(OpticalSystem):
     """ --------------------------------------------------
     initialize and describe the behavior of single pupil
@@ -914,9 +908,6 @@ class Pupil(OpticalSystem):
         return exit_EF
 
 
-##############################################
-##############################################
-### CORONAGRAPHS
 class Coronagraph(OpticalSystem):
     """ --------------------------------------------------
     initialize and describe the behavior of a coronagraph system (from apod plane to the Lyot plane)
@@ -1501,9 +1492,6 @@ class Coronagraph(OpticalSystem):
         return hlc_all_wl
 
 
-##############################################
-##############################################
-### Deformable mirrors
 class DeformableMirror(OpticalSystem):
     """ --------------------------------------------------
     initialize and describe the behavior of a deformable mirror
@@ -2082,9 +2070,6 @@ class DeformableMirror(OpticalSystem):
         return basis
 
 
-##############################################
-##############################################
-### Testbeds
 class Testbed(OpticalSystem):
     """ --------------------------------------------------
     
@@ -2305,12 +2290,7 @@ class Testbed(OpticalSystem):
         return vector_actuator_voltage
 
 
-##############################################
-##############################################
-### internal functions to properly concatenate the EF_through functions
-### probably not needed outside of this file
-
-
+# Some internal functions to properly concatenate the EF_through functions
 def _swap_DMphase_name(DM_EF_through_function, name_var):
     """ --------------------------------------------------
    A function to rename the DMphase parameter to another name (usually DMXXphase)

--- a/Asterix/Optical_System_functions.py
+++ b/Asterix/Optical_System_functions.py
@@ -20,7 +20,7 @@ model_dir = os.path.join(Asterix_root, "Model") + os.path.sep
 ##############################################
 ##############################################
 ### Optical_System
-class Optical_System:
+class OpticalSystem:
     """ --------------------------------------------------
     Super class Optical_System allows to pass parameters to all sub class.
     We can then creat blocks inside this super class. An Optical_System start and
@@ -681,7 +681,7 @@ class Optical_System:
 ##############################################
 ##############################################
 ### PUPIL
-class pupil(Optical_System):
+class Pupil(OpticalSystem):
     """ --------------------------------------------------
     initialize and describe the behavior of single pupil
     pupil is a sub class of Optical_System.
@@ -917,7 +917,7 @@ class pupil(Optical_System):
 ##############################################
 ##############################################
 ### CORONAGRAPHS
-class coronagraph(Optical_System):
+class Coronagraph(OpticalSystem):
     """ --------------------------------------------------
     initialize and describe the behavior of a coronagraph system (from apod plane to the Lyot plane)
     coronagraph is a sub class of Optical_System.
@@ -955,7 +955,7 @@ class coronagraph(Optical_System):
 
         # Plane at the entrance of the coronagraph. In THD2, this is an empty plane.
         # In Roman this is where is the apodiser
-        self.apod_pup = pupil(modelconfig,
+        self.apod_pup = Pupil(modelconfig,
                               prad=self.prad,
                               PupType=coroconfig["filename_instr_apod"],
                               angle_rotation=coroconfig['apod_pup_rotation'],
@@ -1037,7 +1037,7 @@ class coronagraph(Optical_System):
         else:
             raise Exception(f"The requested coronagraph mode '{self.corona_type}' does not exists.")
 
-        self.lyot_pup = pupil(modelconfig,
+        self.lyot_pup = Pupil(modelconfig,
                               prad=self.prad * coroconfig["diam_lyot_in_m"] / self.diam_pup_in_m,
                               PupType=coroconfig["filename_instr_lyot"],
                               angle_rotation=coroconfig['lyot_pup_rotation'],
@@ -1058,7 +1058,7 @@ class coronagraph(Optical_System):
                 # of the coronograph to a round pupil to remove it
                 # THIS IS NOT THE ENTRANCE PUPIL,
                 # this is a round pupil of the same size
-                pup_for_perfect_coro = pupil(modelconfig, prad=self.prad)
+                pup_for_perfect_coro = Pupil(modelconfig, prad=self.prad)
 
                 # do a propagation once with self.perfect_Lyot_pupil = 0 to
                 # measure the Lyot pupil that will be removed after
@@ -1504,7 +1504,7 @@ class coronagraph(Optical_System):
 ##############################################
 ##############################################
 ### Deformable mirrors
-class deformable_mirror(Optical_System):
+class DeformableMirror(OpticalSystem):
     """ --------------------------------------------------
     initialize and describe the behavior of a deformable mirror
     (in pupil plane or out of pupil plane)
@@ -1594,7 +1594,7 @@ class deformable_mirror(Optical_System):
         # We need a pupil in creatingpushact_inpup() and for
         # which in pup. THIS IS NOT THE ENTRANCE PUPIL,
         # this is a round pupil of the same size
-        self.clearpup = pupil(modelconfig, PupType="RoundPup", prad=self.prad)
+        self.clearpup = Pupil(modelconfig, PupType="RoundPup", prad=self.prad)
 
         # create the DM_pushact, surface of the DM for each individual act
         # DM_pushact is always in the DM plane
@@ -2085,7 +2085,7 @@ class deformable_mirror(Optical_System):
 ##############################################
 ##############################################
 ### Testbeds
-class Testbed(Optical_System):
+class Testbed(OpticalSystem):
     """ --------------------------------------------------
     
     Initialize and describe the behavior of a testbed.
@@ -2148,7 +2148,7 @@ class Testbed(Optical_System):
 
             # we first check that all variables in the list are optical systems
             # defined the same way.
-            if not isinstance(list_os[num_optical_sys], Optical_System):
+            if not isinstance(list_os[num_optical_sys], OpticalSystem):
                 raise Exception("list_os[" + str(num_optical_sys) + "] is not an optical system")
 
             if list_os[num_optical_sys].modelconfig != self.modelconfig:
@@ -2161,7 +2161,7 @@ class Testbed(Optical_System):
             for params in inspect.signature(list_os[num_optical_sys].EF_through).parameters:
                 known_keywords.append(params)
 
-            if isinstance(list_os[num_optical_sys], deformable_mirror):
+            if isinstance(list_os[num_optical_sys], DeformableMirror):
 
                 #this function is to replace the DMphase variable by a XXphase variable
                 # where XX is the name of the DM
@@ -2249,7 +2249,7 @@ class Testbed(Optical_System):
 
         for i, DM_name in enumerate(self.name_of_DMs):
 
-            DM = vars(self)[DM_name]  # type: deformable_mirror
+            DM = vars(self)[DM_name]  # type: DeformableMirror
             actu_vect_DM = actu_vect[indice_acum_number_act:indice_acum_number_act + DM.number_act]
             DMphases[i] = DM.voltage_to_phase(actu_vect_DM, einstein_sum=einstein_sum)
 
@@ -2285,7 +2285,7 @@ class Testbed(Optical_System):
         for DM_name in self.name_of_DMs:
 
             # we access each DM object individually
-            DM = vars(self)[DM_name]  # type: deformable_mirror
+            DM = vars(self)[DM_name]  # type: DeformableMirror
 
             # we extract the voltages for this one
             # this voltages are in the DM basis

--- a/Asterix/THD_quick_invert.py
+++ b/Asterix/THD_quick_invert.py
@@ -80,12 +80,12 @@ def THD_quick_invert(Nbmodes, name_active_DM, matrix_directory, regularization):
     else:
         raise Exception("No active DMs")
 
-    _, _, invertGDH = wsc.invertSVD(Gmatrix,
-                                    Nbmodes,
-                                    goal="c",
-                                    regul=regularization,
-                                    visu=True,
-                                    filename_visu=os.path.join(matrix_directory,
+    _, _, invertGDH = wsc.invert_svd(Gmatrix,
+                                     Nbmodes,
+                                     goal="c",
+                                     regul=regularization,
+                                     visu=True,
+                                     filename_visu=os.path.join(matrix_directory,
                                                                "SVD_Modes" + str(Nbmodes) + ".png"))
 
     if name_active_DM == 13 or name_active_DM == 31:

--- a/Asterix/WSC_functions.py
+++ b/Asterix/WSC_functions.py
@@ -11,15 +11,15 @@ from astropy.io import fits
 
 import Asterix.propagation_functions as prop
 import Asterix.processing_functions as proc
-import Asterix.fits_functions as useful
-import Asterix.Optical_System_functions as OptSy
+import Asterix.save_and_read as useful
+import Asterix.optical_systems as OptSy
 
 #################################################################################
 ### Correction functions
 #################################################################################
 
 
-def invertSVD(matrix_to_invert, cut, goal="e", regul="truncation", visu=False, filename_visu=None):
+def invert_svd(matrix_to_invert, cut, goal="e", regul="truncation", visu=False, filename_visu=None):
     """ --------------------------------------------------
     Invert a matrix after a Singular Value Decomposition
     https://en.wikipedia.org/wiki/Singular_value_decomposition
@@ -97,7 +97,7 @@ def invertSVD(matrix_to_invert, cut, goal="e", regul="truncation", visu=False, f
     return [np.diag(InvS), np.diag(InvS_truncated), pseudoinverse]
 
 
-def creatingInteractionmatrix(testbed: OptSy.Testbed,
+def create_interaction_matrix(testbed: OptSy.Testbed,
                               dimEstim,
                               amplitudeEFC,
                               matrix_dir,
@@ -466,9 +466,9 @@ def creatingInteractionmatrix(testbed: OptSy.Testbed,
     return InterMat
 
 
-def cropDHInteractionMatrix(FullInteractionMatrix: np.ndarray, mask: np.ndarray):
+def crop_interaction_matrix_to_dh(FullInteractionMatrix: np.ndarray, mask: np.ndarray):
     """ --------------------------------------------------
-    Crop the  Interaction Matrix. to the mask size
+    Crop the  Interaction Matrix to the DH mask size.
     AUTHOR : Johan Mazoyer
 
     Parameters
@@ -583,8 +583,8 @@ def solutionEM(mask, Result_Estimate, Hessian_Matrix, Jacobian, testbed: OptSy.T
     return testbed.basis_vector_to_act_vector(produit_mat)
 
 
-def solutionSM(mask, Result_Estimate, Jacob_trans_Jacob, Jacobian, DesiredContrast, last_best_alpha,
-               testbed: OptSy.Testbed):
+def calc_strokemin_solution(mask, Result_Estimate, Jacob_trans_Jacob, Jacobian, DesiredContrast, last_best_alpha,
+                            testbed: OptSy.Testbed):
     """ --------------------------------------------------
     Voltage to apply on the deformable mirror in order to minimize the speckle
     intensity in the dark hole region in the stroke min solution
@@ -695,7 +695,7 @@ def solutionSM(mask, Result_Estimate, Jacob_trans_Jacob, Jacobian, DesiredContra
     return testbed.basis_vector_to_act_vector(DMSurfaceCoeff), alpha
 
 
-def solutionSteepest(mask, Result_Estimate, Hessian_Matrix, Jacobian, testbed: OptSy.Testbed):
+def calc_steepest_solution(mask, Result_Estimate, Hessian_Matrix, Jacobian, testbed: OptSy.Testbed):
     """ --------------------------------------------------
     Voltage to apply on the deformable mirror in order to minimize
     the speckle intensity in the dark hole region
@@ -740,7 +740,7 @@ def solutionSteepest(mask, Result_Estimate, Hessian_Matrix, Jacobian, testbed: O
 #################################################################################
 
 
-def createPWmatrix(testbed: OptSy.Testbed, amplitude, posprobes, dimEstim, cutsvd, wavelength):
+def create_pw_matrix(testbed: OptSy.Testbed, amplitude, posprobes, dimEstim, cutsvd, wavelength):
     """ --------------------------------------------------
     Build the interaction matrix for pair-wise probing.
 
@@ -808,21 +808,21 @@ def createPWmatrix(testbed: OptSy.Testbed, amplitude, posprobes, dimEstim, cutsv
             matrix[:, 1] = np.imag(deltapsik[:, i, j])
 
             try:
-                inversion = invertSVD(matrix, cutsvd, visu=False)
+                inversion = invert_svd(matrix, cutsvd, visu=False)
                 SVD[:, i, j] = inversion[0]
                 PWMatrix[l] = inversion[2]
             except:
-                print("Careful: Error in invertSVD! for l=" + str(l))
+                print("Careful: Error in invert_svd()! for l=" + str(l))
                 SVD[:, i, j] = np.zeros(2)
                 PWMatrix[l] = np.zeros((2, numprobe))
             l = l + 1
     return [PWMatrix, SVD]
 
 
-def FP_PWestimate(Difference, Vectorprobes):
+def calculate_pw_estimate(Difference, Vectorprobes):
     """ --------------------------------------------------
-    Calculate the focal plane electric field from the prone image
-    differences and the modeled probe matrix
+    Calculate the focal plane electric field from the probe image
+    differences and the modeled probe matrix.
 
     AUTHOR : Axel Potier
 
@@ -859,14 +859,14 @@ def FP_PWestimate(Difference, Vectorprobes):
     return Resultat / 4.
 
 
-def createdifference(input_wavefront,
-                     testbed: OptSy.Testbed,
-                     posprobes,
-                     dimimages,
-                     amplitudePW,
-                     voltage_vector=0.,
-                     wavelength=None,
-                     **kwargs):
+def simulate_pw_difference(input_wavefront,
+                           testbed: OptSy.Testbed,
+                           posprobes,
+                           dimimages,
+                           amplitudePW,
+                           voltage_vector=0.,
+                           wavelength=None,
+                           **kwargs):
     """ --------------------------------------------------
     Simulate the acquisition of probe images using Pair-wise
     and calculate the difference of images [I(+probe) - I(-probe)]. 
@@ -925,13 +925,13 @@ def createdifference(input_wavefront,
             indice_acum_number_act += DM.number_act
 
         # When we go polychromatic, lets be careful with the normalization, because
-        # todetector_Intensity is normalizing to polychromatic PSF.
-        Ikmoins = testbed.todetector_Intensity(entrance_EF=input_wavefront,
+        # todetector_intensity is normalizing to polychromatic PSF.
+        Ikmoins = testbed.todetector_intensity(entrance_EF=input_wavefront,
                                                voltage_vector=voltage_vector - Voltage_probe,
                                                wavelengths=wavelength,
                                                **kwargs)
 
-        Ikplus = testbed.todetector_Intensity(entrance_EF=input_wavefront,
+        Ikplus = testbed.todetector_intensity(entrance_EF=input_wavefront,
                                               voltage_vector=voltage_vector + Voltage_probe,
                                               wavelengths=wavelength,
                                               **kwargs)

--- a/Asterix/WSC_functions.py
+++ b/Asterix/WSC_functions.py
@@ -189,7 +189,7 @@ def creatingInteractionmatrix(testbed: OptSy.Testbed,
 
     for i, DM_name in enumerate(testbed.name_of_DMs):
 
-        DM = vars(testbed)[DM_name]  # type: OptSy.deformable_mirror
+        DM = vars(testbed)[DM_name]  # type: OptSy.DeformableMirror
         total_number_basis_modes += DM.basis_size
         DM_small_str = "_" + "_".join(DM.string_os.split("_")[5:])
         string_testbed_without_DMS = string_testbed_without_DMS.replace(DM_small_str, '')
@@ -221,7 +221,7 @@ def creatingInteractionmatrix(testbed: OptSy.Testbed,
 
     for DM_name in testbed.name_of_DMs:
 
-        DM = vars(testbed)[DM_name]  # type: OptSy.deformable_mirror
+        DM = vars(testbed)[DM_name]  # type: OptSy.DeformableMirror
         DM_small_str = "_" + "_".join(DM.string_os.split("_")[5:])
 
         basis_str = DM_small_str + "_" + DM.basis_type + "Basis" + str(DM.basis_size)
@@ -291,13 +291,13 @@ def creatingInteractionmatrix(testbed: OptSy.Testbed,
             wavefrontupstream = input_wavefront
 
             for osname in OpticSysNameBefore:
-                OpticSysbefore = vars(testbed)[osname]  # type: OptSy.Optical_System
+                OpticSysbefore = vars(testbed)[osname]  # type: OptSy.OpticalSystem
 
                 if save_all_planes_to_fits == True:
                     # save PP plane before this subsystem
                     name_plane = 'EF_PP_before_' + osname + '_wl{}'.format(int(wavelength * 1e9))
                     useful.save_plane_in_fits(dir_save_all_planes, name_plane, wavefrontupstream)
-                if isinstance(OpticSysbefore, OptSy.deformable_mirror) and OpticSysbefore.active:
+                if isinstance(OpticSysbefore, OptSy.DeformableMirror) and OpticSysbefore.active:
                     # this subsystem is an active DM but not the one we actuate now (located before the one we actuate)
 
                     if OpticSysbefore.z_position == 0:
@@ -381,10 +381,10 @@ def creatingInteractionmatrix(testbed: OptSy.Testbed,
                 # and finally we go through the subsystems after the DMs we want to actuate
                 # (other DMs, coronagraph, etc). These ones we have to go through for each phase of the Basis
                 for osname in OpticSysNameAfter:
-                    OpticSysAfter = vars(testbed)[osname]  # type: OptSy.Optical_System
+                    OpticSysAfter = vars(testbed)[osname]  # type: OptSy.OpticalSystem
                     if osname != OpticSysNameAfter[-1]:
 
-                        if isinstance(OpticSysAfter, OptSy.deformable_mirror) and OpticSysAfter.active:
+                        if isinstance(OpticSysAfter, OptSy.DeformableMirror) and OpticSysAfter.active:
 
                             # this subsystem is an active DM but not the one we actuate now (located after the one we actuate)
                             if OpticSysAfter.z_position == 0:
@@ -458,7 +458,7 @@ def creatingInteractionmatrix(testbed: OptSy.Testbed,
 
     # clean to save memory
     for i, DM_name in enumerate(testbed.name_of_DMs):
-        DM = vars(testbed)[DM_name]  # type: OptSy.deformable_mirror
+        DM = vars(testbed)[DM_name]  # type: OptSy.DeformableMirror
         DM.phase_init = 0
 
     print("")
@@ -782,7 +782,7 @@ def createPWmatrix(testbed: OptSy.Testbed, amplitude, posprobes, dimEstim, cutsv
     PWMatrix = np.zeros((dimEstim**2, 2, numprobe))
     SVD = np.zeros((2, dimEstim, dimEstim))
 
-    DM_probe = vars(testbed)[testbed.name_DM_to_probe_in_PW]  # type: OptSy.deformable_mirror
+    DM_probe = vars(testbed)[testbed.name_DM_to_probe_in_PW]  # type: OptSy.DeformableMirror
 
     psi0 = testbed.todetector()
     k = 0
@@ -914,7 +914,7 @@ def createdifference(input_wavefront,
         indice_acum_number_act = 0
 
         for DM_name in testbed.name_of_DMs:
-            DM = vars(testbed)[DM_name]  # type: OptSy.deformable_mirror
+            DM = vars(testbed)[DM_name]  # type: OptSy.DeformableMirror
 
             if DM_name == testbed.name_DM_to_probe_in_PW:
                 Voltage_probeDMprobe = np.zeros(DM.number_act)

--- a/Asterix/correction_loop.py
+++ b/Asterix/correction_loop.py
@@ -9,28 +9,28 @@ import matplotlib
 matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt
 
-import Asterix.Optical_System_functions as OptSy
+import Asterix.optical_systems as OptSy
 
 from Asterix.MaskDH import MaskDH
 from Asterix.estimator import Estimator
 from Asterix.corrector import Corrector
 
-import Asterix.fits_functions as useful
+import Asterix.save_and_read as useful
 
 
-def CorrectionLoop(testbed: OptSy.Testbed,
-                   estimator: Estimator,
-                   corrector: Corrector,
-                   mask_dh: MaskDH,
-                   Loopconfig,
-                   SIMUconfig,
-                   input_wavefront=0,
-                   initial_DM_voltage=0.,
-                   silence=False,
-                   **kwargs):
+def correction_loop(testbed: OptSy.Testbed,
+                    estimator: Estimator,
+                    corrector: Corrector,
+                    mask_dh: MaskDH,
+                    Loopconfig,
+                    SIMUconfig,
+                    input_wavefront=0,
+                    initial_DM_voltage=0.,
+                    silence=False,
+                    **kwargs):
     """ --------------------------------------------------
     Run a full loop for several Matrix. at each iteration, we update the matrix and
-    run CorrectionLoop1Matrix. 
+    run correction_loop_1matrix().
 
     AUTHOR : Johan Mazoyer
 
@@ -126,21 +126,21 @@ def CorrectionLoop(testbed: OptSy.Testbed,
             # the first matrix is done during initialization
             corrector.update_matrices(testbed, estimator, initial_DM_voltage=initial_DM_voltage)
 
-        Resultats_correction_loop = CorrectionLoop1Matrix(testbed,
-                                                          estimator,
-                                                          corrector,
-                                                          mask_dh,
-                                                          Nbiter_corr,
-                                                          CorrectionLoopResult,
-                                                          gain=gain,
-                                                          Nbmode_corr=Nbmode_corr,
-                                                          Linesearch=Linesearch,
-                                                          input_wavefront=input_wavefront,
-                                                          initial_DM_voltage=initial_DM_voltage,
-                                                          photon_noise=photon_noise,
-                                                          nb_photons=nb_photons,
-                                                          silence=silence,
-                                                          **kwargs)
+        Resultats_correction_loop = correction_loop_1matrix(testbed,
+                                                            estimator,
+                                                            corrector,
+                                                            mask_dh,
+                                                            Nbiter_corr,
+                                                            CorrectionLoopResult,
+                                                            gain=gain,
+                                                            Nbmode_corr=Nbmode_corr,
+                                                            Linesearch=Linesearch,
+                                                            input_wavefront=input_wavefront,
+                                                            initial_DM_voltage=initial_DM_voltage,
+                                                            photon_noise=photon_noise,
+                                                            nb_photons=nb_photons,
+                                                            silence=silence,
+                                                            **kwargs)
 
         min_contrast = min(CorrectionLoopResult["MeanDHContrast"])
         min_index = CorrectionLoopResult["MeanDHContrast"].index(min_contrast)
@@ -155,20 +155,20 @@ def CorrectionLoop(testbed: OptSy.Testbed,
     return Resultats_correction_loop
 
 
-def CorrectionLoop1Matrix(testbed: OptSy.Testbed,
-                          estimator: Estimator,
-                          corrector: Corrector,
-                          mask_dh: MaskDH,
-                          Nbiter_corr,
-                          CorrectionLoopResult,
-                          gain=0.1,
-                          Nbmode_corr=None,
-                          Linesearch=False,
-                          Search_best_Mode=False,
-                          input_wavefront=1.,
-                          initial_DM_voltage=0.,
-                          silence=False,
-                          **kwargs):
+def correction_loop_1matrix(testbed: OptSy.Testbed,
+                            estimator: Estimator,
+                            corrector: Corrector,
+                            mask_dh: MaskDH,
+                            Nbiter_corr,
+                            CorrectionLoopResult,
+                            gain=0.1,
+                            Nbmode_corr=None,
+                            Linesearch=False,
+                            Search_best_Mode=False,
+                            input_wavefront=1.,
+                            initial_DM_voltage=0.,
+                            silence=False,
+                            **kwargs):
     """ --------------------------------------------------
     Run a loop for a given interaction matrix.
 
@@ -204,7 +204,7 @@ def CorrectionLoop1Matrix(testbed: OptSy.Testbed,
                     SVD modes for each iteration
     
     Linesearch: bool, default False. 
-                If True, In this mode, the function CorrectionLoop1Matrix
+                If True, In this mode, the function correction_loop_1matrix()
                 will call itself at each iteration with Search_best_Mode= True to find 
                 the best SVD inversion mode among a few Linesearchmodes. 
 
@@ -253,7 +253,7 @@ def CorrectionLoop1Matrix(testbed: OptSy.Testbed,
             for i in np.arange(len(Nbiter_corr)):
                 modevector = modevector + [Nbmode_corr[i]] * Nbiter_corr[i]
 
-    initialFP = testbed.todetector_Intensity(entrance_EF=input_wavefront,
+    initialFP = testbed.todetector_intensity(entrance_EF=input_wavefront,
                                              voltage_vector=initial_DM_voltage,
                                              save_all_planes_to_fits=False,
                                              dir_save_all_planes='/Users/jmazoyer/Desktop/test/',
@@ -305,20 +305,19 @@ def CorrectionLoop1Matrix(testbed: OptSy.Testbed,
                 # if we are just trying to find the best mode, we just call the function itself
                 # on the Linesearchmodes but without updating the results.
                 # this is elegant but must be carefully done if we want to avoid infinite loop.
-                bestcontrast, bestmode = CorrectionLoop1Matrix(
-                    testbed,
-                    estimator,
-                    corrector,
-                    mask_dh,
-                    np.ones(len(Linesearchmodes), dtype=int),
-                    dict(),
-                    gain=gain,
-                    Nbmode_corr=Linesearchmodes,
-                    Search_best_Mode=True,
-                    input_wavefront=input_wavefront,
-                    initial_DM_voltage=thisloop_voltages_DMs[iteration],
-                    silence=True,
-                    **kwargs)
+                bestcontrast, bestmode = correction_loop_1matrix(testbed,
+                                                                 estimator,
+                                                                 corrector,
+                                                                 mask_dh,
+                                                                 np.ones(len(Linesearchmodes), dtype=int),
+                                                                 dict(),
+                                                                 gain=gain,
+                                                                 Nbmode_corr=Linesearchmodes,
+                                                                 Search_best_Mode=True,
+                                                                 input_wavefront=input_wavefront,
+                                                                 initial_DM_voltage=thisloop_voltages_DMs[iteration],
+                                                                 silence=True,
+                                                                 **kwargs)
 
                 print("Best Mode is ", bestmode, " with contrast: ", bestcontrast)
                 mode = bestmode
@@ -372,7 +371,7 @@ def CorrectionLoop1Matrix(testbed: OptSy.Testbed,
             new_voltage = thisloop_voltages_DMs[-1] + gain * solution
 
         thisloop_FP_Intensities.append(
-            testbed.todetector_Intensity(entrance_EF=input_wavefront,
+            testbed.todetector_intensity(entrance_EF=input_wavefront,
                                          voltage_vector=new_voltage,
                                          save_all_planes_to_fits=False,
                                          dir_save_all_planes='/Users/jmazoyer/Desktop/test_roundpup/',

--- a/Asterix/correction_loop.py
+++ b/Asterix/correction_loop.py
@@ -37,7 +37,7 @@ def CorrectionLoop(testbed: OptSy.Testbed,
     Parameters
     ----------
         
-    testbed: Optical_System.Testbed
+    testbed: OpticalSystem.Testbed
             object which describes your testbed
     
     estimator: Estimator 
@@ -177,7 +177,7 @@ def CorrectionLoop1Matrix(testbed: OptSy.Testbed,
     Parameters
     ----------
         
-    testbed: Optical_System.Testbed
+    testbed: OpticalSystem.Testbed
             object which describes your testbed
     
     estimator: Estimator 

--- a/Asterix/corrector.py
+++ b/Asterix/corrector.py
@@ -62,7 +62,7 @@ class Corrector:
         Correctionconfig : dict
                 general correction parameters
 
-        testbed :  Optical_System.Testbed 
+        testbed :  OpticalSystem.Testbed
                 Testbed object which describe your testbed
 
         MaskDH: 2d numpy array
@@ -204,7 +204,7 @@ class Corrector:
         Parameters
         ----------
        
-        testbed :  Optical_System.Testbed 
+        testbed :  OpticalSystem.Testbed
                 Testbed object which describe your testbed
 
         estimator: Estimator
@@ -264,7 +264,7 @@ class Corrector:
 
         Parameters
         ----------
-        testbed :  Optical_System.Testbed 
+        testbed :  OpticalSystem.Testbed
                 Testbed object which describe your testbed
 
         estimate: 2D complex array 
@@ -311,7 +311,7 @@ class Corrector:
             # for num_DM, DM_name in enumerate(testbed.name_of_DMs):
 
             #     # we access each DM object individually
-            #     DM = vars(testbed)[DM_name]  # type: OptSy.deformable_mirror
+            #     DM = vars(testbed)[DM_name]  # type: OptSy.DeformableMirror
 
             #     # we multpily each DM by a specific DM gain
             #     solutionefc[
@@ -371,7 +371,7 @@ class Corrector:
             # for num_DM, DM_name in enumerate(testbed.name_of_DMs):
 
             #     # we access each DM object individually
-            #     DM = vars(testbed)[DM_name]  # type: OptSy.deformable_mirror
+            #     DM = vars(testbed)[DM_name]  # type: OptSy.DeformableMirror
 
             #     # we multpily each DM by a specific DM gain
             #     solutionSM[

--- a/Asterix/corrector.py
+++ b/Asterix/corrector.py
@@ -87,7 +87,7 @@ class Corrector:
             os.makedirs(matrix_dir)
 
         if isinstance(testbed, OptSy.OpticalSystem) == False:
-            raise Exception("testbed must be an Optical_System objet")
+            raise Exception("testbed must be an OpticalSystem object")
 
         basis_type = Correctionconfig["DM_basis"].lower()
         self.total_number_modes = 0

--- a/Asterix/corrector.py
+++ b/Asterix/corrector.py
@@ -86,14 +86,14 @@ class Corrector:
             print("Creating directory " + matrix_dir + " ...")
             os.makedirs(matrix_dir)
 
-        if isinstance(testbed, OptSy.Optical_System) == False:
+        if isinstance(testbed, OptSy.OpticalSystem) == False:
             raise Exception("testbed must be an Optical_System objet")
 
         basis_type = Correctionconfig["DM_basis"].lower()
         self.total_number_modes = 0
 
         for DM_name in testbed.name_of_DMs:
-            DM = vars(testbed)[DM_name]  # type: OptSy.deformable_mirror
+            DM = vars(testbed)[DM_name]  # type: OptSy.DeformableMirror
             DM.basis = DM.create_DM_basis(basis_type=basis_type)
             DM.basis_size = DM.basis.shape[0]
             self.total_number_modes += DM.basis_size
@@ -179,7 +179,7 @@ class Corrector:
         # DM for a given voltage when using DM.voltage_to_phase
 
         for DM_name in testbed.name_of_DMs:
-            DM = vars(testbed)[DM_name]  # type: OptSy.deformable_mirror
+            DM = vars(testbed)[DM_name]  # type: OptSy.DeformableMirror
             if DM.misregistration:
                 print(DM_name + " Misregistration!")
                 DM.DM_pushact = DM.creatingpushact(DM.DMconfig)

--- a/Asterix/corrector.py
+++ b/Asterix/corrector.py
@@ -7,8 +7,8 @@ import time
 import numpy as np
 from astropy.io import fits
 
-import Asterix.fits_functions as useful
-import Asterix.Optical_System_functions as OptSy
+import Asterix.save_and_read as useful
+import Asterix.optical_systems as OptSy
 from Asterix.estimator import Estimator
 import Asterix.WSC_functions as wsc
 from Asterix.THD_quick_invert import THD_quick_invert
@@ -228,7 +228,7 @@ class Corrector:
             self.FirstIterNewMat = True
 
             start_time = time.time()
-            interMat = wsc.creatingInteractionmatrix(testbed,
+            interMat = wsc.create_interaction_matrix(testbed,
                                                      estimator.dimEstim,
                                                      self.amplitudeEFC,
                                                      self.matrix_dir,
@@ -241,7 +241,7 @@ class Corrector:
             print("time for direct matrix " + testbed.string_os + " (s):", round(time.time() - start_time))
             print("")
 
-            self.Gmatrix = wsc.cropDHInteractionMatrix(interMat, self.MaskEstim)
+            self.Gmatrix = wsc.crop_interaction_matrix_to_dh(interMat, self.MaskEstim)
 
             # useful.quickfits(self.Gmatrix)
 
@@ -295,11 +295,11 @@ class Corrector:
             if mode != self.previousmode:
                 self.previousmode = mode
                 # we only re-invert the matrix if it is different from last time
-                _, _, self.invertGDH = wsc.invertSVD(self.Gmatrix,
-                                                     mode,
-                                                     goal="c",
-                                                     visu=False,
-                                                     regul=self.regularization)
+                _, _, self.invertGDH = wsc.invert_svd(self.Gmatrix,
+                                                      mode,
+                                                      goal="c",
+                                                      visu=False,
+                                                      regul=self.regularization)
 
             solutionefc = wsc.solutionEFC(self.MaskEstim, estimate, self.invertGDH, testbed)
 
@@ -349,8 +349,8 @@ class Corrector:
 
             DesiredContrast = self.expected_gain_in_contrast * ActualCurrentContrast
 
-            solutionSM, self.last_best_alpha = wsc.solutionSM(self.MaskEstim, estimate, self.M0, self.G,
-                                                              DesiredContrast, self.last_best_alpha, testbed)
+            solutionSM, self.last_best_alpha = wsc.calc_strokemin_solution(self.MaskEstim, estimate, self.M0, self.G,
+                                                                           DesiredContrast, self.last_best_alpha, testbed)
 
             if self.count_since_last_best > 5 or ActualCurrentContrast > 2 * self.last_best_contrast or (
                     isinstance(solutionSM, str) and solutionSM == "SMFailedTooManyTime"):
@@ -386,18 +386,18 @@ class Corrector:
 
             if mode != self.previousmode:
                 self.previousmode = mode
-                _, _, self.invertM0 = wsc.invertSVD(self.M0,
-                                                    mode,
-                                                    goal="c",
-                                                    visu=False,
-                                                    regul=self.regularization)
+                _, _, self.invertM0 = wsc.invert_svd(self.M0,
+                                                     mode,
+                                                     goal="c",
+                                                     visu=False,
+                                                     regul=self.regularization)
 
             return -self.amplitudeEFC * wsc.solutionEM(self.MaskEstim, estimate, self.invertM0, self.G,
                                                        testbed)
 
         if self.correction_algorithm == "steepest":
 
-            return -self.amplitudeEFC * wsc.solutionSteepest(self.MaskEstim, estimate, self.M0, self.G,
-                                                             testbed)
+            return -self.amplitudeEFC * wsc.calc_steepest_solution(self.MaskEstim, estimate, self.M0, self.G,
+                                                                   testbed)
         else:
             raise Exception("This correction algorithm is not yet implemented")

--- a/Asterix/estimator.py
+++ b/Asterix/estimator.py
@@ -83,7 +83,7 @@ class Estimator:
             os.makedirs(matrix_dir)
 
         if isinstance(testbed, OptSy.OpticalSystem) == False:
-            raise Exception("testbed must be an Optical_System objet")
+            raise Exception("testbed must be an OpticalSystem object")
 
         self.technique = Estimationconfig["estimation"].lower()
 

--- a/Asterix/estimator.py
+++ b/Asterix/estimator.py
@@ -64,7 +64,7 @@ class Estimator:
         Estimationconfig : dict
                 general estimation parameters
 
-        testbed :  Optical_System.Testbed 
+        testbed :  OpticalSystem.Testbed
                 Testbed object which describe your testbed
 
         matrix_dir: path. 
@@ -202,7 +202,7 @@ class Estimator:
 
         Parameters
         ----------
-        testbed :  Optical_System.Testbed 
+        testbed :  OpticalSystem.Testbed
                 Testbed object which describe your testbed
 
         entrance_EF :    complex float or 2D array, default 1.

--- a/Asterix/estimator.py
+++ b/Asterix/estimator.py
@@ -82,7 +82,7 @@ class Estimator:
             print("Creating directory " + matrix_dir + " ...")
             os.makedirs(matrix_dir)
 
-        if isinstance(testbed, OptSy.Optical_System) == False:
+        if isinstance(testbed, OptSy.OpticalSystem) == False:
             raise Exception("testbed must be an Optical_System objet")
 
         self.technique = Estimationconfig["estimation"].lower()
@@ -126,7 +126,7 @@ class Estimator:
                     #If several DMs we check if there is at least one in PP
                     number_DMs_in_PP = 0
                     for DM_name in testbed.name_of_DMs:
-                        DM = vars(testbed)[DM_name]  # type: OptSy.deformable_mirror
+                        DM = vars(testbed)[DM_name]  # type: OptSy.DeformableMirror
                         if DM.z_position == 0.:
                             number_DMs_in_PP += 1
                             testbed.name_DM_to_probe_in_PW = DM_name

--- a/Asterix/estimator.py
+++ b/Asterix/estimator.py
@@ -5,9 +5,9 @@ import os
 import numpy as np
 from astropy.io import fits
 
-import Asterix.fits_functions as useful
+import Asterix.save_and_read as useful
 import Asterix.processing_functions as proc
-import Asterix.Optical_System_functions as OptSy
+import Asterix.optical_systems as OptSy
 import Asterix.WSC_functions as wsc
 
 
@@ -153,8 +153,8 @@ class Estimator:
                 self.PWMatrix = fits.getdata(matrix_dir + filePW + ".fits")
             else:
                 print("Saving " + filePW + " ...")
-                self.PWMatrix, showSVD = wsc.createPWmatrix(testbed, self.amplitudePW, self.posprobes,
-                                                            self.dimEstim, cutsvdPW, testbed.wavelength_0)
+                self.PWMatrix, showSVD = wsc.create_pw_matrix(testbed, self.amplitudePW, self.posprobes,
+                                                              self.dimEstim, cutsvdPW, testbed.wavelength_0)
                 fits.writeto(matrix_dir + filePW + ".fits", np.array(self.PWMatrix))
                 visuPWMap = "EigenPW_" + string_dims_PWMatrix
                 fits.writeto(matrix_dir + visuPWMap + ".fits", np.array(showSVD[1]))
@@ -254,16 +254,16 @@ class Estimator:
             return proc.resizing(resultatestimation, self.dimEstim)
 
         elif self.technique in ["pairwise", "pw"]:
-            Difference = wsc.createdifference(entrance_EF,
-                                              testbed,
-                                              self.posprobes,
-                                              self.dimEstim,
-                                              self.amplitudePW,
-                                              voltage_vector=voltage_vector,
-                                              wavelength=wavelength,
-                                              **kwargs)
+            Difference = wsc.simulate_pw_difference(entrance_EF,
+                                                    testbed,
+                                                    self.posprobes,
+                                                    self.dimEstim,
+                                                    self.amplitudePW,
+                                                    voltage_vector=voltage_vector,
+                                                    wavelength=wavelength,
+                                                    **kwargs)
 
-            return wsc.FP_PWestimate(Difference, self.PWMatrix)
+            return wsc.calculate_pw_estimate(Difference, self.PWMatrix)
 
         elif self.technique == 'coffee':
             return np.zeros((self.dimEstim, self.dimEstim))

--- a/Asterix/example_run_asterix.py
+++ b/Asterix/example_run_asterix.py
@@ -3,13 +3,13 @@
 
 import os
 
-from Asterix import Main_THD
+from Asterix import main_THD
 import time
 
 Asterixroot = os.path.dirname(os.path.realpath(__file__))
 
 start_time = time.time()
-Main_THD.runthd2(Asterixroot + os.path.sep + 'Example_param_file.ini',
+main_THD.runthd2(Asterixroot + os.path.sep + 'Example_param_file.ini',
                  NewDMconfig={'DM1_active': False},
                  NewEstimationconfig={'estimation': 'pw'},
                  NewCorrectionconfig={
@@ -29,7 +29,7 @@ print("")
 print("")
 
 start_time = time.time()
-Main_THD.runthd2(Asterixroot + os.path.sep + 'Example_param_file.ini',
+main_THD.runthd2(Asterixroot + os.path.sep + 'Example_param_file.ini',
                  NewDMconfig={'DM1_active': False},
                  NewEstimationconfig={'estimation': 'perfect'},
                  NewCorrectionconfig={
@@ -48,7 +48,7 @@ print("")
 print("")
 
 start_time = time.time()
-Main_THD.runthd2(Asterixroot + os.path.sep + 'Example_param_file.ini',
+main_THD.runthd2(Asterixroot + os.path.sep + 'Example_param_file.ini',
                  NewDMconfig={'DM1_active': True},
                  NewEstimationconfig={'estimation': 'perfect'},
                  NewCorrectionconfig={
@@ -67,7 +67,7 @@ print("")
 print("")
 
 start_time = time.time()
-Main_THD.runthd2(Asterixroot + os.path.sep + 'Example_param_file.ini',
+main_THD.runthd2(Asterixroot + os.path.sep + 'Example_param_file.ini',
                  NewDMconfig={'DM1_active': True},
                  NewEstimationconfig={'estimation': 'pw'},
                  NewCorrectionconfig={

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -3,14 +3,14 @@ __author__ = 'Raphael Galicher, Johan Mazoyer, and Axel Potier'
 
 import os
 
-import Asterix.fits_functions as useful
-import Asterix.Optical_System_functions as OptSy
+import Asterix.save_and_read as useful
+import Asterix.optical_systems as OptSy
 
 from Asterix.MaskDH import MaskDH
 from Asterix.estimator import Estimator
 from Asterix.corrector import Corrector
-from Asterix.correction_loop import CorrectionLoop
-from Asterix.save_results import Save_loop_results
+from Asterix.correction_loop import correction_loop
+from Asterix.save_results import save_loop_results
 
 #######################################################
 #######################################################
@@ -154,16 +154,15 @@ def runthd2(parameter_file,
     # aberrated WF in the testbed Lyot stop
     EF_aberrations_introduced_in_LS = thd2.EF_from_phase_and_ampl(phase_abb=phase_abb_do)
 
-    Resultats_correction_loop = CorrectionLoop(
-        thd2,
-        estim,
-        correc,
-        MaskScience,
-        Loopconfig,
-        SIMUconfig,
-        input_wavefront=input_wavefront,
-        EF_aberrations_introduced_in_LS=EF_aberrations_introduced_in_LS,
-        initial_DM_voltage=0,
-        silence=False)
+    Resultats_correction_loop = correction_loop(thd2,
+                                                estim,
+                                                correc,
+                                                MaskScience,
+                                                Loopconfig,
+                                                SIMUconfig,
+                                                input_wavefront=input_wavefront,
+                                                EF_aberrations_introduced_in_LS=EF_aberrations_introduced_in_LS,
+                                                initial_DM_voltage=0,
+                                                silence=False)
 
-    Save_loop_results(Resultats_correction_loop, config, thd2, MaskScience, result_dir)
+    save_loop_results(Resultats_correction_loop, config, thd2, MaskScience, result_dir)

--- a/Asterix/optical_systems.py
+++ b/Asterix/optical_systems.py
@@ -11,7 +11,7 @@ import skimage.transform
 import Asterix.processing_functions as proc
 import Asterix.propagation_functions as prop
 import Asterix.phase_amplitude_functions as phase_ampl
-import Asterix.fits_functions as useful
+import Asterix.save_and_read as useful
 
 Asterix_root = os.path.dirname(os.path.realpath(__file__)) + os.path.sep
 model_dir = os.path.join(Asterix_root, "Model") + os.path.sep
@@ -227,7 +227,7 @@ class OpticalSystem:
 
         return focal_plane_EF
 
-    def todetector_Intensity(self,
+    def todetector_intensity(self,
                              entrance_EF=1.,
                              wavelengths=None,
                              in_contrast=True,
@@ -291,7 +291,7 @@ class OpticalSystem:
         -------------------------------------------------- """
 
         if 'wavelength' in kwargs:
-            raise Exception("""todetector_Intensity() function is polychromatic, 
+            raise Exception("""todetector_intensity() function is polychromatic, 
                 do not use wavelength keyword.
                 Use wavelengths keyword even for monochromatic intensity""")
 
@@ -330,11 +330,11 @@ class OpticalSystem:
 
         if in_contrast == True:
             if (wavelength_vec != self.wav_vec).all():
-                raise Exception("""carefull: contrast normalization in todetector_Intensity assumes
+                raise Exception("""Careful: contrast normalization in todetector_intensity assumes
                      it is done in all possible BWs (wavelengths = self.wav_vec). If self.nb_wav > 1
                      and you want only one BW with the good contrast normalization, use
                      np.abs(to_detector(wavelength = wavelength))**2... If you want a specific
-                     normalization for a subset of  wavelengths, use in_contrast = False and
+                     normalization for a subset of  wavelengths, use in_contrast=False and
                      measure the PSF to normalize.
                 """)
             else:
@@ -1589,7 +1589,7 @@ class DeformableMirror(OpticalSystem):
         self.DM_pushact = self.creatingpushact(DMconfig)
 
         # create or load 'which actuators are in pupil'
-        self.WhichInPupil = self.creatingWhichinPupil()
+        self.WhichInPupil = self.id_in_pupil_actuators()
 
         self.misregistration = DMconfig[self.Name_DM + "_misregistration"]
         # now if we relaunch self.DM_pushact, and if misregistration = True
@@ -1835,7 +1835,7 @@ class DeformableMirror(OpticalSystem):
 
         return pushact3d
 
-    def creatingWhichinPupil(self):
+    def id_in_pupil_actuators(self):
         """ --------------------------------------------------
         Create a vector with the index of all the actuators located in the entrance pupil
         
@@ -2040,7 +2040,7 @@ class DeformableMirror(OpticalSystem):
             Name_FourrierBasis_fits = "Fourier_basis_" + self.Name_DM + '_prad' + str(
                 self.prad) + '_nact' + str(sqrtnbract) + 'x' + str(sqrtnbract)
 
-            cossinbasis = phase_ampl.SinCosBasis(sqrtnbract)
+            cossinbasis = phase_ampl.sine_cosine_basis(sqrtnbract)
 
             basis_size = cossinbasis.shape[0]
             basis = np.zeros((basis_size, self.number_act))

--- a/Asterix/phase_amplitude_functions.py
+++ b/Asterix/phase_amplitude_functions.py
@@ -1,7 +1,7 @@
 import numpy as np
 import Asterix.propagation_functions as prop
 import Asterix.processing_functions as proc
-import Asterix.fits_functions as useful
+import Asterix.save_and_read as useful
 
 
 def roundpupil(dim_pp, prad, no_pixel=False, center_pos='b'):
@@ -140,7 +140,7 @@ def random_phase_map(pupil_rad, dim_image, phaserms, rhoc, slope):
     return phase
 
 
-def SinCosBasis(Nact1D):
+def sine_cosine_basis(Nact1D):
     """ --------------------------------------------------
     For a given number of actuator accross the DM, create coefficients for the sin/cos basis
 
@@ -157,7 +157,7 @@ def SinCosBasis(Nact1D):
     
     Returns
     ------
-    SinCosBasis : 3D array 
+    SinCos : 3D array
                 Coefficient to apply to DMs to obtain sine and cosine phases.
                 size :[(Nact1D)^2,Nact1D,Nact1D] if even
                 size :[(Nact1D)^2 -1 ,Nact1D,Nact1D] if odd (to remove piston)

--- a/Asterix/processing_functions.py
+++ b/Asterix/processing_functions.py
@@ -1,6 +1,6 @@
 import numpy as np
 import scipy.optimize as opt
-import Asterix.fits_functions as useful
+import Asterix.save_and_read as useful
 
 
 def twoD_Gaussian(xy, amplitude, sigma_x, sigma_y, xo, yo, theta, h, flatten=True):

--- a/Asterix/propagation_functions.py
+++ b/Asterix/propagation_functions.py
@@ -1,6 +1,6 @@
 import numpy as np
 import Asterix.processing_functions as proc
-import Asterix.fits_functions as useful
+import Asterix.save_and_read as useful
 
 
 def mft(image,

--- a/Asterix/save_and_read.py
+++ b/Asterix/save_and_read.py
@@ -11,7 +11,7 @@ from astropy.io import fits
 import datetime
 
 import random
-import Asterix.Optical_System_functions as OptSy
+import Asterix.optical_systems as OptSy
 
 
 def _quickshow(tab):

--- a/Asterix/save_results.py
+++ b/Asterix/save_results.py
@@ -7,7 +7,7 @@ import matplotlib
 matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt
 
-import Asterix.Optical_System_functions as OptSy
+import Asterix.optical_systems as OptSy
 
 warnings.filterwarnings("ignore", category=RuntimeWarning)
 
@@ -281,7 +281,7 @@ def contrast_curves(reduced_data,
     return contrast_curve
 
 
-def Save_loop_results(CorrectionLoopResult, config, testbed: OptSy.Testbed, MaskScience, result_dir):
+def save_loop_results(CorrectionLoopResult, config, testbed: OptSy.Testbed, MaskScience, result_dir):
     """ --------------------------------------------------
     Save the result from a correction loop in result_dir
     
@@ -294,10 +294,10 @@ def Save_loop_results(CorrectionLoopResult, config, testbed: OptSy.Testbed, Mask
     Parameters
     ----------
     CorrectionLoopResult: dict 
-        dictionnary containing the results from CorrectionLoop1Matrix or CorrectionLoop
+        dictionary containing the results from correction_loop_1matrix() or correction_loop()
 
     config: dict
-        complete parameter dictionnary
+        complete parameter dictionary
 
     testbed: OpticalSystem
         an OpticalSystem object which describes your testbed

--- a/Asterix/save_results.py
+++ b/Asterix/save_results.py
@@ -377,7 +377,7 @@ def Save_loop_results(CorrectionLoopResult, config, testbed: OptSy.Testbed, Mask
                      header,
                      overwrite=True)
 
-        DM = vars(testbed)[DM_name]  # type: OptSy.deformable_mirror
+        DM = vars(testbed)[DM_name]  # type: OptSy.DeformableMirror
         voltage_DMs_tosave = voltage_DMs_nparray[:, indice_acum_number_act:indice_acum_number_act +
                                                  DM.number_act]
         indice_acum_number_act += DM.number_act

--- a/Asterix/save_results.py
+++ b/Asterix/save_results.py
@@ -299,8 +299,8 @@ def Save_loop_results(CorrectionLoopResult, config, testbed: OptSy.Testbed, Mask
     config: dict
         complete parameter dictionnary
 
-    testbed: Optical_System
-        an Optical_System object which describes your testbed
+    testbed: OpticalSystem
+        an OpticalSystem object which describes your testbed
     
     mask_dh: 2d numpy array
         binary array of size [dimScience, dimScience] : dark hole mask

--- a/Asterix/tests/test_coronagraph.py
+++ b/Asterix/tests/test_coronagraph.py
@@ -26,7 +26,7 @@ def test_default_coronagraph():
     Coronaconfig.update({'filename_instr_apod': "RoundPup"})
 
     # Create the coronagraph
-    corono = OptSy.coronagraph(modelconfig, Coronaconfig)
+    corono = OptSy.Coronagraph(modelconfig, Coronaconfig)
     coro_psf = corono.todetector_Intensity(center_on_pixel=True)
 
     assert np.max(coro_psf) == 0.0, "A perfect coronagraph should return an empty array."

--- a/Asterix/tests/test_coronagraph.py
+++ b/Asterix/tests/test_coronagraph.py
@@ -3,7 +3,7 @@ import numpy as np
 from configobj import ConfigObj
 from validate import Validator
 
-import Asterix.Optical_System_functions as OptSy
+import Asterix.optical_systems as OptSy
 
 
 def test_default_coronagraph():
@@ -27,6 +27,6 @@ def test_default_coronagraph():
 
     # Create the coronagraph
     corono = OptSy.Coronagraph(modelconfig, Coronaconfig)
-    coro_psf = corono.todetector_Intensity(center_on_pixel=True)
+    coro_psf = corono.todetector_intensity(center_on_pixel=True)
 
     assert np.max(coro_psf) == 0.0, "A perfect coronagraph should return an empty array."

--- a/Asterix/tests/test_parameter_file.py
+++ b/Asterix/tests/test_parameter_file.py
@@ -1,7 +1,7 @@
 import os
 from configobj import ConfigObj
 from validate import Validator
-import Asterix.Optical_System_functions as OptSy
+import Asterix.optical_systems as OptSy
 
 
 def test_example_parameter_file():

--- a/Asterix/tuto_asterix_model.py
+++ b/Asterix/tuto_asterix_model.py
@@ -4,8 +4,8 @@ import numpy as np
 from configobj import ConfigObj
 from validate import Validator
 
-import Asterix.Optical_System_functions as OptSy
-import Asterix.fits_functions as useful
+import Asterix.optical_systems as OptSy
+import Asterix.save_and_read as useful
 
 
 # Set the path to your configuration file of choice
@@ -68,7 +68,7 @@ useful._quickfits(numpy_array_pup, dir=result_dir, name="numpy_array_pup")
 EF_through_roman = pup_roman.EF_through(entrance_EF=1.)
 
 #  Calculate the associated PSF. Default is polychromatic.
-psf_roman = pup_roman.todetector_Intensity()
+psf_roman = pup_roman.todetector_intensity()
 useful._quickfits(psf_roman, dir=result_dir, name="psf_roman")
 
 # The chromaticity of the source is defined in all opitcal systems with three parameters:
@@ -117,7 +117,7 @@ Coronaconfig.update({'filename_instr_apod': "RoundPup"})
 corono = OptSy.Coronagraph(modelconfig, Coronaconfig)
 
 # For the coronagraph, we can measure 2 types of PSFs: with or without the FPM
-No_mask_PSF = corono.todetector_Intensity(center_on_pixel=True, noFPM=True)
+No_mask_PSF = corono.todetector_intensity(center_on_pixel=True, noFPM=True)
 # This allows us to normalize the images.
 Max_No_mask_PSF = np.max(No_mask_PSF)
 
@@ -130,7 +130,7 @@ phase = corono.generate_phase_aberr(SIMUconfig,
 aberrated_EF = corono.EF_from_phase_and_ampl(phase_abb=phase)
 
 # By default, this is the normal coronagraphic PSF (with FPM)
-coronagraphic_PSF = corono.todetector_Intensity(entrance_EF=aberrated_EF)
+coronagraphic_PSF = corono.todetector_intensity(entrance_EF=aberrated_EF)
 
 # Which we can now normalize:
 normalized_coronagraphic_PSF = coronagraphic_PSF / Max_No_mask_PSF
@@ -146,7 +146,7 @@ if not os.path.exists(plot_all_fits_dir):
     os.makedirs(plot_all_fits_dir)
 
 # Be careful, this can produce tens of fits files and more, especially in a correction loop:
-FP_after_corono_in_contrast = corono.todetector_Intensity(entrance_EF=aberrated_EF,
+FP_after_corono_in_contrast = corono.todetector_intensity(entrance_EF=aberrated_EF,
                                                           save_all_planes_to_fits=True,
                                                           dir_save_all_planes=plot_all_fits_dir) / No_mask_PSF
 
@@ -160,7 +160,7 @@ DM3 = OptSy.DeformableMirror(modelconfig,
 # DMs are also optical systems but have another parameter to control them, DMphase.
 # Measure the EF through the DM:
 EF_though_DM = DM3.EF_through(entrance_EF=1., DMphase=0.)
-# plus all normal functions of optical systems (todetector, todetector_Intensity)
+# plus all normal functions of optical systems (todetector, todetector_intensity)
 
 # For example, something like the following can be funny:
 EF_though_DM = DM3.EF_through(entrance_EF=aberrated_EF, DMphase=phase)
@@ -178,11 +178,11 @@ testbed_1DM = OptSy.Testbed([pup_round, DM3, corono],
 # --> testbed_1DM.entrancepupil, testbed.DM3, etc
 
 # To avoid any confusion in case of multiple DMs, the command to access DMs is now XXXphase, where XXX is the name of the DM.
-PSF_after_testbed = testbed_1DM.todetector_Intensity(entrance_EF=aberrated_EF,
+PSF_after_testbed = testbed_1DM.todetector_intensity(entrance_EF=aberrated_EF,
                                                      DM3phase=phase)
 
 # And the confusing DM3phase is removed so this will send an error:
-# PSF_after_testbed = testbed_1DM.todetector_Intensity(entrance_EF=aberrated_EF, DMphase = phase)
+# PSF_after_testbed = testbed_1DM.todetector_intensity(entrance_EF=aberrated_EF, DMphase = phase)
 
 # We can now play with all the things we defined up to now, for example:
 testbed_1DM_romanpup = OptSy.Testbed([pup_roman, DM3, corono],

--- a/Asterix/tuto_asterix_model.py
+++ b/Asterix/tuto_asterix_model.py
@@ -45,16 +45,16 @@ modelconfig.update({'diam_pup_in_pix': 80})
 # we start the tutorial by initializing a pupil
 # Clear pupil of radius prad as defined by the diameter in pixels above
 # (across the diameter of the telescope; usually in the configfile)
-pup_round = OptSy.pupil(modelconfig)
+pup_round = OptSy.Pupil(modelconfig)
 
 # If you have an input file, you can initialize a complex pupil with the right size.
 # This loads the Roman pupil of same radius/diameter as defined above (usually in the configfile).
-pup_roman = OptSy.pupil(modelconfig, PupType="RomanPup")
+pup_roman = OptSy.Pupil(modelconfig, PupType="RomanPup")
 
 # By default, all pupils have the diameter of the telescope but smaller/larger pupils
 # can also be defined. This can be useful for example for the Lyot stop.
 # Here, create a clear pupil with a radius of 100 pixels.
-pup_round_100 = OptSy.pupil(modelconfig, prad=100)
+pup_round_100 = OptSy.Pupil(modelconfig, prad=100)
 
 # Careful, pup_roman is not an array, it is an Optical System object.
 # If you want to access the pupil itself as an attribute that is an array, and save it out if you like.
@@ -86,7 +86,7 @@ print("transmission pup roman = ", transmission_roman_pup)
 # We can also change the bandwidth.
 modelconfig.update({'Delta_wav': 50e-9})
 # But then Optical System object has to be reinitialized:
-pup_roman_poly = OptSy.pupil(modelconfig, PupType="RomanPup")
+pup_roman_poly = OptSy.Pupil(modelconfig, PupType="RomanPup")
 
 # Be careful when you change the "modelconfig" in the configuration file because Optical Systems are designed to work
 # together but that only works if they are defined with the same baseline configuration.
@@ -114,7 +114,7 @@ Coronaconfig.update({'filename_instr_apod': "RoundPup"})
 # Coronaconfig.update({'filename_instr_lyot': "RoundPup"})
 # Coronaconfig.update({'diam_lyot_in_m': modelconfig["diam_pup_in_m"]*0.97})
 
-corono = OptSy.coronagraph(modelconfig, Coronaconfig)
+corono = OptSy.Coronagraph(modelconfig, Coronaconfig)
 
 # For the coronagraph, we can measure 2 types of PSFs: with or without the FPM
 No_mask_PSF = corono.todetector_Intensity(center_on_pixel=True, noFPM=True)
@@ -152,10 +152,10 @@ FP_after_corono_in_contrast = corono.todetector_Intensity(entrance_EF=aberrated_
 
 # Finally, we can initialize some DMs. DMs can be in a pupil or outside a pupil.
 # In the default configuraiton file, this one is in a pupil plane.
-DM3 = OptSy.deformable_mirror(modelconfig,
-                              DMconfig,
-                              Name_DM='DM3',
-                              Model_local_dir=Model_local_dir)
+DM3 = OptSy.DeformableMirror(modelconfig,
+                             DMconfig,
+                             Name_DM='DM3',
+                             Model_local_dir=Model_local_dir)
 
 # DMs are also optical systems but have another parameter to control them, DMphase.
 # Measure the EF through the DM:
@@ -202,20 +202,20 @@ modelconfig.update({'diam_pup_in_pix': 200})
 # Once we change the modelconfig secion of the configuration file/object, all the previously defined systems are of
 # the wrong dimensions so they cannot be concatenated and must be recalculated.
 del pup_round, DM3, corono
-pup_round = OptSy.pupil(modelconfig)
+pup_round = OptSy.Pupil(modelconfig)
 
-DM3 = OptSy.deformable_mirror(modelconfig, DMconfig, Name_DM='DM3', Model_local_dir=Model_local_dir)
+DM3 = OptSy.DeformableMirror(modelconfig, DMconfig, Name_DM='DM3', Model_local_dir=Model_local_dir)
 
 DMconfig.update({'DM1_active': True})
 
-DM1 = OptSy.deformable_mirror(modelconfig,
-                              DMconfig,
-                              Name_DM='DM1',
-                              Model_local_dir=Model_local_dir)
+DM1 = OptSy.DeformableMirror(modelconfig,
+                             DMconfig,
+                             Name_DM='DM1',
+                             Model_local_dir=Model_local_dir)
 
 # We also need to "clear" the apodizer plane because  there is no apodizer plane on the thd2 bench.
 Coronaconfig.update({'filename_instr_apod': "Clear"})
-corono_thd = OptSy.coronagraph(modelconfig, Coronaconfig)
+corono_thd = OptSy.Coronagraph(modelconfig, Coronaconfig)
 
 # And then just concatenate:
 thd2 = OptSy.Testbed([pup_round, DM1, DM3, corono_thd],
@@ -230,19 +230,19 @@ print("Name of the DMs: ", thd2.name_of_DMs)
 DMconfig.update({'DM1_z_position': -15e-2})  # meter
 DMconfig.update({'DM1_active': True})
 
-DMnew = OptSy.deformable_mirror(modelconfig,
-                                DMconfig,
-                                Name_DM='DM1',
-                                Model_local_dir=Model_local_dir)
+DMnew = OptSy.DeformableMirror(modelconfig,
+                               DMconfig,
+                               Name_DM='DM1',
+                               Model_local_dir=Model_local_dir)
 # The variable Name_DM in this function is to be understood as the type of DM you want to use (DM3 is a BMC32x32 type DM
 # and DM1 is a BMC34x34) but the real name in the system is to be defined in the concatenation.
 
 # We also want to add a pupil in between all these DMs. Let's make it a round pupil for now, but we could imagine
 # putting an apodizer here.
-pupil_inbetween_DM = OptSy.pupil(modelconfig)
+pupil_inbetween_DM = OptSy.Pupil(modelconfig)
 
 # And a roman entrance pupil
-pup_roman = OptSy.pupil(modelconfig, PupType="RomanPup")
+pup_roman = OptSy.Pupil(modelconfig, PupType="RomanPup")
 
 
 # Let's concatenate everything!

--- a/notebooks/beginner-tutorial_optical-components-and-systems.ipynb
+++ b/notebooks/beginner-tutorial_optical-components-and-systems.ipynb
@@ -303,7 +303,7 @@
    "outputs": [],
    "source": [
     "# Create a pupil\n",
-    "pup_round = OptSy.pupil(modelconfig)"
+    "pup_round = OptSy.Pupil(modelconfig)"
    ]
   },
   {
@@ -342,7 +342,7 @@
    "outputs": [],
    "source": [
     "# Create a pupil object representing the Roman pupil\n",
-    "pup_roman = OptSy.pupil(modelconfig, PupType=\"RomanPup\")"
+    "pup_roman = OptSy.Pupil(modelconfig, PupType=\"RomanPup\")"
    ]
   },
   {
@@ -373,7 +373,7 @@
    "outputs": [],
    "source": [
     "# Create a round pupil with 200 pixels across\n",
-    "pup_round_100 = OptSy.pupil(modelconfig, prad=100)\n",
+    "pup_round_100 = OptSy.Pupil(modelconfig, prad=100)\n",
     "\n",
     "# Plot this pupil\n",
     "plt.imshow(pup_round_100.pup, cmap='Greys_r')\n",
@@ -521,7 +521,7 @@
    "outputs": [],
    "source": [
     "# Create the coronagraph\n",
-    "corono = OptSy.coronagraph(modelconfig, Coronaconfig)"
+    "corono = OptSy.Coronagraph(modelconfig, Coronaconfig)"
    ]
   },
   {
@@ -698,7 +698,7 @@
    "outputs": [],
    "source": [
     "# Create in-pupil DM\n",
-    "DM3 = OptSy.deformable_mirror(modelconfig, DMconfig, Name_DM='DM3', Model_local_dir='temp')"
+    "DM3 = OptSy.DeformableMirror(modelconfig, DMconfig, Name_DM='DM3', Model_local_dir='temp')"
    ]
   },
   {
@@ -889,7 +889,7 @@
    "outputs": [],
    "source": [
     "# Instantiate new pupil object from updated parameters\n",
-    "pup_round_larger = OptSy.pupil(modelconfig)\n",
+    "pup_round_larger = OptSy.Pupil(modelconfig)\n",
     "\n",
     "plt.imshow(pup_round_larger.pup, cmap='Greys_r')\n",
     "plt.title(\"Slightly larger round pupil\")"
@@ -903,14 +903,14 @@
    "outputs": [],
    "source": [
     "# Create in-pupil DM\n",
-    "DM3 = OptSy.deformable_mirror(modelconfig,\n",
+    "DM3 = OptSy.DeformableMirror(modelconfig,\n",
     "                              DMconfig,\n",
     "                              Name_DM='DM3',\n",
     "                              Model_local_dir='temp')\n",
     "\n",
     "# Create out-of-pupil DM\n",
     "DMconfig.update({'DM1_active': True})\n",
-    "DM1 = OptSy.deformable_mirror(modelconfig,\n",
+    "DM1 = OptSy.DeformableMirror(modelconfig,\n",
     "                              DMconfig,\n",
     "                              Name_DM='DM1',\n",
     "                              Model_local_dir='temp')"
@@ -925,7 +925,7 @@
    "source": [
     "# We also need to \"clear\" the apodizer plane because  there is no apodizer plane on the THD2 bench.\n",
     "Coronaconfig.update({'filename_instr_apod': \"Clear\"})\n",
-    "corono_thd = OptSy.coronagraph(modelconfig, Coronaconfig)"
+    "corono_thd = OptSy.Coronagraph(modelconfig, Coronaconfig)"
    ]
   },
   {
@@ -977,7 +977,7 @@
    "source": [
     "DMconfig.update({'DM1_z_position': -15e-2})  # meter\n",
     "DMconfig.update({'DM1_active': True})\n",
-    "DMnew = OptSy.deformable_mirror(modelconfig,\n",
+    "DMnew = OptSy.DeformableMirror(modelconfig,\n",
     "                                DMconfig,\n",
     "                                Name_DM='DM1',\n",
     "                                Model_local_dir='temp')"
@@ -1001,7 +1001,7 @@
    "outputs": [],
    "source": [
     "# Instantiate pupil for in-between DMs\n",
-    "pupil_inbetween_DM = OptSy.pupil(modelconfig)"
+    "pupil_inbetween_DM = OptSy.Pupil(modelconfig)"
    ]
   },
   {
@@ -1012,7 +1012,7 @@
    "outputs": [],
    "source": [
     "# And a roman entrance pupil\n",
-    "pup_roman_larger = OptSy.pupil(modelconfig, PupType=\"RomanPup\")"
+    "pup_roman_larger = OptSy.Pupil(modelconfig, PupType=\"RomanPup\")"
    ]
   },
   {

--- a/notebooks/beginner-tutorial_optical-components-and-systems.ipynb
+++ b/notebooks/beginner-tutorial_optical-components-and-systems.ipynb
@@ -30,7 +30,7 @@
     "from configobj import ConfigObj\n",
     "from validate import Validator\n",
     "\n",
-    "import Asterix.Optical_System_functions as OptSy"
+    "import Asterix.optical_systems as OptSy"
    ]
   },
   {
@@ -427,7 +427,7 @@
    "id": "b595c91d",
    "metadata": {},
    "source": [
-    "We can also calculate the associated PSF of this optical element (which is now a simple optical system) by using the method `todetector_Intensity()`."
+    "We can also calculate the associated PSF of this optical element (which is now a simple optical system) by using the method `todetector_intensity()`."
    ]
   },
   {
@@ -437,7 +437,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "psf_roman = pup_roman.todetector_Intensity()"
+    "psf_roman = pup_roman.todetector_intensity()"
    ]
   },
   {
@@ -540,7 +540,7 @@
    "outputs": [],
    "source": [
     "# PSF without FPM\n",
-    "direct_psf = corono.todetector_Intensity(center_on_pixel=True, noFPM=True)\n",
+    "direct_psf = corono.todetector_intensity(center_on_pixel=True, noFPM=True)\n",
     "# Get normalization factor from direct PSF\n",
     "max_psf = direct_psf.max()"
    ]
@@ -553,7 +553,7 @@
    "outputs": [],
    "source": [
     "# Coronagraphic PSF (with FPM)\n",
-    "coro_psf = corono.todetector_Intensity(center_on_pixel=True, noFPM=False)"
+    "coro_psf = corono.todetector_intensity(center_on_pixel=True, noFPM=False)"
    ]
   },
   {
@@ -673,7 +673,7 @@
    "outputs": [],
    "source": [
     "# Calculate coronagraphic PSF with chosen in put E-field\n",
-    "coro_psf_aber = corono.todetector_Intensity(entrance_EF=aberrated_EF)\n",
+    "coro_psf_aber = corono.todetector_intensity(entrance_EF=aberrated_EF)\n",
     "\n",
     "plt.imshow(coro_psf_aber/max_psf, cmap='inferno', norm=LogNorm())\n",
     "plt.title('Coronagraphic PSF with phase aberrations')\n",
@@ -808,7 +808,7 @@
    "outputs": [],
    "source": [
     "# Calculate the PSF through the whole optical system\n",
-    "psf_after_testbed = testbed_1DM.todetector_Intensity(entrance_EF=aberrated_EF, DM3phase=phase)\n",
+    "psf_after_testbed = testbed_1DM.todetector_intensity(entrance_EF=aberrated_EF, DM3phase=phase)\n",
     "\n",
     "plt.imshow(psf_after_testbed, cmap='inferno', norm=LogNorm())\n",
     "plt.title('Full testbed PSF (unnormalized) - round pupil')\n",
@@ -833,7 +833,7 @@
     "# Create testbed with RST pupil\n",
     "testbed_1DM_romanpup = OptSy.Testbed([pup_roman, DM3, corono],\n",
     "                                     [\"entrancepupil\", \"DM3\", \"corono\"])\n",
-    "psf_after_roman_testbed = testbed_1DM_romanpup.todetector_Intensity(entrance_EF=aberrated_EF, DM3phase=phase)\n",
+    "psf_after_roman_testbed = testbed_1DM_romanpup.todetector_intensity(entrance_EF=aberrated_EF, DM3phase=phase)\n",
     "\n",
     "plt.imshow(psf_after_roman_testbed, cmap='inferno', norm=LogNorm())\n",
     "plt.title('Full testbed PSF (unnormalized) - RST pupil')\n",

--- a/source/correction.rst
+++ b/source/correction.rst
@@ -41,7 +41,7 @@ Interaction Matrix
 +++++++++++++++++++++++++++++++
 
 Most correction algorithms requires the measurement of an Interaction Matrix.
-The specific function doing this is located in WSC_functions.py : creatingInteractionmatrix
+The specific function doing this is located in WSC_functions.py : create_interaction_matrix()
 
 We  save the matrix in .fits independently for each DMs so that you do not have to recalculate if you go 
 from 1 to 2 DMs (provided that this is the only change in the testbed of course).
@@ -126,11 +126,11 @@ Same parameters as efc
 Correction loop
 +++++++++++++++++++++++++++++++
 
-``correction_loop.py`` contains 3 functions. The first one is ``CorrectionLoop1Matrix`` which is a for loop repeated
-``Number_matrix`` , which update the Interference Matrix and run the ``CorrectionLoop1Matrix`` at each iteration.
+``correction_loop.py`` contains 3 functions. The first one is ``correction_loop_1matrix()`` which is a for loop repeated
+``Number_matrix`` , which update the Interference Matrix and run the ``correction_loop_1matrix()`` at each iteration.
 
 
-The ``CorrectionLoop1Matrix`` function is a loop running ``Nbiter_corr`` times that is basically doing:
+The ``correction_loop_1matrix()`` function is a loop running ``Nbiter_corr`` times that is basically doing:
 
 * estimation
 
@@ -138,6 +138,6 @@ The ``CorrectionLoop1Matrix`` function is a loop running ``Nbiter_corr`` times t
 
 * application on DM and measure of DM
 
-The results are stored in a dictionnary then sent to ``Save_loop_results`` for ploting and saving in the folder 
+The results are stored in a dictionnary then sent to ``save_loop_results()`` for ploting and saving in the folder
 named '/Results/Name_experiement' where ``Name_Experiment`` is a parameter. All .fits saved have all parameters in the header. 
 The config (with updated parameters) is also saved in a .ini file, so you can run the same experiment. 

--- a/source/create_my_testbed.rst
+++ b/source/create_my_testbed.rst
@@ -8,7 +8,7 @@ Optical System
 
 Asterix have been thought from the beginning to be able to easily adapt to new configurations of the testbed 
 wihtout major changes. This modularity is based on the ``Asterix.Optical_System_functions.OpticalSystem`` class.
-An Optical_ystem is a part of the testbed which starts and ends in a pupil plane, which allows them to be easily
+An OpticalSystem is a part of the testbed which starts and ends in a pupil plane, which allows them to be easily
 concatenated. To be able to be well concatenated, they must all be using the same general parameters (physical 
 and numerical parameters). These parameters are stored in the first part of the parameter file, common to 
 all ``OpticalSystem``: [modelconfig].

--- a/source/create_my_testbed.rst
+++ b/source/create_my_testbed.rst
@@ -7,18 +7,18 @@ Optical System
 +++++++++++++++++++++++
 
 Asterix have been thought from the beginning to be able to easily adapt to new configurations of the testbed 
-wihtout major changes. This modularity is based on the ``Asterix.Optical_System_functions.Optical_System`` class.
-An Optical_System is a part of the testbed which starts and ends in a pupil plane, which allows them to be easily 
+wihtout major changes. This modularity is based on the ``Asterix.Optical_System_functions.OpticalSystem`` class.
+An Optical_ystem is a part of the testbed which starts and ends in a pupil plane, which allows them to be easily
 concatenated. To be able to be well concatenated, they must all be using the same general parameters (physical 
 and numerical parameters). These parameters are stored in the first part of the parameter file, common to 
-all ``Optical_System``: [modelconfig]. 
+all ``OpticalSystem``: [modelconfig].
 Among those parameters, you have the size in pixels of all pupils. This is the size of the entrance pupil, which
 will set up all other dimensions. The pupil planes are overpadded compared to this pupil size because 
-some ``Optical_System`` require it. By convention, all pupil planes are centered bewteen the 4 central pixels. 
+some ``OpticalSystem`` require it. By convention, all pupil planes are centered bewteen the 4 central pixels.
 
 
 Parameter file can be read using ``Asterix.fits_functions.read_parameter_file`` function. We can create a generic
-``Optical_System`` like this. 
+``OpticalSystem`` like this.
 
 .. code-block:: python
     
@@ -28,14 +28,14 @@ Parameter file can be read using ``Asterix.fits_functions.read_parameter_file`` 
     config = useful.read_parameter_file(parameter_file)
     modelconfig = config["modelconfig"]
 
-    generic_os = OptSy.Optical_System(modelconfig)
+    generic_os = OptSy.OpticalSystem(modelconfig)
 
 
 For the moment, this ``generic_os`` does not do anything, it's like an empty pupil plane. 
 
-Each ``Optical_System`` has an attribute function ``EF_through`` which describes the effect this Optical_System has 
-on the electrical field when going through it. Once this function is defined, all Optical_System have access to 
-a library of functions, common to all ``Optical_System`` : ``todetector`` (electrical field in the next focal plane), 
+Each ``OpticalSystem`` has an attribute function ``EF_through`` which describes the effect this Optical System has
+on the electrical field when going through it. Once this function is defined, all OpticalSystem instances have access to
+a library of functions, common to all ``OpticalSystem`` : ``todetector`` (electrical field in the next focal plane),
 ``todetector_Intensity`` (Intensity in the next focal plane), ``transmission`` (measure ratio of photons lost 
 when crossing the system), etc.
 
@@ -61,11 +61,11 @@ Finally, for all optical system, you can use generic functions like to creaet an
 
 
 
-In the next section, we will present the existing ``Optical_System``s (``Optical_System.pupil``, 
-``Optical_System.coronagraph``, ``Optical_System.deformable_mirror``) and the 
-way to concatenate them easily to create an ``Optical_System.Testbed``. 
+In the next section, we will present the existing ``OpticalSystem``s (``OpticalSystem.Pupil``,
+``OpticalSystem.Coronagraph``, ``OpticalSystem.DeformableMirror``) and the
+way to concatenate them easily to create an ``OpticalSystem.Testbed``.
 
-Finally, ``Optical_System`` have been set up with a mode where each optical plane is save to .fits for debugging purposes.
+Finally, ``OpticalSystem`` have been set up with a mode where each optical plane is save to .fits for debugging purposes.
 This can generate a lot of fits especially if in a loop so be careful. 
 To use this options use keywords ``save_all_planes_to_fits = True`` and set up the directory ``dir_save_all_planes``
 
@@ -74,10 +74,10 @@ Function documentation can be found in Section :ref:`os-label`.
 Pupil
 +++++++++++++++++++++++
 
-``Optical_System.pupil`` is the most simple type of ``Optical_System``. It initializes and describes the behavior 
-of single pupil pupil is a sub class of ``Optical_System``. Obviously you can define your pupil without that 
+``OpticalSystem.Pupil`` is the most simple type of ``OpticalSystem``. It initializes and describes the behavior
+of single pupil pupil is a sub class of ``OpticalSystem``. Obviously you can define your pupil without that
 with 2d arrray multiplication (this is a fairly simple object). The main advantage of defining them using 
-``Optical_System`` is that you can use default ``Optical_System`` functions to obtain PSF, transmission, etc...
+``OpticalSystem`` is that you can use default ``OpticalSystem`` functions to obtain PSF, transmission, etc...
 and concatenate them with other elements. 
 
 .. code-block:: python
@@ -88,9 +88,9 @@ and concatenate them with other elements.
     config = useful.read_parameter_file(parameter_file)
     modelconfig = config["modelconfig"]
 
-    pup_round = OptSy.pupil(modelconfig)
+    pup_round = OptSy.Pupil(modelconfig)
 
-    # Because this is an Optical_System, you can access attribute functions: 
+    # Because this is an OpticalSystem, you can access attribute functions:
     
     exit_EF = pup_round.EF_through() # electrical field after the system 
                                     #(by default, entrance field is 1.)
@@ -102,13 +102,13 @@ You can define a different radius than the pupil one in the parameter file
 
 .. code-block:: python
 
-    pup_round = OptSy.pupil(modelconfig, prad = 43)
+    pup_round = OptSy.Pupil(modelconfig, prad = 43)
 
 Some specific aperture types are defined that you can access using the keyword ``PupType``
 
 .. code-block:: python
 
-    pup_roman = OptSy.pupil(modelconfig, PupType = "RomanPup")
+    pup_roman = OptSy.Pupil(modelconfig, PupType = "RomanPup")
 
 Currently supported ``PupType`` are : "RoundPup", "CleanPlane" (empty pupil plane), "RomanPup", "RomanLyot", "RomanPupTHD2", "RomanLyotTHD2".
 
@@ -125,7 +125,7 @@ Function documentation can be found in Section :ref:`pupil-label`.
 Coronagraph
 +++++++++++++++++++++++
 
-``Optical_System.coronagraph`` is a sub class of ``Optical_System`` which initializes and describes the behavior 
+``OpticalSystem.Coronagraph`` is a sub class of ``OpticalSystem`` which initializes and describes the behavior
 of a coronagraph system (from apodization plane at the entrance of the coronagraph to the Lyot plane). Function
 documentation can be found in Section :ref:`coronagraph-label`. 
 
@@ -139,7 +139,7 @@ documentation can be found in Section :ref:`coronagraph-label`.
     modelconfig = config["modelconfig"]
     Coronaconfig = config["Coronaconfig"]
 
-    corono = OptSy.coronagraph(modelconfig, Coronaconfig)
+    corono = OptSy.Coronagraph(modelconfig, Coronaconfig)
     
     exit_EF = corono.EF_through() # electrical field after the system 
                                     #(by default, entrance field is 1.)
@@ -149,13 +149,13 @@ documentation can be found in Section :ref:`coronagraph-label`.
 Type of coronagraph can be changed with ``corona_type`` parameter.  Currently supported ``corona_type`` 
 are 'fqpm' or 'knife', 'classiclyot' or 'HLC'. Focal plane functions are automatically normalized in contrast
 by default. For details about the way to normalize in polychromatic light, see ``measure_normalization`` 
-and ``todetector_Intensity`` documention in :ref:`os-label`
+and ``todetector_Intensity`` documentation in :ref:`os-label`
 
 
 Deformable Mirror
 +++++++++++++++++++++++
 
-``Optical_System.deformable_mirror`` is a subclass of ``Optical_System`` which initializes and describes the behavior 
+``OpticalSystem.DeformableMirror`` is a subclass of ``OpticalSystem`` which initializes and describes the behavior
 of a deformable mirror (DM) system. 
 
 
@@ -168,7 +168,7 @@ of a deformable mirror (DM) system.
     modelconfig = config["modelconfig"]
     DMconfig = config["DMconfig"]
 
-    DM1 = OptSy.deformable_mirror(modelconfig,
+    DM1 = OptSy.DeformableMirror(modelconfig,
                                     DMconfig,
                                     Name_DM='DM1',
                                     Model_local_dir=Model_local_dir)
@@ -186,7 +186,7 @@ Because we are only in close range, this is more accurate than Fresnel propogati
 Function documentation can be found in Section :ref:`deformable-mirror-label`. 
 
 
-Concatenate your Optical_Systems
+Concatenate your Optical Systems
 ++++++++++++++++++++++++++++++++++++++++++++++
 
 This is a particular subclass of Optical System, because we do not know what is inside
@@ -203,19 +203,19 @@ It can only be initialized by giving a list of Optical Systems and it will creat
     Coronaconfig = config["Coronaconfig"]
     DMconfig = config["DMconfig"]
 
-    pup_round = OptSy.pupil(modelconfig)
+    pup_round = OptSy.Pupil(modelconfig)
 
-    DM34act = OptSy.deformable_mirror(modelconfig,
+    DM34act = OptSy.DeformableMirror(modelconfig,
                                     DMconfig,
                                     Name_DM='DM1',
                                     Model_local_dir=Model_local_dir)
 
-    DM32act = OptSy.deformable_mirror(modelconfig,
+    DM32act = OptSy.DeformableMirror(modelconfig,
                                     DMconfig,
                                     Name_DM='DM3',
                                     Model_local_dir=Model_local_dir)
 
-    corono = OptSy.coronagraph(modelconfig, Coronaconfig)
+    corono = OptSy.Coronagraph(modelconfig, Coronaconfig)
     # and then just concatenate
     testbed = OptSy.Testbed([pup_round, DM34act, DM32act, corono],
                             ["entrancepupil", "DM1", "DM3", "corono"])
@@ -235,7 +235,7 @@ or a specific pupil in the entrance plane of the coronagraph (e.g. like the Roma
 
 .. code-block:: python
 
-    pup_roman = OptSy.pupil(modelconfig, PupType = "RomanPup")
+    pup_roman = OptSy.Pupil(modelconfig, PupType = "RomanPup")
     testbed = OptSy.Testbed([pup_round, DM34act, DM32act,pup_roman, corono],
                                 ["entrancepupil", "DM1", "DM3", "romanpupil" , "corono"])
     

--- a/source/create_my_testbed.rst
+++ b/source/create_my_testbed.rst
@@ -33,7 +33,7 @@ Parameter file can be read using ``Asterix.fits_functions.read_parameter_file`` 
 
 For the moment, this ``generic_os`` does not do anything, it's like an empty pupil plane. 
 
-Each ``OpticalSystem`` has an attribute function ``EF_through`` which describes the effect this Optical System has
+Each ``OpticalSystem`` has an attribute function ``EF_through`` which describes the effect this optical system has
 on the electrical field when going through it. Once this function is defined, all OpticalSystem instances have access to
 a library of functions, common to all ``OpticalSystem`` : ``todetector`` (electrical field in the next focal plane),
 ``todetector_Intensity`` (Intensity in the next focal plane), ``transmission`` (measure ratio of photons lost 

--- a/source/create_my_testbed.rst
+++ b/source/create_my_testbed.rst
@@ -7,7 +7,7 @@ Optical System
 +++++++++++++++++++++++
 
 Asterix have been thought from the beginning to be able to easily adapt to new configurations of the testbed 
-wihtout major changes. This modularity is based on the ``Asterix.Optical_System_functions.OpticalSystem`` class.
+wihtout major changes. This modularity is based on the ``Asterix.optical_systems.OpticalSystem`` class.
 An OpticalSystem is a part of the testbed which starts and ends in a pupil plane, which allows them to be easily
 concatenated. To be able to be well concatenated, they must all be using the same general parameters (physical 
 and numerical parameters). These parameters are stored in the first part of the parameter file, common to 
@@ -17,13 +17,13 @@ will set up all other dimensions. The pupil planes are overpadded compared to th
 some ``OpticalSystem`` require it. By convention, all pupil planes are centered bewteen the 4 central pixels.
 
 
-Parameter file can be read using ``Asterix.fits_functions.read_parameter_file`` function. We can create a generic
+Parameter file can be read using ``Asterix.save_and_read.read_parameter_file`` function. We can create a generic
 ``OpticalSystem`` like this.
 
 .. code-block:: python
     
-    import Asterix.fits_functions as useful
-    import Asterix.Optical_System_functions as OptSy
+    import Asterix.save_and_read as useful
+    import Asterix.optical_systems as OptSy
 
     config = useful.read_parameter_file(parameter_file)
     modelconfig = config["modelconfig"]
@@ -36,7 +36,7 @@ For the moment, this ``generic_os`` does not do anything, it's like an empty pup
 Each ``OpticalSystem`` has an attribute function ``EF_through`` which describes the effect this optical system has
 on the electrical field when going through it. Once this function is defined, all OpticalSystem instances have access to
 a library of functions, common to all ``OpticalSystem`` : ``todetector`` (electrical field in the next focal plane),
-``todetector_Intensity`` (Intensity in the next focal plane), ``transmission`` (measure ratio of photons lost 
+``todetector_intensity`` (Intensity in the next focal plane), ``transmission`` (measure ratio of photons lost
 when crossing the system), etc.
 
 .. code-block:: python
@@ -44,7 +44,7 @@ when crossing the system), etc.
     exit_EF = generic_os.EF_through() # electrical field after the system 
                                     # (by default, entrance field is 1.)
     EF_FP = generic_os.todetector() # electrical field in the next focal plane
-    PSF = generic_os.todetector_Intensity() #  Intensity in the next focal plane
+    PSF = generic_os.todetector_intensity() #  Intensity in the next focal plane
 
 
 Finally, for all optical system, you can use generic functions like to creaet and manipulate phase and amplitude screens
@@ -57,7 +57,7 @@ Finally, for all optical system, you can use generic functions like to creaet an
     input_wavefront = thd2.EF_from_phase_and_ampl(phase_abb=phase_abb_up)
 
     # Focal plane intensity for this aberrations
-    PSF = generic_os.todetector_Intensity(entrance_EF = input_wavefront) 
+    PSF = generic_os.todetector_intensity(entrance_EF = input_wavefront)
 
 
 
@@ -82,8 +82,8 @@ and concatenate them with other elements.
 
 .. code-block:: python
     
-    import Asterix.fits_functions as useful
-    import Asterix.Optical_System_functions as OptSy
+    import Asterix.save_and_read as useful
+    import Asterix.optical_systems as OptSy
 
     config = useful.read_parameter_file(parameter_file)
     modelconfig = config["modelconfig"]
@@ -95,7 +95,7 @@ and concatenate them with other elements.
     exit_EF = pup_round.EF_through() # electrical field after the system 
                                     #(by default, entrance field is 1.)
     EF_FP = pup_round.todetector() # electrical field in the next focal plane
-    PSF = pup_round.todetector_Intensity() #  Intensity in the next focal plane
+    PSF = pup_round.todetector_intensity() #  Intensity in the next focal plane
 
 
 You can define a different radius than the pupil one in the parameter file
@@ -132,8 +132,8 @@ documentation can be found in Section :ref:`coronagraph-label`.
 
 .. code-block:: python
     
-    import Asterix.fits_functions as useful
-    import Asterix.Optical_System_functions as OptSy
+    import Asterix.save_and_read as useful
+    import Asterix.optical_systems as OptSy
 
     config = useful.read_parameter_file(parameter_file)
     modelconfig = config["modelconfig"]
@@ -144,12 +144,12 @@ documentation can be found in Section :ref:`coronagraph-label`.
     exit_EF = corono.EF_through() # electrical field after the system 
                                     #(by default, entrance field is 1.)
     EF_FP = corono.todetector() # electrical field in the next focal plane
-    PSF = corono.todetector_Intensity() #  Intensity in the next focal plane
+    PSF = corono.todetector_intensity() #  Intensity in the next focal plane
 
 Type of coronagraph can be changed with ``corona_type`` parameter.  Currently supported ``corona_type`` 
 are 'fqpm' or 'knife', 'classiclyot' or 'HLC'. Focal plane functions are automatically normalized in contrast
 by default. For details about the way to normalize in polychromatic light, see ``measure_normalization`` 
-and ``todetector_Intensity`` documentation in :ref:`os-label`
+and ``todetector_intensity`` documentation in :ref:`os-label`
 
 
 Deformable Mirror
@@ -161,8 +161,8 @@ of a deformable mirror (DM) system.
 
 .. code-block:: python
     
-    import Asterix.fits_functions as useful
-    import Asterix.Optical_System_functions as OptSy
+    import Asterix.save_and_read as useful
+    import Asterix.optical_systems as OptSy
 
     config = useful.read_parameter_file(parameter_file)
     modelconfig = config["modelconfig"]
@@ -195,8 +195,8 @@ It can only be initialized by giving a list of Optical Systems and it will creat
 
 .. code-block:: python
     
-    import Asterix.fits_functions as useful
-    import Asterix.Optical_System_functions as OptSy
+    import Asterix.save_and_read as useful
+    import Asterix.optical_systems as OptSy
 
     config = useful.read_parameter_file(parameter_file)
     modelconfig = config["modelconfig"]

--- a/source/index.rst
+++ b/source/index.rst
@@ -45,12 +45,12 @@ Annex: Asterix Functions
 ==================
 
 
-Main_THD.py
+main_THD.py
 -----------------
-.. automodule:: Asterix.Main_THD
+.. automodule:: Asterix.main_THD
     :members:
 
-.. callgraph:: Asterix.Main_THD.runthd2
+.. callgraph:: Asterix.main_THD.runthd2
     :toctree: api
     :zoomable:
     :direction: horizontal
@@ -61,19 +61,19 @@ correction_loop.py
 .. automodule:: Asterix.correction_loop
     :members:
 
-.. callgraph:: Asterix.correction_loop.CorrectionLoop
+.. callgraph:: Asterix.correction_loop.correction_loop
     :toctree: api
     :zoomable:
     :direction: horizontal
 
 
-Optical_System_functions.py
+optical_systems.py
 -----------------
 
 OpticalSystem: main class
 ++++++++++++++++++++++++++
 .. _os-label:
-.. autoclass:: Asterix.Optical_System_functions.OpticalSystem
+.. autoclass:: Asterix.optical_systems.OpticalSystem
     :members:
     :show-inheritance:
 
@@ -81,18 +81,18 @@ OpticalSystem: main class
 OpticalSystem: pupil subclass
 ++++++++++++++++++++++++++
 .. _pupil-label:
-.. autoclass:: Asterix.Optical_System_functions.Pupil
+.. autoclass:: Asterix.optical_systems.Pupil
     :members:
     :show-inheritance:
 
 OpticalSystem: coronagraph subclass
 ++++++++++++++++++++++++++
 .. _coronagraph-label:
-.. autoclass:: Asterix.Optical_System_functions.Coronagraph
+.. autoclass:: Asterix.optical_systems.Coronagraph
     :members:
     :show-inheritance:
 
-.. callgraph:: Asterix.Optical_System_functions.Coronagraph.__init__
+.. callgraph:: Asterix.optical_systems.Coronagraph.__init__
     :toctree: api
     :zoomable:
     :direction: horizontal
@@ -100,11 +100,11 @@ OpticalSystem: coronagraph subclass
 OpticalSystem: DeformableMirror subclass
 ++++++++++++++++++++++++++
 .. _deformable-mirror-label:
-.. autoclass:: Asterix.Optical_System_functions.DeformableMirror
+.. autoclass:: Asterix.optical_systems.DeformableMirror
     :members:
     :show-inheritance:
 
-.. callgraph:: Asterix.Optical_System_functions.DeformableMirror.__init__
+.. callgraph:: Asterix.optical_systems.DeformableMirror.__init__
     :toctree: api
     :zoomable:
     :direction: horizontal
@@ -112,7 +112,7 @@ OpticalSystem: DeformableMirror subclass
 OpticalSystem: Testbed subclass
 ++++++++++++++++++++++++++
 .. _testbed-label:
-.. autoclass:: Asterix.Optical_System_functions.Testbed
+.. autoclass:: Asterix.optical_systems.Testbed
     :members:
     :show-inheritance:
 
@@ -178,9 +178,9 @@ processing_functions.py
     :members:
 
 
-fits_functions.py
+save_and_read.py
 -----------------
-.. automodule:: Asterix.fits_functions
+.. automodule:: Asterix.save_and_read
     :members:
 
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -70,46 +70,46 @@ correction_loop.py
 Optical_System_functions.py
 -----------------
 
-Optical_System: main class
+OpticalSystem: main class
 ++++++++++++++++++++++++++
 .. _os-label:
-.. autoclass:: Asterix.Optical_System_functions.Optical_System
+.. autoclass:: Asterix.Optical_System_functions.OpticalSystem
     :members:
     :show-inheritance:
 
 
-Optical_System: pupil subclass
+OpticalSystem: pupil subclass
 ++++++++++++++++++++++++++
 .. _pupil-label:
-.. autoclass:: Asterix.Optical_System_functions.pupil
+.. autoclass:: Asterix.Optical_System_functions.Pupil
     :members:
     :show-inheritance:
 
-Optical_System: coronagraph subclass
+OpticalSystem: coronagraph subclass
 ++++++++++++++++++++++++++
 .. _coronagraph-label:
-.. autoclass:: Asterix.Optical_System_functions.coronagraph
+.. autoclass:: Asterix.Optical_System_functions.Coronagraph
     :members:
     :show-inheritance:
 
-.. callgraph:: Asterix.Optical_System_functions.coronagraph.__init__
+.. callgraph:: Asterix.Optical_System_functions.Coronagraph.__init__
     :toctree: api
     :zoomable:
     :direction: horizontal
 
-Optical_System: deformable_mirror subclass
+OpticalSystem: DeformableMirror subclass
 ++++++++++++++++++++++++++
 .. _deformable-mirror-label:
-.. autoclass:: Asterix.Optical_System_functions.deformable_mirror
+.. autoclass:: Asterix.Optical_System_functions.DeformableMirror
     :members:
     :show-inheritance:
 
-.. callgraph:: Asterix.Optical_System_functions.deformable_mirror.__init__
+.. callgraph:: Asterix.Optical_System_functions.DeformableMirror.__init__
     :toctree: api
     :zoomable:
     :direction: horizontal
 
-Optical_System: Testbed subclass
+OpticalSystem: Testbed subclass
 ++++++++++++++++++++++++++
 .. _testbed-label:
 .. autoclass:: Asterix.Optical_System_functions.Testbed

--- a/source/run_asterix.rst
+++ b/source/run_asterix.rst
@@ -5,7 +5,7 @@ Basic Asterix Tutorial with THD2 model
 
 This sections is if you want to use the code as it currently set up, in the THD2 configuration.
 To run Asterix you first need a parameter .ini file describing all the testbed configuration and a python file to call the main. 
-An example of these files are provided in the packages : Example_param_file.ini and Example_Run_Asterix.py
+An example of these files are provided in the packages : Example_param_file.ini and example_run_asterix.py
 
 Run Asterix in THD2 mode
 +++++++++++++++++++++++
@@ -16,27 +16,27 @@ with the THD2 testbed, just run:
 .. code-block:: python
 
     import os
-    from Asterix import Main_THD
+    from Asterix import main_THD
     Asterixroot = os.path.dirname(os.path.realpath(__file__))
-    Main_THD.runthd2(Asterixroot + os.path.sep + 'Example_param_file.ini')
+    main_THD.runthd2(Asterixroot + os.path.sep + 'Example_param_file.ini')
 
 Please avoid running Asterix directly in the Asterix install directory to avoid saving .fits files everywhere.
 The first parameter of the parameter file is ``Data_dir``. By default it is set to '.' which means it will save the files
 in the directory you currently are when you run this code. A good practice is therefore to create your own parameter file by
-copying Example_param_file.ini in another directory and create you own calling python file which call Main_THD.runthd2.
+copying Example_param_file.ini in another directory and create you own calling python file which call ``main_THD.runthd2()``.
 
 .. code-block:: python
 
-    from Asterix import Main_THD
-    Main_THD.runthd2(path_to_my_param_file + 'my_param_file.ini')
+    from Asterix import main_THD
+    main_THD.runthd2(path_to_my_param_file + 'my_param_file.ini')
 
 To run several simulation with slightly different parameters, you can override one of the parameters directly from the main. 
 For example:
 
 .. code-block:: python
 
-    from Asterix import Main_THD
-    Main_THD.runthd2(path_to_my_param_file + 'my_param_file.ini'
+    from Asterix import main_THD
+    main_THD.runthd2(path_to_my_param_file + 'my_param_file.ini'
         NewCoronaconfig={"corona_type" : 'fqpm'})
 
 will overide the current corona_type parameter and replace it with "fqpm", leaving all other parameters unchanged.


### PR DESCRIPTION
Class names in Python are written in camel case [according to PEP8](https://peps.python.org/pep-0008/#class-names). Some of the classes in Asterix were already adhering to that, others no. This PR unifies this and removes some obvious comments that repeat the class names.

A summary of Python naming conventions can be found here:
https://visualgit.readthedocs.io/en/latest/pages/naming_convention.html

It seemed like a good time to do this since we just closed all PRs (except for #52 which only changes plotting) before I start working on more substantial changes.

Needs #60 to me merged first.