### PR TITLE
Add save all planes option to main

### DIFF
--- a/Asterix/example_run_asterix.py
+++ b/Asterix/example_run_asterix.py
@@ -24,7 +24,6 @@ main_THD.runthd2(parameter_file_path,
                      "Nbmode_corr": [320, 340]
                  },
                  NewSIMUconfig={'Name_Experiment': "My_first_experiment"},
-                 save_all_planes_to_fits=False,
                  dir_save_all_planes=None)
 
 print('time correction 1DM perfect estim efc', time.time() - start_time)

--- a/Asterix/example_run_asterix.py
+++ b/Asterix/example_run_asterix.py
@@ -23,7 +23,9 @@ main_THD.runthd2(parameter_file_path,
                      'Nbiter_corr': [5, 10],
                      "Nbmode_corr": [320, 340]
                  },
-                 NewSIMUconfig={'Name_Experiment': "My_first_experiment"})
+                 NewSIMUconfig={'Name_Experiment': "My_first_experiment"},
+                 save_all_planes_to_fits=False,
+                 dir_save_all_planes=None)
 
 print('time correction 1DM perfect estim efc', time.time() - start_time)
 print("")
@@ -51,18 +53,18 @@ print("")
 
 start_time = time.time()
 main_THD.runthd2(parameter_file_path,
-                NewDMconfig={'DM1_active': True},
-                NewEstimationconfig={'estimation': 'perfect'},
-                NewCorrectionconfig={
-                    'DH_side': "Full",
-                    'correction_algorithm': "sm",
-                    'Nbmodes_OnTestbed': 600
-                },
-                NewLoopconfig={
-                    'Nbiter_corr': [20],
-                    'Nbmode_corr': [250]
-                },
-                NewSIMUconfig={'Name_Experiment': "My_fourth_experiment"})
+                 NewDMconfig={'DM1_active': True},
+                 NewEstimationconfig={'estimation': 'perfect'},
+                 NewCorrectionconfig={
+                     'DH_side': "Full",
+                     'correction_algorithm': "sm",
+                     'Nbmodes_OnTestbed': 600
+                 },
+                 NewLoopconfig={
+                     'Nbiter_corr': [20],
+                     'Nbmode_corr': [250]
+                 },
+                 NewSIMUconfig={'Name_Experiment': "My_third_experiment"})
 print('time correction 2DM perfect estim sm', time.time() - start_time)
 print("")
 print("")
@@ -81,7 +83,7 @@ main_THD.runthd2(parameter_file_path,
                      'Nbiter_corr': [5, 1, 1, 1, 3, 2, 1, 2, 4, 3],
                      'Nbmode_corr': [500, 800, 500, 1000, 700, 900, 1000, 900, 700, 900]
                  },
-                 NewSIMUconfig={'Name_Experiment': "My_fifth_experiment"})
+                 NewSIMUconfig={'Name_Experiment': "My_fourth_experiment"})
 print('time correction 2DM pw efc', time.time() - start_time)
 print("")
 print("")

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -15,7 +15,8 @@ def runthd2(parameter_file,
             NewEstimationconfig={},
             NewCorrectionconfig={},
             NewLoopconfig={},
-            NewSIMUconfig={}):
+            NewSIMUconfig={},
+            **kwargs):
     """
     Run a simulation of a correction loop for the THD2 testbed.
 
@@ -84,8 +85,7 @@ def runthd2(parameter_file,
     corono = Coronagraph(modelconfig, Coronaconfig, Model_local_dir=model_local_dir)
 
     # Concatenate into the full testbed optical system
-    thd2 = Testbed([entrance_pupil, DM1, DM3, corono],
-                   ["entrancepupil", "DM1", "DM3", "corono"])
+    thd2 = Testbed([entrance_pupil, DM1, DM3, corono], ["entrancepupil", "DM1", "DM3", "corono"])
 
     # The following line can be used to change the DM which aplpies PW probes. This could be used to use the DM out of
     # the pupil plane.
@@ -101,7 +101,7 @@ def runthd2(parameter_file,
 
     # Initialize the DH masks
     mask_dh = MaskDH(Correctionconfig)
-    science_mask_dh = mask_dh.creatingMaskDH(thd2.dimScience, thd2.Science_sampling)
+    science_mask_dh = mask_dh.creatingMaskDH(thd2.dimScience, thd2.Science_sampling, **kwargs)
 
     # Initialize the corrector
     corrector = Corrector(Correctionconfig,
@@ -139,6 +139,7 @@ def runthd2(parameter_file,
                               input_wavefront=input_wavefront,
                               EF_aberrations_introduced_in_LS=wavefront_in_LS,
                               initial_DM_voltage=0,
-                              silence=False)
+                              silence=False,
+                              **kwargs)
 
     save_loop_results(results, config, thd2, science_mask_dh, result_dir)

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -18,7 +18,6 @@ def runthd2(parameter_file,
             NewSIMUconfig={},
             silence=False,
             **kwargs):
-
     """
     Run a simulation of a correction loop for the THD2 testbed.
 

--- a/Asterix/optics/coronagraph.py
+++ b/Asterix/optics/coronagraph.py
@@ -176,7 +176,6 @@ class Coronagraph(OpticalSystem):
                    wavelength=None,
                    noFPM=False,
                    EF_aberrations_introduced_in_LS=1.,
-                   save_all_planes_to_fits=False,
                    dir_save_all_planes=None,
                    **kwargs):
         """
@@ -204,16 +203,10 @@ class Coronagraph(OpticalSystem):
                         Can also be a float scalar in which case entrance_EF is constant
                         default is 1.
                         electrical field created by the downstream aberrations introduced directly in the Lyot Stop
-
-        save_all_planes_to_fits: Bool, default False.
-                if True, save all planes to fits for debugging purposes to dir_save_all_planes
-                This can generate a lot of fits especially if in a loop so the code force you
-                to define a repository.
         
         dir_save_all_planes : default None. 
-                                directory to save all plane in
-                              fits if save_all_planes_to_fits = True
-
+                               if not None, directory to save all planes in fits for debugging purposes.
+                               This can generate a lot of fits especially if in a loop, use with caution
         Returns
         ------
         exit_EF : 2D array, of size [self.dim_overpad_pupil, self.dim_overpad_pupil]
@@ -227,11 +220,7 @@ class Coronagraph(OpticalSystem):
         if wavelength is None:
             wavelength = self.wavelength_0
 
-        if save_all_planes_to_fits == True and dir_save_all_planes == None:
-            raise Exception("save_all_planes_to_fits = True can generate a lot of .fits files" +
-                            "please define a clear directory using dir_save_all_planes kw argument")
-
-        if save_all_planes_to_fits == True:
+        if dir_save_all_planes is not None:
             name_plane = 'EF_PP_before_apod' + '_wl{}'.format(int(wavelength * 1e9))
             save_plane_in_fits(dir_save_all_planes, name_plane, entrance_EF)
 
@@ -244,7 +233,7 @@ class Coronagraph(OpticalSystem):
 
         input_wavefront_after_apod = self.apod_pup.EF_through(entrance_EF=entrance_EF, wavelength=wavelength)
 
-        if save_all_planes_to_fits == True:
+        if dir_save_all_planes is not None:
             name_plane = 'apod' + '_wl{}'.format(int(wavelength * 1e9))
             save_plane_in_fits(dir_save_all_planes, name_plane, self.apod_pup.pup)
 
@@ -263,7 +252,7 @@ class Coronagraph(OpticalSystem):
                                                        center_pos='bb',
                                                        norm='ortho')
 
-            if save_all_planes_to_fits == True:
+            if dir_save_all_planes is not None:
                 name_plane = 'EF_FP_before_FPM' + '_wl{}'.format(int(wavelength * 1e9))
                 save_plane_in_fits(dir_save_all_planes, name_plane, np.fft.fftshift(corono_focal_plane))
 
@@ -300,7 +289,7 @@ class Coronagraph(OpticalSystem):
                                           inverse=False,
                                           norm='ortho')
 
-            if save_all_planes_to_fits == True:
+            if dir_save_all_planes is not None:
                 name_plane = 'EF_FP_before_FPM' + '_wl{}'.format(int(wavelength * 1e9))
                 save_plane_in_fits(dir_save_all_planes, name_plane, corono_focal_plane)
                 if not noFPM:
@@ -342,7 +331,7 @@ class Coronagraph(OpticalSystem):
                                           inverse=False,
                                           norm='ortho')
 
-            if save_all_planes_to_fits == True:
+            if dir_save_all_planes is not None:
                 name_plane = 'EF_FP_before_FPM' + '_wl{}'.format(int(wavelength * 1e9))
                 save_plane_in_fits(dir_save_all_planes, name_plane, corono_focal_plane)
                 if not noFPM:
@@ -370,7 +359,7 @@ class Coronagraph(OpticalSystem):
         else:
             raise Exception(self.prop_apod2lyot + " is not a known prop_apod2lyot propagation mehtod")
 
-        if save_all_planes_to_fits == True:
+        if dir_save_all_planes is not None:
             name_plane = 'EF_PP_before_LS' + '_wl{}'.format(int(wavelength * 1e9))
             save_plane_in_fits(dir_save_all_planes, name_plane, lyotplane_before_lyot)
 
@@ -388,7 +377,7 @@ class Coronagraph(OpticalSystem):
             lyotplane_after_lyot = lyotplane_after_lyot - self.perfect_Lyot_pupil[self.wav_vec.tolist().index(
                 wavelength)]
 
-        if save_all_planes_to_fits == True:
+        if dir_save_all_planes is not None:
             name_plane = 'LS' + '_wl{}'.format(int(wavelength * 1e9))
             save_plane_in_fits(dir_save_all_planes, name_plane, self.lyot_pup.pup)
 

--- a/Asterix/optics/coronagraph.py
+++ b/Asterix/optics/coronagraph.py
@@ -29,13 +29,13 @@ class Coronagraph(OpticalSystem):
         Parameters
         ----------
         modelconfig : dict
-                general configuration parameters (sizes and dimensions)
+            general configuration parameters (sizes and dimensions)
         coroconfig : : dict
-                coronagraph parameters
+            coronagraph parameters
 
         Model_local_dir: string, default None
-                    directory to save things you can measure yourself
-                    and can save to save times      
+            directory to save things you can measure yourself
+            and can save to save times      
         
         """
 
@@ -189,28 +189,29 @@ class Coronagraph(OpticalSystem):
         Parameters
         ----------
         entrance_EF:    2D complex array of size [self.dim_overpad_pupil, self.dim_overpad_pupil]
-                        Can also be a float scalar in which case entrance_EF is constant
-                        default is 1.
-                        Electric field in the pupil plane a the entrance of the system.
+            Can also be a float scalar in which case entrance_EF is constant
+            default is 1.
+            Electric field in the pupil plane a the entrance of the system.
 
         wavelength : float. Default is self.wavelength_0 the reference wavelength
-                        current wavelength in m.
+            Current wavelength in m.
 
         noFPM : bool (default: False)
             if True, remove the FPM if one want to measure a un-obstructed PSF
         
         EF_aberrations_introduced_in_LS: 2D complex array of size [self.dim_overpad_pupil, self.dim_overpad_pupil]
-                        Can also be a float scalar in which case entrance_EF is constant
-                        default is 1.
-                        electrical field created by the downstream aberrations introduced directly in the Lyot Stop
+            Can also be a float scalar in which case entrance_EF is constant
+            default is 1.
+            electrical field created by the downstream aberrations introduced directly in the Lyot Stop
         
         dir_save_all_planes : default None. 
-                               if not None, directory to save all planes in fits for debugging purposes.
-                               This can generate a lot of fits especially if in a loop, use with caution
+            If not None, directory to save all planes in fits for debugging purposes.
+            This can generate a lot of fits especially if in a loop, use with caution
+
         Returns
         ------
         exit_EF : 2D array, of size [self.dim_overpad_pupil, self.dim_overpad_pupil]
-                Electric field in the pupil plane a the exit of the system
+            Electric field in the pupil plane a the exit of the system
         
         """
 
@@ -451,7 +452,7 @@ class Coronagraph(OpticalSystem):
         Returns
         ------
         vortex_fpm : list of 2D numpy array
-                            the FP mask at all wl
+            The FP mask at all wl
 
         """
 
@@ -488,7 +489,7 @@ class Coronagraph(OpticalSystem):
         Returns
         ------
         Knife FPM : list of len(self.wav_vec) 2D arrays 
-                    gcomplex transmission of the Knife edge coronagraph mask at all wl
+            Complex transmission of the Knife edge coronagraph mask at all wl
 
         """
         if self.prop_apod2lyot == "fft":
@@ -533,7 +534,7 @@ class Coronagraph(OpticalSystem):
         Returns
         ------
         classical Lyot fpm : list of 2D numpy array
-                            the FP mask at all wl
+            The FP mask at all wl
 
         """
 
@@ -555,7 +556,7 @@ class Coronagraph(OpticalSystem):
         Returns
         ------
         classical Lyot hlc : list of 2D numpy array
-                            the FP mask at all wl
+            The FP mask at all wl
         
         """
 

--- a/Asterix/optics/deformable_mirror.py
+++ b/Asterix/optics/deformable_mirror.py
@@ -127,22 +127,20 @@ class DeformableMirror(OpticalSystem):
 
         Parameters
         ----------
-        entrance_EF:    2D complex array of size [self.dim_overpad_pupil, self.dim_overpad_pupil] or float scalar in which case entrance_EF is constant
-                        default is 1.
-                        Electric field in the pupil plane a the entrance of the system.
+        entrance_EF:    2D complex array of size [self.dim_overpad_pupil, self.dim_overpad_pupil] or complex/float scalar (entrance_EF is constant)
+            default is 1. Electric field in the pupil plane a the entrance of the system.
 
         wavelength : float. Default is self.wavelength_0 the reference wavelength
-                    current wavelength in m.
+            Current wavelength in m.
 
-        DMphase : 2D array of size [self.dim_overpad_pupil, self.dim_overpad_pupil],can be complex or float scalar in which case DM_phase is constant
-                    default is 0.
-
-                    CAREFUL !! If the DM is part of a testbed. this variable name is changed
-                    to DMXXphase (DMXX: name of the DM) to avoid confusion with
+        DMphase : 2D array of size [self.dim_overpad_pupil, self.dim_overpad_pupil], or complex/float scalar (DM_phase is constant)
+            Default is 0.
+            CAREFUL !! If the DM is part of a testbed. this variable name is changed
+            to DMXXphase (DMXX: name of the DM) to avoid confusion
 
         dir_save_all_planes : default None. 
-                               if not None, directory to save all planes in fits for debugging purposes.
-                               This can generate a lot of fits especially if in a loop, use with caution
+            if not None, directory to save all planes in fits for debugging purposes.
+            This can generate a lot of fits especially if in a loop, use with caution
 
         Returns
         ------
@@ -418,22 +416,22 @@ class DeformableMirror(OpticalSystem):
         Parameters
         ----------
         pupil_wavefront : 2D array (float, double or complex)
-                    Wavefront in the pupil plane
+            Wavefront in the pupil plane
 
         phase_DM : 2D array
-                    Phase introduced by out of PP DM
+            Phase introduced by out of PP DM
 
         wavelength : float
-                    wavelength in m
+            wavelength in m
 
         dir_save_all_planes : default None. 
-                               if not None, directory to save all planes in fits for debugging purposes.
-                               This can generate a lot of fits especially if in a loop, use with caution
+            If not None, directory to save all planes in fits for debugging purposes.
+            This can generate a lot of fits especially if in a loop, use with caution
 
         Returns
         ------
         EF_back_in_pup_plane : 2D array (complex)
-                            Wavefront in the pupil plane following the DM
+            Wavefront in the pupil plane following the DM
 
         """
 

--- a/Asterix/optics/deformable_mirror.py
+++ b/Asterix/optics/deformable_mirror.py
@@ -117,13 +117,7 @@ class DeformableMirror(OpticalSystem):
         # now if we relaunch self.DM_pushact, and if misregistration = True
         # it will be different due to misregistration
 
-    def EF_through(self,
-                   entrance_EF=1.,
-                   wavelength=None,
-                   DMphase=0.,
-                   save_all_planes_to_fits=False,
-                   dir_save_all_planes=None,
-                   **kwargs):
+    def EF_through(self, entrance_EF=1., wavelength=None, DMphase=0., dir_save_all_planes=None, **kwargs):
         """
         Propagate the electric field through the DM.
         if z_DM = 0, then it's just a phase multiplication
@@ -146,14 +140,9 @@ class DeformableMirror(OpticalSystem):
                     CAREFUL !! If the DM is part of a testbed. this variable name is changed
                     to DMXXphase (DMXX: name of the DM) to avoid confusion with
 
-        save_all_planes_to_fits: Bool, default False
-                if True, save all planes to fits for debugging purposes to dir_save_all_planes
-                This can generate a lot of fits especially if in a loop so the code force you
-                to define a repository.
-
-        dir_save_all_planes : path, default None 
-                            directory to save all plane in
-                                    fits if save_all_planes_to_fits = True
+        dir_save_all_planes : default None. 
+                               if not None, directory to save all planes in fits for debugging purposes.
+                               This can generate a lot of fits especially if in a loop, use with caution
 
         Returns
         ------
@@ -161,10 +150,6 @@ class DeformableMirror(OpticalSystem):
             Electric field in the pupil plane a the exit of the system
 
         """
-
-        if save_all_planes_to_fits == True and dir_save_all_planes == None:
-            raise Exception("save_all_planes_to_fits = True can generate a lot of .fits files" +
-                            "please define a clear directory using dir_save_all_planes kw argument")
 
         # call the OpticalSystem super function to check
         # and format the variable entrance_EF
@@ -176,7 +161,7 @@ class DeformableMirror(OpticalSystem):
         if isinstance(DMphase, (int, float, np.float)):
             DMphase = np.full((self.dim_overpad_pupil, self.dim_overpad_pupil), np.float(DMphase))
 
-        if save_all_planes_to_fits == True:
+        if dir_save_all_planes is not None:
             name_plane = 'EF_PP_before_' + self.Name_DM + '_wl{}'.format(int(wavelength * 1e9))
             save_plane_in_fits(dir_save_all_planes, name_plane, entrance_EF)
             name_plane = 'phase_' + self.Name_DM + '_wl{}'.format(int(wavelength * 1e9))
@@ -194,10 +179,9 @@ class DeformableMirror(OpticalSystem):
             EF_after_DM = self.prop_pup_to_DM_and_back(entrance_EF,
                                                        DMphase,
                                                        wavelength,
-                                                       save_all_planes_to_fits=save_all_planes_to_fits,
                                                        dir_save_all_planes=dir_save_all_planes)
 
-        if save_all_planes_to_fits == True:
+        if dir_save_all_planes is not None:
             name_plane = 'EF_PP_after_' + self.Name_DM + '_wl{}'.format(int(wavelength * 1e9))
             save_plane_in_fits(dir_save_all_planes, name_plane, EF_after_DM)
 
@@ -420,12 +404,7 @@ class DeformableMirror(OpticalSystem):
 
         return WhichInPupil
 
-    def prop_pup_to_DM_and_back(self,
-                                entrance_EF,
-                                phase_DM,
-                                wavelength,
-                                save_all_planes_to_fits=False,
-                                dir_save_all_planes=None):
+    def prop_pup_to_DM_and_back(self, entrance_EF, phase_DM, wavelength, dir_save_all_planes=None):
         """
         Propagate the field towards an out-of-pupil plane ,
         add the DM phase, and propagate to the next pupil plane
@@ -447,13 +426,9 @@ class DeformableMirror(OpticalSystem):
         wavelength : float
                     wavelength in m
 
-        save_all_planes_to_fits: Bool, default False
-                if True, save all planes to fits for debugging purposes to dir_save_all_planes
-                This can generate a lot of fits especially if in a loop so the code force you
-                to define a repository.
-        
-        dir_save_all_planes : string default None. 
-                            directory to save all plane in fits if save_all_planes_to_fits = True
+        dir_save_all_planes : default None. 
+                               if not None, directory to save all planes in fits for debugging purposes.
+                               This can generate a lot of fits especially if in a loop, use with caution
 
         Returns
         ------
@@ -466,7 +441,7 @@ class DeformableMirror(OpticalSystem):
             prop.prop_angular_spectrum(entrance_EF, wavelength, self.z_position, self.diam_pup_in_m / 2.,
                                        self.prad), self.dim_overpad_pupil)
 
-        if save_all_planes_to_fits == True:
+        if dir_save_all_planes is not None:
             name_plane = 'EF_before_DM_in_' + self.Name_DM + 'plane_wl{}'.format(int(wavelength * 1e9))
             save_plane_in_fits(dir_save_all_planes, name_plane, EF_inDMplane)
 
@@ -474,7 +449,7 @@ class DeformableMirror(OpticalSystem):
         EF_inDMplane_after_DM = EF_inDMplane * self.EF_from_phase_and_ampl(phase_abb=phase_DM,
                                                                            wavelengths=wavelength)
 
-        if save_all_planes_to_fits == True:
+        if dir_save_all_planes is not None:
             name_plane = 'EF_after_DM_in_' + self.Name_DM + 'plane_wl{}'.format(int(wavelength * 1e9))
             save_plane_in_fits(dir_save_all_planes, name_plane, EF_inDMplane)
 

--- a/Asterix/optics/optical_systems.py
+++ b/Asterix/optics/optical_systems.py
@@ -91,15 +91,13 @@ class OpticalSystem:
 
         Parameters
         ----------
-        entrance_EF :   2D array of size [self.dim_overpad_pupil, self.dim_overpad_pupil],
-                        can be complex.
-                        Can also be a float scalar in which case entrance_EF is constant
-                        default is 1.
-                    Electric field in the pupil plane a the entrance of the system.
+        entrance_EF :   2D array of size [self.dim_overpad_pupil, self.dim_overpad_pupil], or complex/float scalar (entrance_EF is constant)
+            Default is 1.
+            Electric field in the pupil plane a the entrance of the system.
 
         dir_save_all_planes : default None. 
-                               if not None, directory to save all planes in fits for debugging purposes.
-                               This can generate a lot of fits especially if in a loop, use with caution
+            If not None, directory to save all planes in fits for debugging purposes.
+            This can generate a lot of fits especially if in a loop, use with caution
 
         **kwargs: 
             other parameters can be passed for OpticalSystem objects EF_trough functions
@@ -133,27 +131,25 @@ class OpticalSystem:
 
         Parameters
         ----------
-        entrance_EF:    2D complex array of size [self.dim_overpad_pupil, self.dim_overpad_pupil]
-                        Can also be a float scalar in which case entrance_EF is constant
-                        default is 1.
-                        Electric field in the pupil plane a the entrance of the system.
+        entrance_EF:    2D complex array of size [self.dim_overpad_pupil, self.dim_overpad_pupil], or complex/float scalar (entrance_EF is constant)
+            Default is 1. Electric field in the pupil plane a the entrance of the system.
 
         wavelength : float. Default is self.wavelength_0 the reference wavelength
-                current wavelength in m.
+            Current wavelength in m.
         
-        in_contrast : bool, default True. normalize to 
-                        np.sqrt(self.norm_monochrom[self.wav_vec.tolist().index(wavelength)]))
-                        (see self.measure_normalization)
+        in_contrast : bool, default True. 
+            Normalize to np.sqrt(self.norm_monochrom[self.wav_vec.tolist().index(wavelength)]))
+            (see self.measure_normalization)
 
         center_on_pixel : bool Default False
             If True, the PSF will be centered on a pixel
             If False, the PSF will be centered between 4 pixels
-                This of course assume that no tip-tilt have been introduced in the entrance_EF
-                or during self.EF_through
+            This of course assume that no tip-tilt have been introduced 
+            in the entrance_EFor during self.EF_through
 
         dir_save_all_planes : default None. 
-                               if not None, directory to save all planes in fits for debugging purposes.
-                               This can generate a lot of fits especially if in a loop, use with caution
+            If not None, directory to save all planes in fits for debugging purposes.
+            This can generate a lot of fits especially if in a loop, use with caution
 
         **kwargs: 
             other kw parameters can be passed direclty to self.EF_through function
@@ -161,9 +157,9 @@ class OpticalSystem:
         Returns
         ------
         ef_focal_plane : 2D array of size [self.dimScience, self.dimScience]
-                Electric field in the focal plane.
-                the lambda / D is defined with the entrance pupil diameter, such as:
-                self.wavelength_0 /  (2*self.prad) = self.Science_sampling pixels
+            Electric field in the focal plane.
+            the lambda / D is defined with the entrance pupil diameter, such as:
+            self.wavelength_0 /  (2*self.prad) = self.Science_sampling pixels
 
         """
         if center_on_pixel == True:
@@ -217,43 +213,42 @@ class OpticalSystem:
 
         Parameters
         ----------
-        entrance_EF:   3D complex array of size [nb_wav,self.dim_overpad_pupil, self.dim_overpad_pupil]
+        entrance_EF:   3D complex array of size [nb_wav, self.dim_overpad_pupil, self.dim_overpad_pupil]
                         or 2D complex array of size [self.dim_overpad_pupil, self.dim_overpad_pupil]
-                        Can also be a float scalar in which case entrance_EF is constant
-                        default is 1.
-                        Electric field in the pupil plane a the entrance of the system.
+                        or complex/float scalar (entrance_EF is constant)
+            Default is 1. Electric field in the pupil plane a the entrance of the system.
 
         wavelengths : float or float array of wavelength in m.
-                        Default is all wavelenthg in self.wav_vec
+            Default is all wavelenthg in self.wav_vec
         
         in_contrast : bool, default True. normalize to 
-                            self.norm_polychrom (see self.measure_normalization)
+            self.norm_polychrom (see self.measure_normalization)
 
         center_on_pixel : bool Default False
             If True, the PSF will be centered on a pixel
             If False, the PSF will be centered between 4 pixels
-                This of course assume that no tip-tilt have been introduced in the entrance_EF
-                or during self.EF_through
+            This of course assume that no tip-tilt have been introduced in the entrance_EF
+            or during self.EF_through
 
         dir_save_all_planes : default None. 
-                               if not None, directory to save all planes in fits for debugging purposes.
-                               This can generate a lot of fits especially if in a loop, use with caution
+            If not None, directory to save all planes in fits for debugging purposes.
+            This can generate a lot of fits especially if in a loop, use with caution
 
         noise : boolean, optional
-                If True, add photon noise to the image
+            If True, add photon noise to the image
     
         nb_photons : int, optional
-                Number of photons entering the pupil
+            Number of photons entering the pupil
 
         **kwargs: 
-            other kw parameters can be passed direclty to self.EF_through function
+            Other kw parameters can be passed direclty to self.EF_through function
 
         Returns
         ------
         focal_plane_Intensity : 2D array of size [self.dimScience, self.dimScience]
-                    Intensity in the focal plane. the lambda / D is defined with 
-                    the entrance pupil diameter, such as:
-                    self.wavelength_0 /  (2*self.prad) = self.Science_sampling pixels
+            Intensity in the focal plane. the lambda / D is defined with 
+            the entrance pupil diameter, such as:
+            self.wavelength_0 /  (2*self.prad) = self.Science_sampling pixels
 
         """
 
@@ -398,23 +393,20 @@ class OpticalSystem:
         Parameters
         ----------
         SIMUconfig : dict
-                    parameter of this simualtion (describing the phase)
+            parameter of this simualtion (describing the phase)
         
         up_or_down : string, default, 'up'
-                    'up' or 'do', use to access the right parameters in the parameter file for 
-                        upstream (entrance pupil) or downstream (Lyot plane) aberrations
-
+            'up' or 'do', use to access the right parameters in the parameter file for 
+            upstream (entrance pupil) or downstream (Lyot plane) aberrations
 
         Model_local_dir: string, default None
-                    directory to save things you can measure yourself
-                    and can save to save time
-                    In this case the phase aberrations is saved if Model_local_dir is not None
-
+            directory to save things you can measure yourself and can save to save time
+            In this case the phase aberrations is saved if Model_local_dir is not None
 
         Returns
         ------
         return_phase : 2D array, real of size [self.dim_overpad_pupil, self.dim_overpad_pupil]
-                phase abberation at the reference wavelength
+            phase abberation at the reference wavelength
 
         """
         if Model_local_dir is None:
@@ -471,17 +463,16 @@ class OpticalSystem:
         Parameters
         ----------
         SIMUconfig : dict
-                    parameter of this simualtion (describing the amplitude)
+            Parameter of this simualtion (describing the amplitude)
 
         Model_local_dir: string, default None
-                    directory to save things you can measure yourself
-                    and can save to save time
+            Directory to save things you can measure yourself and can save to save time
 
 
         Returns
         ------
         return_ampl : 2D array, real of size [self.dim_overpad_pupil, self.dim_overpad_pupil]
-                amplitude abberation
+            Amplitude abberation
 
         """
         if not os.path.exists(Model_local_dir):
@@ -594,23 +585,23 @@ class OpticalSystem:
         Parameters
         ----------
         phase_abb : 2D array of size [self.dim_overpad_pupil, self.dim_overpad_pupil]. real
-            phase aberration at reference wavelength self.wavelength_0. if 0, no phase aberration (default)
+            Phase aberration at reference wavelength self.wavelength_0. if 0, no phase aberration (default)
 
         ampl_abb : 2D array of size [self.dim_overpad_pupil, self.dim_overpad_pupil]. real
-             amplitude aberration at reference wavelength self.wavelength_0. if 0, no amplitude aberration (default)
+             Amplitude aberration at reference wavelength self.wavelength_0. if 0, no amplitude aberration (default)
 
         wavelengths : float or list of floats. 
-                    Default is all the wl of the testbed self.wav_vec
-                    wavelengths in m.
+            Default is all the wl of the testbed self.wav_vec
+            wavelengths in m.
 
 
         Returns
         ------
         EF : scalar or numpy 2D array or numpy 3d array
-            Electric field in the pupil plane a the exit of the system
-            1. if no phase / amplitude
-            2D array, of size phase_abb.shape if monochromatic
-            or 3D array of size [self.nb_wav,phase_abb.shape] in case of polychromatic
+            Electric field in the pupil plane a the exit of the system:
+                1. if no phase / amplitude
+                2D array, of size phase_abb.shape if monochromatic
+                or 3D array of size [self.nb_wav,phase_abb.shape] in case of polychromatic
 
         """
 

--- a/Asterix/optics/optical_systems.py
+++ b/Asterix/optics/optical_systems.py
@@ -97,13 +97,10 @@ class OpticalSystem:
                         default is 1.
                     Electric field in the pupil plane a the entrance of the system.
 
-        save_all_planes_to_fits: Bool, default False
-                if True, save all planes to fits for debugging purposes to dir_save_all_planes
-                This can generate a lot of fits especially if in a loop so the code force you
-                to define a repository.
-        dir_save_all_planes : string, default None
-                            directory to save all plane in fits
-                                if save_all_planes_to_fits = True
+        dir_save_all_planes : default None. 
+                               if not None, directory to save all planes in fits for debugging purposes.
+                               This can generate a lot of fits especially if in a loop, use with caution
+
         **kwargs: 
             other parameters can be passed for OpticalSystem objects EF_trough functions
 
@@ -126,7 +123,6 @@ class OpticalSystem:
                    wavelength=None,
                    center_on_pixel=False,
                    in_contrast=True,
-                   save_all_planes_to_fits=False,
                    dir_save_all_planes=None,
                    **kwargs):
         """
@@ -155,13 +151,9 @@ class OpticalSystem:
                 This of course assume that no tip-tilt have been introduced in the entrance_EF
                 or during self.EF_through
 
-        save_all_planes_to_fits: Bool, default False.
-                if True, save all planes to fits for debugging purposes to dir_save_all_planes
-                This can generate a lot of fits especially if in a loop so the code force you
-                to define a repository.
-        
-        dir_save_all_planes : string efault None. 
-                                directory to save all plane in fits if save_all_planes_to_fits = True
+        dir_save_all_planes : default None. 
+                               if not None, directory to save all planes in fits for debugging purposes.
+                               This can generate a lot of fits especially if in a loop, use with caution
 
         **kwargs: 
             other kw parameters can be passed direclty to self.EF_through function
@@ -186,7 +178,6 @@ class OpticalSystem:
 
         exit_EF = self.EF_through(entrance_EF=entrance_EF,
                                   wavelength=wavelength,
-                                  save_all_planes_to_fits=save_all_planes_to_fits,
                                   dir_save_all_planes=dir_save_all_planes,
                                   **kwargs)
 
@@ -202,7 +193,7 @@ class OpticalSystem:
         if in_contrast == True:
             focal_plane_EF /= np.sqrt(self.norm_monochrom[self.wav_vec.tolist().index(wavelength)])
 
-        if save_all_planes_to_fits == True:
+        if dir_save_all_planes is not None:
             who_called_me = self.__class__.__name__
             name_plane = 'EF_FP_after_' + who_called_me + '_obj' + '_wl{}'.format(int(wavelength * 1e9))
             save_plane_in_fits(dir_save_all_planes, name_plane, focal_plane_EF)
@@ -216,7 +207,6 @@ class OpticalSystem:
                              center_on_pixel=False,
                              photon_noise=False,
                              nb_photons=1e30,
-                             save_all_planes_to_fits=False,
                              dir_save_all_planes=None,
                              **kwargs):
         """
@@ -245,13 +235,9 @@ class OpticalSystem:
                 This of course assume that no tip-tilt have been introduced in the entrance_EF
                 or during self.EF_through
 
-        save_all_planes_to_fits: Bool, default False.
-                if True, save all planes to fits for debugging purposes to dir_save_all_planes
-                This can generate a lot of fits especially if in a loop so the code force you
-                to define a repository.
-        dir_save_all_planes : string default None. 
-                                Directory to save all plane
-                                in fits if save_all_planes_to_fits = True
+        dir_save_all_planes : default None. 
+                               if not None, directory to save all planes in fits for debugging purposes.
+                               This can generate a lot of fits especially if in a loop, use with caution
 
         noise : boolean, optional
                 If True, add photon noise to the image
@@ -305,7 +291,6 @@ class OpticalSystem:
                                 wavelength=wav,
                                 in_contrast=False,
                                 center_on_pixel=center_on_pixel,
-                                save_all_planes_to_fits=save_all_planes_to_fits,
                                 dir_save_all_planes=dir_save_all_planes,
                                 **kwargs))**2
 
@@ -325,7 +310,7 @@ class OpticalSystem:
             focal_plane_Intensity = np.random.poisson(
                 focal_plane_Intensity * self.normPupto1 * nb_photons) / (self.normPupto1 * nb_photons)
 
-        if save_all_planes_to_fits == True:
+        if dir_save_all_planes is not None:
             who_called_me = self.__class__.__name__
             name_plane = 'Int_FP_after_' + who_called_me + '_obj'
             save_plane_in_fits(dir_save_all_planes, name_plane, focal_plane_Intensity)

--- a/Asterix/optics/phase_amplitude_functions.py
+++ b/Asterix/optics/phase_amplitude_functions.py
@@ -21,15 +21,15 @@ def roundpupil(dim_pp, prad, no_pixel=False, center_pos='b'):
     prad : float
         Size of the pupil radius (in pixels)
     no_pixel : boolean (defaut false).
-                If true, the pupil is first defined at a very large
-                scale (prad = 10*prad) and then rescale to the given parameter prad.
-                This limits the pixel crenellation in pupil for small pupils
+        If true, the pupil is first defined at a very large
+        scale (prad = 10*prad) and then rescale to the given parameter prad.
+        This limits the pixel crenellation in pupil for small pupils
 
     center_pos : string (optinal defaut 'b')
-                      option for the center. 
-                      'p' center on pixel dim_pp//2
-                      'b' center in between pixels dim_pp//2 -1 and dim_pp//2
-                      for dim_pp odd or even
+        option for the center. 
+            'p' center on pixel dim_pp//2
+            'b' center in between pixels dim_pp//2 -1 and dim_pp//2
+        for dim_pp odd or even
 
     Returns
     ------
@@ -70,11 +70,11 @@ def shift_phase_ramp(dim_pp, shift_x, shift_y):
     Parameters
     ----------
     dim_pp : int
-                Size of the phase ramp (in pixels)
+        Size of the phase ramp (in pixels)
     shift_x : float
-                Shift desired in the x direction (in pixels)
+        Shift desired in the x direction (in pixels)
     shift_y : float
-                Shift desired in the y direction (in pixels)
+        Shift desired in the y direction (in pixels)
 
     Returns
     ------
@@ -158,9 +158,9 @@ def sine_cosine_basis(Nact1D):
     Returns
     ------
     SinCos : 3D array
-                Coefficient to apply to DMs to obtain sine and cosine phases.
-                size :[(Nact1D)^2,Nact1D,Nact1D] if even
-                size :[(Nact1D)^2 -1 ,Nact1D,Nact1D] if odd (to remove piston)
+        Coefficient to apply to DMs to obtain sine and cosine phases.
+        size :[(Nact1D)^2,Nact1D,Nact1D] if even
+        size :[(Nact1D)^2 -1 ,Nact1D,Nact1D] if odd (to remove piston)
     
     """
 

--- a/Asterix/optics/pupil.py
+++ b/Asterix/optics/pupil.py
@@ -178,12 +178,7 @@ class Pupil(OpticalSystem):
         #initialize the max and sum of PSFs for the normalization to contrast
         self.measure_normalization()
 
-    def EF_through(self,
-                   entrance_EF=1.,
-                   wavelength=None,
-                   save_all_planes_to_fits=False,
-                   dir_save_all_planes=None,
-                   **kwargs):
+    def EF_through(self, entrance_EF=1., wavelength=None, dir_save_all_planes=None, **kwargs):
         """
         Propagate the electric field through the pupil
         AUTHOR : Johan Mazoyer
@@ -198,14 +193,9 @@ class Pupil(OpticalSystem):
         wavelength : float. Default is self.wavelength_0 the reference wavelength
                 current wavelength in m.
 
-        save_all_planes_to_fits: Bool, default False.
-                if True, save all planes to fits for debugging purposes to dir_save_all_planes
-                This can generate a lot of fits especially if in a loop so the code force you
-                to define a repository.
-
         dir_save_all_planes : default None. 
-                                directory to save all plane
-                                in fits if save_all_planes_to_fits = True
+                               if not None, directory to save all planes in fits for debugging purposes.
+                               This can generate a lot of fits especially if in a loop, use with caution
 
         Returns
         ------
@@ -214,16 +204,12 @@ class Pupil(OpticalSystem):
 
         """
 
-        if save_all_planes_to_fits == True and dir_save_all_planes == None:
-            raise Exception("save_all_planes_to_fits = True can generate a lot of .fits files" +
-                            "please define a clear directory using dir_save_all_planes kw argument")
-
         # call the OpticalSystem super function to check and format the variable entrance_EF
         entrance_EF = super().EF_through(entrance_EF=entrance_EF)
         if wavelength is None:
             wavelength = self.wavelength_0
 
-        if save_all_planes_to_fits == True:
+        if dir_save_all_planes is not None:
             name_plane = 'EF_PP_before_pupil' + '_wl{}'.format(int(wavelength * 1e9))
             save_plane_in_fits(dir_save_all_planes, name_plane, entrance_EF)
 
@@ -239,7 +225,7 @@ class Pupil(OpticalSystem):
         else:
             raise Exception("pupil dimension are not acceptable")
 
-        if save_all_planes_to_fits == True:
+        if dir_save_all_planes is not None:
             name_plane = 'EF_PP_after_pupil' + '_wl{}'.format(int(wavelength * 1e9))
             save_plane_in_fits(dir_save_all_planes, name_plane, exit_EF)
 

--- a/Asterix/optics/pupil.py
+++ b/Asterix/optics/pupil.py
@@ -185,22 +185,20 @@ class Pupil(OpticalSystem):
 
         Parameters
         ----------
-        entrance_EF:    2D complex array of size [self.dim_overpad_pupil, self.dim_overpad_pupil]
-                        Can also be a float scalar in which case entrance_EF is constant
-                        default is 1.
-                        Electric field in the pupil plane a the entrance of the system.
+        entrance_EF:    2D complex array of size [self.dim_overpad_pupil, self.dim_overpad_pupil] or complex/float scalar (entrance_EF is constant)
+            Default is 1. Electric field in the pupil plane a the entrance of the system.
 
         wavelength : float. Default is self.wavelength_0 the reference wavelength
-                current wavelength in m.
+            Current wavelength in m.
 
         dir_save_all_planes : default None. 
-                               if not None, directory to save all planes in fits for debugging purposes.
-                               This can generate a lot of fits especially if in a loop, use with caution
+            If not None, directory to save all planes in fits for debugging purposes.
+            This can generate a lot of fits especially if in a loop, use with caution
 
         Returns
         ------
         exit_EF : 2D array, of size [self.dim_overpad_pupil, self.dim_overpad_pupil]
-                        Electric field in the pupil plane a the exit of the system
+            Electric field in the pupil plane a the exit of the system
 
         """
 

--- a/Asterix/optics/testbed.py
+++ b/Asterix/optics/testbed.py
@@ -23,21 +23,26 @@ class Testbed(OpticalSystem):
 
     def __init__(self, list_os, list_os_names):
         """
-        This function allows you to concatenate OpticalSystem objects to create a testbed:
-        parameter:
-            list_os:        list of OpticalSystem instances
-                            all the systems must have been defined with
-                            the same modelconfig or it will send an error.
-                            The list order is form the first optics system to the last in the
-                            path of the light (so usually from entrance pupil to Lyot pupil)
+        This function allows you to concatenate OpticalSystem objects to create a testbed
+        
+        AUTHOR : Johan Mazoyer
+        
+        Parameters
+        ----------
+        list_os:    list of OpticalSystem instances
+            all the systems must have been defined with
+            the same modelconfig or it will send an error.
+            The list order is form the first optics system to the last in the
+            path of the light (so usually from entrance pupil to Lyot pupil)
 
-            list_os_names:  list of string of the same size as list_os 
-                            Name of the optical systems. 
-                            Then can then be accessed inside the Testbed object by os_#i = Testbed.list_os_names[i]
+        list_os_names:  list of string of the same size as list_os 
+            Name of the optical systems. 
+            Then can then be accessed inside the Testbed object by os_#i = Testbed.list_os_names[i]
 
         Returns
         ------
-            testbed : an optical system which is the concatenation of all the optical systems
+        testbed : Asterix.optics.testbed.Tesbed
+            an optical system which is the concatenation of all the optical systems
 
         """
         if len(list_os) != len(list_os_names):
@@ -142,21 +147,21 @@ class Testbed(OpticalSystem):
         actuator amplitude. I split theactu_vect and  then for each DM, it uses
         DM.voltage_to_phase (no s)
 
+        AUTHOR : Johan Mazoyer
+
         Parameters
         ----------
         actu_vect : float or 1D array of size testbed.number_act
-                    values of the amplitudes for each actuator and each DM
-        einstein_sum : boolean. default false
-                        Use numpy Einstein sum to sum the pushact[i]*actu_vect[i]
-                        gives the same results as normal sum. Seems ot be faster for unique actuator
-                        but slower for more complex phases
+            values of the amplitudes for each actuator and each DM
+        einstein_sum : boolean. default False
+            Use numpy Einstein sum to sum the pushact[i]*actu_vect[i]
+            gives the same results as normal sum. Seems ot be faster for unique actuator
+            but slower for more complex phases
 
         Returns
         ------
-            3D array of size [testbed.number_DMs, testbed.dim_overpad_pupil,testbed.dim_overpad_pupil]
+        phases: 3D array of size [testbed.number_DMs, testbed.dim_overpad_pupil,testbed.dim_overpad_pupil]
             phase maps for each DMs by order of light path in the same unit as actu_vect * DM_pushact
-
-        AUTHOR : Johan Mazoyer
 
         """
         DMphases = np.zeros((self.number_DMs, self.dim_overpad_pupil, self.dim_overpad_pupil))
@@ -184,17 +189,19 @@ class Testbed(OpticalSystem):
         transform a vector of voltages on the mode of a basis in a  vector of
         voltages of the actuators of the DMs of the system
 
+        AUTHOR : Johan Mazoyer
+
         Parameters
         ----------
         vector_basis_voltage: 1D-array real : 
-                        vector of voltages of size (total(basisDM sizes)) on the mode of the basis for all
-                        DMs by order of the light path
+            vector of voltages of size (total(basisDM sizes)) on the mode of the basis for all
+            DMs by order of the light path
 
         Returns
         ------
         vector_actuator_voltage: 1D-array real : 
-                        vector of base coefficients for all actuators of the DMs by order of the light path
-                        size (total(DM actuators))
+            vector of base coefficients for all actuators of the DMs by order of the light path
+            size (total(DM actuators))
         
         """
 
@@ -228,21 +235,21 @@ class Testbed(OpticalSystem):
 # Some internal functions to properly concatenate the EF_through functions
 def _swap_DMphase_name(DM_EF_through_function, name_var):
     """
-   A function to rename the DMphase parameter to another name (usually DMXXphase)
+    A function to rename the DMphase parameter to another name (usually DMXXphase)
         
     AUTHOR : Johan Mazoyer
 
     Parameters:
     ------
-        DM_EF_through_function : function
-            the function of which we want to change the params
-        name_var : string 
-            the name of the  new name variable
+    DM_EF_through_function : function
+        the function of which we want to change the params
+    name_var : string 
+        the name of the  new name variable
 
     Returns
     ------
-        the_new_function: function
-            with name_var as a param
+    the_new_function: function
+        with name_var as a param
 
     """
 
@@ -266,15 +273,15 @@ def _concat_fun(outer_EF_through_fun, inner_EF_through_fun):
 
     Parameters:
     ------
-        outer_fun: function
-                x -> outer_fun(x)
-        inner_fun: function 
-                x -> inner_fun(x)
+    outer_fun: function
+        x -> outer_fun(x)
+    inner_fun: function 
+        x -> inner_fun(x)
 
     Returns
-        ------
-        the concatenated function: function
-                x -> outer_fun(inner_fun(x))
+    ------
+    the concatenated function: function
+        x -> outer_fun(inner_fun(x))
 
     """
 
@@ -297,13 +304,13 @@ def _clean_EF_through(testbed_EF_through, known_keywords):
 
     Parameters:
     ------
-         testbed_EF_through: function
-         known_keywords: list of strings of known keywords
+    testbed_EF_through: function
+        known_keywords: list of strings of known keywords
 
     Returns
     ------
-        cleaned_testbed_EF_through: function
-            a function where only known keywords are allowed
+    cleaned_testbed_EF_through: function
+        a function where only known keywords are allowed
         
     """
 
@@ -337,15 +344,15 @@ def _control_testbed_with_voltages(testbed: Testbed, testbed_EF_through):
 
     Parameters:
     ------
-        DM_EF_through_function : function
-                the function of which we want to change the params
-        name_var : string 
-                the name of the  new name variable
+    DM_EF_through_function : function
+        the function of which we want to change the params
+    name_var : string 
+        the name of the  new name variable
 
     Returns
     ------
-        the_new_function: function
-                with name_var as a param
+    the_new_function: function
+        with name_var as a param
 
     """
 

--- a/Asterix/tests/test_utils.py
+++ b/Asterix/tests/test_utils.py
@@ -15,9 +15,11 @@ def write_test_results_to_file(results_in, fname):
     fname : string
         Full path and filename, including ".txt" at the end, for the file to be written out.
     """
-    results = {'nb_total_iter': results_in['nb_total_iter'],
-               'Nb_iter_per_mat': results_in['Nb_iter_per_mat'],
-               'MeanDHContrast': results_in['MeanDHContrast']}
+    results = {
+        'nb_total_iter': results_in['nb_total_iter'],
+        'Nb_iter_per_mat': results_in['Nb_iter_per_mat'],
+        'MeanDHContrast': results_in['MeanDHContrast']
+    }
 
     with open(fname, 'w') as convert_file:
         convert_file.write(json.dumps(results))

--- a/Asterix/utils/hci_metrics.py
+++ b/Asterix/utils/hci_metrics.py
@@ -42,49 +42,49 @@ def plot_contrast_curves(reduced_data,
     
     Parameters
     ----------
-        reduced_data: array [dim, dim] or [nb_iter, dim, dim]
-            array containing the reduced data. Assume to be already in contrast unit (divided by max of PSF)
-            if the array is of dimension 3, the first dimension is assumed to be the number of iter and a 
-            contrast curve will be plotted for each
-        
-        xcen: float, default None (reduced_data.shape[0]/2 - 1/2)
-            pixel, position x of the star
-        
-        ycen: float, default None (reduced_data.shape[1]/2 - 1/2)
-            pixel, position y of the star
-        
-        delta_raddii: default 3
-            pixel, width of the small concentric rings
-        
-        type_of_contrast: string default 'mean'
-            can be  'mean' : mean contrast on the rings 
-                    'stddev_1sig' : 1 sigma standard deviation on the rings
-                    'stddev_5sig' : 5 sigma standard deviation on the rings
+    reduced_data: array [dim, dim] or [nb_iter, dim, dim]
+        array containing the reduced data. Assume to be already in contrast unit (divided by max of PSF)
+        if the array is of dimension 3, the first dimension is assumed to be the number of iter and a 
+        contrast curve will be plotted for each
     
-        numberofpix_per_loD: float, defaut None
-            resolution of the focal plane in # of pixel per lambda/D (useful for testbed)
-            If set the absciss unit will be in lambda/D 
+    xcen: float, default None (reduced_data.shape[0]/2 - 1/2)
+        pixel, position x of the star
+    
+    ycen: float, default None (reduced_data.shape[1]/2 - 1/2)
+        pixel, position y of the star
+    
+    delta_raddii: default 3
+        pixel, width of the small concentric rings
+    
+    type_of_contrast: string default 'mean'
+        can be  'mean' : mean contrast on the rings 
+                'stddev_1sig' : 1 sigma standard deviation on the rings
+                'stddev_5sig' : 5 sigma standard deviation on the rings
 
-        numberofmas_per_pix: float, defaut None
-            resolution of the focal plane in # of mas per pixel  (useful for real instruments)
-            If set the absciss unit will be in mas
-            
-            If none of these keywords are set, the absciss unit will be in pixels
-            If both are set, it will raise an error
+    numberofpix_per_loD: float, defaut None
+        resolution of the focal plane in # of pixel per lambda/D (useful for testbed)
+        If set the absciss unit will be in lambda/D 
+
+    numberofmas_per_pix: float, defaut None
+        resolution of the focal plane in # of mas per pixel  (useful for real instruments)
+        If set the absciss unit will be in mas
         
-        mask_DH : 2d binary Array  default is all focal plane
-            mask delimiting the DH
-        
-        path: string, default ''
-            path where to save the pdf plot file
-        
-        filename: string, default ''
-            base of the file name to save the pdf plot file
-        
-        legend_labels: string array of the same number of images in the first cube, default None
-            Name of the legend labels,
-            If None and if the array is of dimension 2, no legend
-            If None and if the array is of dimension 3, we assume these are iterations
+        If none of these keywords are set, the absciss unit will be in pixels
+        If both are set, it will raise an error
+    
+    mask_DH : 2d binary Array  default is all focal plane
+        mask delimiting the DH
+    
+    path: string, default ''
+        path where to save the pdf plot file
+    
+    filename: string, default ''
+        base of the file name to save the pdf plot file
+    
+    legend_labels: string array of the same number of images in the first cube, default None
+        Name of the legend labels,
+        If None and if the array is of dimension 2, no legend
+        If None and if the array is of dimension 3, we assume these are iterations
 
     """
 
@@ -207,33 +207,31 @@ def contrast_curves(reduced_data,
     16/03/2022
     
     Parameters
-    ----------
-        
-        reduced_data: array
-            [dim dim] array containing the reduced data
-        
-        xcen: float, default None (reduced_data.shape[0]/2 -1/2) 
-            pixel, position x of the star
-        
-        ycen: float, default None (reduced_data.shape[1]/2 -1/2) 
-            pixel, position y of the star
-        
-        delta_raddii: default 3
-            pixel, width of the small concentric rings
-        
-        type_of_contrast: string default 'mean'
-            can be  'mean' : mean contrast on the rings 
-                    'stddev_1sig' : 1 sigma standard deviation on the rings
-                    'stddev_5sig' : 5 sigma standard deviation on the rings
-        
-        mask_DH : 2d binary Array  default is all focal plane
-            mask delimiting the DH
-
+    ---------- 
+    reduced_data: array
+        [dim dim] array containing the reduced data
+    
+    xcen: float, default None (reduced_data.shape[0]/2 -1/2) 
+        pixel, position x of the star
+    
+    ycen: float, default None (reduced_data.shape[1]/2 -1/2) 
+        pixel, position y of the star
+    
+    delta_raddii: default 3
+        pixel, width of the small concentric rings
+    
+    type_of_contrast: string default 'mean'
+        can be  'mean' : mean contrast on the rings 
+                'stddev_1sig' : 1 sigma standard deviation on the rings
+                'stddev_5sig' : 5 sigma standard deviation on the rings
+    
+    mask_DH : 2d binary Array  default is all focal plane
+        mask delimiting the DH
 
     Returns
     ------
-
-        1d array with the contrast on concentric rings measure with different metrics
+    contrast_curve: 1d numpy array
+        array with the contrast on concentric rings measure with different metrics.
         Values outside of the mask are nan
 
      """

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -39,8 +39,8 @@ def save_plane_in_fits(dir_save_fits, name_plane, image):
     current_time_str = datetime.datetime.today().strftime('%H_%M_%S_%f')[:-3]
     name_fits = current_time_str + '_' + name_plane
 
-    if dir_save_fits is None:
-        raise Exception("Please define a directoy for dir_save_fits")
+    if os.path.exists(dir_save_fits) is False:
+        raise Exception("Please define an existing directory for dir_save_fits keyword or None")
 
     # sometime the image can be a single float (0 for phase or 1 for EF).
     if isinstance(image, (int, float, np.float)):

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -39,6 +39,9 @@ def save_plane_in_fits(dir_save_fits, name_plane, image):
     current_time_str = datetime.datetime.today().strftime('%H_%M_%S_%f')[:-3]
     name_fits = current_time_str + '_' + name_plane
 
+    if dir_save_fits is None:
+        raise Exception("Please define a directoy for dir_save_fits")
+
     # sometime the image can be a single float (0 for phase or 1 for EF).
     if isinstance(image, (int, float, np.float)):
         print(name_plane + " is a constant, not save in fits")

--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -162,44 +162,44 @@ def correction_loop_1matrix(testbed: Testbed,
     Parameters
     ----------
     testbed: OpticalSystem.Testbed
-            object which describes your testbed
+        object which describes your testbed
     estimator: Estimator 
-            This contains all information about the estimation
+        This contains all information about the estimation
     corrector: Corrector. 
-            This contains all information about the correction
+        This contains all information about the correction
     mask_dh: 2d numpy array
-            binary array of size [dimScience, dimScience] : dark hole mask
+        binary array of size [dimScience, dimScience] : dark hole mask
     Nbiter_corr: int or list of int
-            number of iterations in the loop
+        number of iterations in the loop
     CorrectionLoopResult: dict
-            Dictionary containing the result of the previous loop.
-            This will be updated with the result of the current loop.
+        Dictionary containing the result of the previous loop.
+        This will be updated with the result of the current loop.
     gain:  float between 0 and 1, default 0.1
-            Control gain of the loop in EFC mode.
+        Control gain of the loop in EFC mode.
     Nbmode_corr: int or list of int
-            Of same size as Nbiter_corr; SVD modes for each iteration.
+        Of same size as Nbiter_corr; SVD modes for each iteration.
     Linesearch: bool, default False. 
-            If True, the function correction_loop_1matrix()
-            will call itself at each iteration with Search_best_Mode=True to find
-            the best SVD inversion mode among a few Linesearch modes.
+        If True, the function correction_loop_1matrix()
+        will call itself at each iteration with Search_best_Mode=True to find
+        the best SVD inversion mode among a few Linesearch modes.
     Search_best_Mode: bool, default False. 
-            If true, the algorithm does not return the
-            loop information, just the best mode and best contrast.
-            This mode is used in Linesearch mode.
-            Be careful when using this parameter, it can create an infinite loop.
+        If true, the algorithm does not return the
+        loop information, just the best mode and best contrast.
+        This mode is used in Linesearch mode.
+        Be careful when using this parameter, it can create an infinite loop.
     input_wavefront: float or 2d complex array or 3d complex array
-            Initial wavefront at the beginning of this loop.
-            Electrical Field which can be a:
-                float=1 if no phase/amplitude aberrations present (default)
-                2D complex array, of size phase_abb.shape if monochromatic
-                or 3D complex array of size [self.nb_wav,phase_abb.shape] if polychromatic
+        Initial wavefront at the beginning of this loop.
+        Electrical Field which can be a:
+            float=1 if no phase/amplitude aberrations present (default)
+            2D complex array, of size phase_abb.shape if monochromatic
+            or 3D complex array of size [self.nb_wav,phase_abb.shape] if polychromatic
     initial_DM_voltage: float or 1D array
-            Initial DM voltages at the beginning of this loop. The Matrix is measured using this initial DM voltages.
-            Can be:
-                float 0 if flat DMs (default)
-                or 1D array of size testbed.number_act
+        Initial DM voltages at the beginning of this loop. The Matrix is measured using this initial DM voltages.
+        Can be:
+            float 0 if flat DMs (default)
+            or 1D array of size testbed.number_act
     silence: Boolean, default False
-            If False, print and plot results as the loop runs.
+        If False, print and plot results as the loop runs.
 
     Returns
     ------

--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -251,16 +251,7 @@ def correction_loop_1matrix(testbed: Testbed,
 
     initialFP = testbed.todetector_intensity(entrance_EF=input_wavefront,
                                              voltage_vector=initial_DM_voltage,
-                                             save_all_planes_to_fits=False,
-                                             dir_save_all_planes='/Users/jmazoyer/Desktop/test/',
                                              **kwargs)
-
-    estim_init = estimator.estimate(testbed,
-                                    voltage_vector=initial_DM_voltage,
-                                    entrance_EF=input_wavefront,
-                                    wavelength=testbed.wavelength_0,
-                                    **kwargs)
-
     initialFP_contrast = np.mean(initialFP[np.where(mask_dh != 0)])
 
     thisloop_voltages_DMs = list()
@@ -271,7 +262,6 @@ def correction_loop_1matrix(testbed: Testbed,
 
     thisloop_voltages_DMs.append(initial_DM_voltage)
     thisloop_FP_Intensities.append(initialFP)
-    thisloop_EF_estim.append(estim_init)
     thisloop_MeanDHContrast.append(initialFP_contrast)
 
     if not silence:
@@ -368,11 +358,7 @@ def correction_loop_1matrix(testbed: Testbed,
             new_voltage = thisloop_voltages_DMs[-1] + gain * solution
 
         thisloop_FP_Intensities.append(
-            testbed.todetector_intensity(entrance_EF=input_wavefront,
-                                         voltage_vector=new_voltage,
-                                         save_all_planes_to_fits=False,
-                                         dir_save_all_planes='/Users/jmazoyer/Desktop/test_roundpup/',
-                                         **kwargs))
+            testbed.todetector_intensity(entrance_EF=input_wavefront, voltage_vector=new_voltage, **kwargs))
         thisloop_EF_estim.append(resultatestimation)
         thisloop_MeanDHContrast.append(np.mean(thisloop_FP_Intensities[-1][np.where(mask_dh != 0)]))
 

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -232,7 +232,6 @@ class Corrector:
                                                      initial_DM_voltage=initial_DM_voltage,
                                                      input_wavefront=input_wavefront,
                                                      MatrixType=self.MatrixType,
-                                                     save_all_planes_to_fits=False,
                                                      dir_save_all_planes=None)
 
             self.Gmatrix = wfc.crop_interaction_matrix_to_dh(interMat, self.MaskEstim)

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -58,25 +58,25 @@ class Corrector:
         Parameters
         ----------
         Correctionconfig : dict
-                general correction parameters
+            general correction parameters
 
         testbed :  OpticalSystem.Testbed
-                Testbed object which describe your testbed
+            Testbed object which describe your testbed
 
         MaskDH: 2d numpy array
-                binary array of size [dimEstim, dimEstim] : dark hole mask
+            binary array of size [dimEstim, dimEstim] : dark hole mask
 
         estimator: Estimator
-                an estimator object. This contains all information about the estimation
+            an estimator object. This contains all information about the estimation
 
         matrix_dir: path default: None
-                save all the difficult to measure files here
+            save all the difficult to measure files here
 
         save_for_bench: bool default: false
-                should we save for the real testbed in realtestbed_dir
+            should we save for the real testbed in realtestbed_dir
 
         realtestbed_dir: path 
-                save all the files the real testbed need to run your code
+            save all the files the real testbed need to run your code
 
         """
         if not os.path.exists(matrix_dir):
@@ -204,13 +204,13 @@ class Corrector:
         ----------
        
         testbed :  OpticalSystem.Testbed
-                Testbed object which describe your testbed
+            Testbed object which describe your testbed
 
         estimator: Estimator
-                an estimator object. This contains all information about the estimation
+            an estimator object. This contains all information about the estimation
 
         initial_DM_voltage : float or 1d numpy array, default 0.
-                initial DM voltages to measure the Matrix
+            initial DM voltages to measure the Matrix
 
         input_wavefront : float or 2d numpy array or 3d numpy array, default 1.
             initial wavefront to measure the Matrix
@@ -256,22 +256,22 @@ class Corrector:
         Parameters
         ----------
         testbed :  OpticalSystem.Testbed
-                Testbed object which describe your testbed
+            Testbed object which describe your testbed
 
         estimate: 2D complex array 
-                    Array of size of sixe [dimEstim, dimEstim]. 
-                    This is the result of Estimator.estimate, from which this function 
-                    send a command to the DM
+            Array of size of sixe [dimEstim, dimEstim]. 
+            This is the result of Estimator.estimate, from which this function 
+            send a command to the DM
         
         mode: int, defaut 1
-                Use in EFC, EM, and Steepest, this is the mode we use in the SVD inversion
-                if the mode is the same than the previous iteration, we store the inverted 
-                matrix to avoid inverted it again
+            Use in EFC, EM, and Steepest, this is the mode we use in the SVD inversion
+            if the mode is the same than the previous iteration, we store the inverted 
+            matrix to avoid inverted it again
         
         
         ActualCurrentContrast: float defaut 1. 
-                Use in StrokeMin to find a target contrast
-                Contrast at the current iteration of the loop 
+            Use in StrokeMin to find a target contrast
+            Contrast at the current iteration of the loop 
 
         
         Return

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -233,7 +233,7 @@ class Corrector:
                                                      input_wavefront=input_wavefront,
                                                      MatrixType=self.MatrixType,
                                                      save_all_planes_to_fits=False,
-                                                     dir_save_all_planes="/Users/jmazoyer/Desktop/g0_all/")
+                                                     dir_save_all_planes=None)
 
             self.Gmatrix = wfc.crop_interaction_matrix_to_dh(interMat, self.MaskEstim)
 

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -250,8 +250,7 @@ class Estimator:
 
             resultatestimation = testbed.todetector(entrance_EF=entrance_EF,
                                                     voltage_vector=voltage_vector,
-                                                    wavelength=wavelength,
-                                                    **kwargs)
+                                                    wavelength=wavelength)
 
             return resizing(resultatestimation, self.dimEstim)
 
@@ -262,10 +261,9 @@ class Estimator:
                                                     self.dimEstim,
                                                     self.amplitudePW,
                                                     voltage_vector=voltage_vector,
-                                                    wavelength=wavelength,
-                                                    **kwargs)
+                                                    wavelength=wavelength)
 
-            return wfs.calculate_pw_estimate(Difference, self.PWMatrix)
+            return wfs.calculate_pw_estimate(Difference, self.PWMatrix, **kwargs)
 
         elif self.technique == 'coffee':
             return np.zeros((self.dimEstim, self.dimEstim))

--- a/Asterix/wfsc/maskDH.py
+++ b/Asterix/wfsc/maskDH.py
@@ -58,8 +58,8 @@ class MaskDH:
         FP_sampling: float
             resolution of focal plane pixel  per lambda / D
         dir_save_all_planes : default None. 
-                               if not None, directory to save all planes in fits for debugging purposes.
-                               This can generate a lot of fits especially if in a loop, use with caution
+            If not None, directory to save all planes in fits for debugging purposes.
+            This can generate a lot of fits especially if in a loop, use with caution
 
         Returns
         ------

--- a/Asterix/wfsc/maskDH.py
+++ b/Asterix/wfsc/maskDH.py
@@ -45,12 +45,7 @@ class MaskDH:
 
         self.string_mask = self.tostring()
 
-    def creatingMaskDH(self,
-                       dimFP,
-                       FP_sampling,
-                       save_all_planes_to_fits=False,
-                       dir_save_all_planes=None,
-                       **kwargs):
+    def creatingMaskDH(self, dimFP, FP_sampling, dir_save_all_planes=None, **kwargs):
         """
         Create a binary mask.
 
@@ -62,13 +57,9 @@ class MaskDH:
             size of the output FP mask
         FP_sampling: float
             resolution of focal plane pixel  per lambda / D
-        save_all_planes_to_fits: Bool, default False.
-            if True, save all planes to fits for debugging purposes to dir_save_all_planes
-            This can generate a lot of fits especially if in a loop so the code force you
-            to define a repository.
         dir_save_all_planes : default None. 
-                            directory to save all plane in
-                            fits if save_all_planes_to_fits = True
+                               if not None, directory to save all planes in fits for debugging purposes.
+                               This can generate a lot of fits especially if in a loop, use with caution
 
         Returns
         ------
@@ -116,7 +107,7 @@ class MaskDH:
                     maskDH[yy - xx * np.tan(self.circ_angle * np.pi / 180) < 0] = 0
                     maskDH[yy + xx * np.tan(self.circ_angle * np.pi / 180) < 0] = 0
 
-        if save_all_planes_to_fits == True:
+        if dir_save_all_planes is not None:
             name_plane = 'DH_mask'
             save_plane_in_fits(dir_save_all_planes, name_plane, maskDH)
 

--- a/Asterix/wfsc/maskDH.py
+++ b/Asterix/wfsc/maskDH.py
@@ -2,6 +2,7 @@
 # pylint: disable=trailing-whitespace
 
 import numpy as np
+from Asterix.utils import save_plane_in_fits
 
 
 class MaskDH:
@@ -44,7 +45,12 @@ class MaskDH:
 
         self.string_mask = self.tostring()
 
-    def creatingMaskDH(self, dimFP, FP_sampling):
+    def creatingMaskDH(self,
+                       dimFP,
+                       FP_sampling,
+                       save_all_planes_to_fits=False,
+                       dir_save_all_planes=None,
+                       **kwargs):
         """
         Create a binary mask.
 
@@ -56,6 +62,13 @@ class MaskDH:
             size of the output FP mask
         FP_sampling: float
             resolution of focal plane pixel  per lambda / D
+        save_all_planes_to_fits: Bool, default False.
+            if True, save all planes to fits for debugging purposes to dir_save_all_planes
+            This can generate a lot of fits especially if in a loop so the code force you
+            to define a repository.
+        dir_save_all_planes : default None. 
+                            directory to save all plane in
+                            fits if save_all_planes_to_fits = True
 
         Returns
         ------
@@ -102,6 +115,11 @@ class MaskDH:
                 if self.circ_angle != 0:
                     maskDH[yy - xx * np.tan(self.circ_angle * np.pi / 180) < 0] = 0
                     maskDH[yy + xx * np.tan(self.circ_angle * np.pi / 180) < 0] = 0
+
+        if save_all_planes_to_fits == True:
+            name_plane = 'DH_mask'
+            save_plane_in_fits(dir_save_all_planes, name_plane, maskDH)
+
         return maskDH
 
     def tostring(self):

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -57,10 +57,10 @@ def create_interaction_matrix(testbed: Testbed,
         save all the matrices here
     
     MatrixType: string
-            'smallphase' (when applying modes on the DMs we, do a small phase assumption : exp(i phi) = 1+ i.phi) 
-            or 'perfect' (we keep exp(i phi)).
-            in both case, if the DMs are not initially flat (non zero initial_DM_voltage), 
-                    we do not make the small phase assumption for initial DM phase
+        'smallphase' (when applying modes on the DMs we, do a small phase assumption : exp(i phi) = 1+ i.phi) 
+        or 'perfect' (we keep exp(i phi)).
+        in both case, if the DMs are not initially flat (non zero initial_DM_voltage), 
+        we do not make the small phase assumption for initial DM phase
 
     input_wavefront: 1D-array real
         initial DM voltage for all DMs
@@ -69,11 +69,11 @@ def create_interaction_matrix(testbed: Testbed,
         input wavefront in pupil plane
     
     dir_save_all_planes : default None. 
-                               if not None, directory to save all planes in fits for debugging purposes.
-                               This can generate a lot of fits especially if in a loop, use with caution
+        If not None, directory to save all planes in fits for debugging purposes.
+        This can generate a lot of fits especially if in a loop, use with caution
     
     visu : bool default false
-            if true show the focal plane intensity in 2D for each mode
+        if true show the focal plane intensity in 2D for each mode
 
     Returns
     ------
@@ -387,7 +387,8 @@ def crop_interaction_matrix_to_dh(FullInteractionMatrix: np.ndarray, mask: np.nd
     ----------
     FullInteractionMatrix: Interaction matrix over the full focal plane
 
-    mask : a binary mask to delimitate the DH
+    mask : 2D numpy array
+        a binary mask to delimitate the DH
 
     Returns 
     ------
@@ -419,8 +420,8 @@ def calc_efc_solution(mask, Result_Estimate, inversed_jacobian, testbed: Testbed
 
     Parameters
     ----------
-    mask:               2D Binary mask 
-        corresponding to the dark hole region
+    mask:   2D Binary mask 
+        dark hole region
 
     Result_Estimate:    2D array 
         can be complex, focal plane electric field

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -23,7 +23,6 @@ def create_interaction_matrix(testbed: Testbed,
                               initial_DM_voltage=0.,
                               input_wavefront=1.,
                               MatrixType='',
-                              save_all_planes_to_fits=False,
                               dir_save_all_planes=None,
                               visu=False):
     """
@@ -69,14 +68,9 @@ def create_interaction_matrix(testbed: Testbed,
     input_wavefront: 2D-array complex
         input wavefront in pupil plane
     
-    save_all_planes_to_fits: Bool, default False.
-            if True, save all planes to fits for debugging purposes to dir_save_all_planes
-            This can generate a lot of fits especially if in a loop so the code force you
-            to define a repository.
-
-    dir_save_all_planes : path, default None. 
-                            directory to save all plane
-                            in fits if save_all_planes_to_fits = True
+    dir_save_all_planes : default None. 
+                               if not None, directory to save all planes in fits for debugging purposes.
+                               This can generate a lot of fits especially if in a loop, use with caution
     
     visu : bool default false
             if true show the focal plane intensity in 2D for each mode
@@ -167,7 +161,6 @@ def create_interaction_matrix(testbed: Testbed,
             G0 = resizing(
                 testbed.todetector(entrance_EF=input_wavefront,
                                    voltage_vector=initial_DM_voltage,
-                                   save_all_planes_to_fits=save_all_planes_to_fits,
                                    dir_save_all_planes=dir_save_all_planes), dimEstim)
 
             if (initial_DM_voltage == 0.).all():
@@ -190,7 +183,7 @@ def create_interaction_matrix(testbed: Testbed,
                 for i in range(DM.basis_size):
                     phasesBasis[i] = DM.voltage_to_phase(DM.basis[i]) * amplitudeEFC
 
-            if save_all_planes_to_fits == True:
+            if dir_save_all_planes is not None:
                 # save the basis phase to check what is happening
                 name_plane = DM_name + '_' + DM.basis_type + '_basis_Phase'
                 save_plane_in_fits(dir_save_all_planes, name_plane, phasesBasis)
@@ -213,7 +206,7 @@ def create_interaction_matrix(testbed: Testbed,
             for osname in OpticSysNameBefore:
                 OpticSysbefore = vars(testbed)[osname]  # type: OpticalSystem
 
-                if save_all_planes_to_fits == True:
+                if dir_save_all_planes is not None:
                     # save PP plane before this subsystem
                     name_plane = 'EF_PP_before_' + osname + '_wl{}'.format(int(wavelength * 1e9))
                     save_plane_in_fits(dir_save_all_planes, name_plane, wavefrontupstream)
@@ -227,7 +220,7 @@ def create_interaction_matrix(testbed: Testbed,
                         wavefrontupstream = OpticSysbefore.prop_pup_to_DM_and_back(
                             wavefrontupstream, OpticSysbefore.phase_init, wavelength)
 
-                    if save_all_planes_to_fits == True:
+                    if dir_save_all_planes is not None:
                         # save phase on this DM
                         name_plane = 'Phase_init_on_' + osname + '_wl{}'.format(int(wavelength * 1e9))
                         save_plane_in_fits(dir_save_all_planes, name_plane, OpticSysbefore.phase_init)
@@ -235,7 +228,7 @@ def create_interaction_matrix(testbed: Testbed,
                 else:
                     wavefrontupstream = OpticSysbefore.EF_through(entrance_EF=wavefrontupstream)
 
-                if save_all_planes_to_fits == True:
+                if dir_save_all_planes is not None:
                     # save PP plane after this subsystem
                     name_plane = 'EF_PP_after_' + osname + '_wl{}'.format(int(wavelength * 1e9))
                     save_plane_in_fits(dir_save_all_planes, name_plane, wavefrontupstream)
@@ -267,7 +260,7 @@ def create_interaction_matrix(testbed: Testbed,
                         wavefront = wavefrontupstream * DM.EF_from_phase_and_ampl(phase_abb=phasesBasis[i] +
                                                                                   DM.phase_init)
 
-                        if save_all_planes_to_fits == True:
+                        if dir_save_all_planes is not None:
                             name_plane = 'Phase_on_' + DM_name + '_wl{}'.format(int(wavelength * 1e9))
                             save_plane_in_fits(dir_save_all_planes, name_plane, OpticSysbefore.phase_init)
 
@@ -294,7 +287,7 @@ def create_interaction_matrix(testbed: Testbed,
                                 DM.EF_from_phase_and_ampl(phase_abb=DM.phase_init), DM.wavelength_0,
                                 -DM.z_position, DM.diam_pup_in_m / 2, DM.prad), DM.dim_overpad_pupil)
 
-                if save_all_planes_to_fits == True:
+                if dir_save_all_planes is not None:
                     name_plane = 'EF_PP_after_' + DM_name + '_wl{}'.format(int(wavelength * 1e9))
                     save_plane_in_fits(dir_save_all_planes, name_plane, wavefront)
                 # and finally we go through the subsystems after the DMs we want to actuate
@@ -313,14 +306,14 @@ def create_interaction_matrix(testbed: Testbed,
                                 wavefront = OpticSysAfter.prop_pup_to_DM_and_back(
                                     wavefront, OpticSysAfter.phase_init, wavelength)
 
-                            if save_all_planes_to_fits == True:
+                            if dir_save_all_planes is not None:
                                 name_plane = 'Phase_init_on_' + osname + '_wl{}'.format(int(wavelength * 1e9))
                                 save_plane_in_fits(dir_save_all_planes, name_plane, OpticSysAfter.phase_init)
 
                         else:
                             wavefront = OpticSysAfter.EF_through(entrance_EF=wavefront)
 
-                        if save_all_planes_to_fits == True:
+                        if dir_save_all_planes is not None:
                             name_plane = 'EF_PP_after_' + osname + '_wl{}'.format(int(wavelength * 1e9))
                             save_plane_in_fits(dir_save_all_planes, name_plane, wavefront)
                     else:
@@ -337,7 +330,7 @@ def create_interaction_matrix(testbed: Testbed,
                             OpticSysAfter.todetector(entrance_EF=wavefront, in_contrast=False) /
                             normalisation_testbed_EF_contrast, dimEstim)
 
-                        if save_all_planes_to_fits == True:
+                        if dir_save_all_planes is not None:
                             name_plane = 'FPAfterTestbed_' + osname + '_wl{}'.format(int(wavelength * 1e9))
                             save_plane_in_fits(dir_save_all_planes, name_plane, Gvector)
 
@@ -347,7 +340,7 @@ def create_interaction_matrix(testbed: Testbed,
                 # to be investigated, in simulation and on the testbed
                 Gvector = Gvector - G0
 
-                if save_all_planes_to_fits == True:
+                if dir_save_all_planes is not None:
                     name_plane = 'Gvector_in_matrix_' + osname + '_wl{}'.format(int(wavelength * 1e9))
                     save_plane_in_fits(dir_save_all_planes, name_plane, Gvector)
 

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -85,11 +85,7 @@ def create_pw_matrix(testbed: Testbed, amplitude, posprobes, dimEstim, cutsvd, w
     return [PWMatrix, SVD]
 
 
-def calculate_pw_estimate(Difference,
-                          Vectorprobes,
-                          save_all_planes_to_fits=False,
-                          dir_save_all_planes=None,
-                          **kwargs):
+def calculate_pw_estimate(Difference, Vectorprobes, dir_save_all_planes=None, **kwargs):
     """
     Calculate the focal plane electric field from the probe image
     differences and the modeled probe matrix.
@@ -104,15 +100,10 @@ def calculate_pw_estimate(Difference,
     Vectorprobes: 2D array
             model probe matrix for the same probe as for difference
 
-    save_all_planes_to_fits: Bool, default False.
-            if True, save all planes to fits for debugging purposes to dir_save_all_planes
-            This can generate a lot of fits especially if in a loop so the code force you
-            to define a repository.
-    
     dir_save_all_planes : default None. 
-                            directory to save all plane in
-                            fits if save_all_planes_to_fits = True
-
+                               if not None, directory to save all planes in fits for debugging purposes.
+                               This can generate a lot of fits especially if in a loop, use with caution
+                               
     Returns
     ------
     Difference: 3D array
@@ -134,7 +125,7 @@ def calculate_pw_estimate(Difference,
 
             l = l + 1
 
-    if save_all_planes_to_fits == True:
+    if dir_save_all_planes is not None:
         name_plane = 'PW_Estimate'
         save_plane_in_fits(dir_save_all_planes, name_plane, Resultat / 4.)
 

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -95,20 +95,20 @@ def calculate_pw_estimate(Difference, Vectorprobes, dir_save_all_planes=None, **
     Parameters
     ----------
     Difference: 3D array
-            cube with image difference for each probes
+        cube with image difference for each probes
 
     Vectorprobes: 2D array
-            model probe matrix for the same probe as for difference
+        model probe matrix for the same probe as for difference
 
     dir_save_all_planes : default None. 
-                               if not None, directory to save all planes in fits for debugging purposes.
-                               This can generate a lot of fits especially if in a loop, use with caution
+        If not None, directory to save all planes in fits for debugging purposes.
+        This can generate a lot of fits especially if in a loop, use with caution
                                
     Returns
     ------
     Difference: 3D array
-            cube with image difference for each probes.
-            Used for pair-wise probing
+        cube with image difference for each probes.
+        Used for pair-wise probing
 
     """
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -12,9 +12,9 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('../..'))
 sys.path.append('/Users/jmazoyer/GitProjects/my_projects/Asterix/Asterix/')
-
 
 # -- Project information -----------------------------------------------------
 
@@ -27,14 +27,16 @@ author = 'Johan Mazoyer, Iva Laginja, Axel Potier, Raphaël Galicher'
 # release = 'v2.1' # change version 22/02/22
 # release = 'v2.2' # change version 15/03/22
 # release = 'v2.3' # change version 02/09/22
-release = 'v2.4' # change version 24/09/22
+release = 'v2.4'  # change version 24/09/22
 
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.coverage', 'sphinx.ext.napoleon', "sphinx.ext.graphviz", "pyan.sphinx"]
+extensions = [
+    'sphinx.ext.autodoc', 'sphinx.ext.coverage', 'sphinx.ext.napoleon', "sphinx.ext.graphviz", "pyan.sphinx"
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -53,7 +55,6 @@ pygments_style = 'sphinx'
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -65,7 +66,6 @@ html_theme = 'alabaster'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
-
 
 # add graphviz options
 graphviz_output_format = "svg"

--- a/source/correction.rst
+++ b/source/correction.rst
@@ -25,7 +25,9 @@ and measure the string to save matrices.
     # testbed is previously defined
 
     Correctionconfig = config["Correctionconfig"]
-    mask_dh = MaskDH(Correctionconfig)
+    mask_dh = MaskDH(Correctionconfig) # read the configuration
+    science_mask_dh = mask_dh.creatingMaskDH(testbed.dimScience, testbed.Science_sampling, **kwargs) # create a mask at a given size and resolution
+
 
                                             
 Several shape are possible for the DH using the parameter ``DH_shape``:
@@ -38,6 +40,8 @@ Several shape are possible for the DH using the parameter ``DH_shape``:
     - ``DH_side`` : can be set to "top", "bottom", "left", "right" and "full" to create full and half dark hole.
 - "noDH" DH. In this mode, the mask is just 1 everywhere. 
 
+``creatingMaskDH()`` function has been set up with a mode where each optical plane is save to .fits for debugging purposes.
+To use this options use keywords ``save_all_planes_to_fits = True`` and set up the directory ``dir_save_all_planes``.
 
 Interaction Matrix
 +++++++++++++++++++++++++++++++

--- a/source/correction.rst
+++ b/source/correction.rst
@@ -40,7 +40,7 @@ Several shape are possible for the DH using the parameter ``DH_shape``:
     - ``DH_side`` : can be set to "top", "bottom", "left", "right" and "full" to create full and half dark hole.
 - "noDH" DH. In this mode, the mask is just 1 everywhere. 
 
-``creatingMaskDH()`` function has been set up with a mode where each optical plane is save to .fits for debugging purposes.
+``creatingMaskDH()`` function has been set up with a mode where each optical plane is saved to .fits file for debugging purposes.
 To use this option, set up the keyword ``dir_save_all_planes`` to an existing path directory.
 
 Interaction Matrix

--- a/source/correction.rst
+++ b/source/correction.rst
@@ -41,7 +41,7 @@ Several shape are possible for the DH using the parameter ``DH_shape``:
 - "noDH" DH. In this mode, the mask is just 1 everywhere. 
 
 ``creatingMaskDH()`` function has been set up with a mode where each optical plane is save to .fits for debugging purposes.
-To use this options use keywords ``save_all_planes_to_fits = True`` and set up the directory ``dir_save_all_planes``.
+To use this option, set up the keyword ``dir_save_all_planes`` to an existing path directory.
 
 Interaction Matrix
 +++++++++++++++++++++++++++++++

--- a/source/create_my_testbed.rst
+++ b/source/create_my_testbed.rst
@@ -67,7 +67,7 @@ way to concatenate them easily to create an ``Testbed``.
 
 Finally, ``OpticalSystem`` have been set up with a mode where each optical plane is save to .fits for debugging purposes.
 This can generate a lot of fits especially if in a loop so be careful. 
-To use this options use keywords ``save_all_planes_to_fits = True`` and set up the directory ``dir_save_all_planes``
+To use this option, set up the keyword ``dir_save_all_planes`` to an existing path directory.
 
 Function documentation can be found in Section :ref:`os-label`. 
 

--- a/source/estimation.rst
+++ b/source/estimation.rst
@@ -30,6 +30,8 @@ set by the ``Estim_bin_factor`` parameter and is ``dimScience`` / ``Estim_bin_fa
                                           entrance_EF=input_wavefront)
 
 
+``estimate`` function has been set up with a mode where each optical plane is save to .fits for debugging purposes.
+To use this options use keywords ``save_all_planes_to_fits = True`` and set up the directory ``dir_save_all_planes``.
 
 Perfect Estimation
 +++++++++++++++++++++++

--- a/source/estimation.rst
+++ b/source/estimation.rst
@@ -30,7 +30,7 @@ set by the ``Estim_bin_factor`` parameter and is ``dimScience`` / ``Estim_bin_fa
                                           entrance_EF=input_wavefront)
 
 
-``estimate`` function has been set up with a mode where each optical plane is save to .fits for debugging purposes.
+``estimate`` function has been set up with a mode where each optical plane is saved to .fits file for debugging purposes.
 To use this option, set up the keyword ``dir_save_all_planes`` to an existing path directory.
 
 Perfect Estimation

--- a/source/estimation.rst
+++ b/source/estimation.rst
@@ -31,7 +31,7 @@ set by the ``Estim_bin_factor`` parameter and is ``dimScience`` / ``Estim_bin_fa
 
 
 ``estimate`` function has been set up with a mode where each optical plane is save to .fits for debugging purposes.
-To use this options use keywords ``save_all_planes_to_fits = True`` and set up the directory ``dir_save_all_planes``.
+To use this option, set up the keyword ``dir_save_all_planes`` to an existing path directory.
 
 Perfect Estimation
 +++++++++++++++++++++++

--- a/source/run_asterix.rst
+++ b/source/run_asterix.rst
@@ -51,15 +51,15 @@ When you run Asterix, the first time several directories will be created:
 * Labview/ Finally, if the parameter 'onbench' is set to True, the code will create a directory to put matrices in the format needed to control the THD2 testbed. 
 
 
-As with a lot of function in Asterix, ``runthd2()`` has been set up with a mode where each optical plane is save to .fits for debugging purposes.
+As with a lot of functions in Asterix, ``runthd2()`` has been set up with a mode where each optical plane is saved to .fits file for debugging purposes.
 This can generate a lot of fits especially if in a loop so use with caution. To use this option, set up the keyword ``dir_save_all_planes`` to an existing path directory.
-What is saved if you activate this option in runthd2() was crefully thougth about, to avoid sending thousands of .fits per second:
+What is saved if you activate this option in runthd2() was carefully thougth about, to avoid sending thousands of .fits files:
 
 * Dark Hole Mask
 * PW Estimate at each iteration.
 * 1 full run through testbed (~17 fits for 1 DM testbed -one before and after each planes more or less-) at each iteration.
 
-What we are not saved by default, but can be easily done by setting up the keyword ``dir_save_all_planes`` to an existing path directory, individually for these functions:
+What is not saved by default, but can be easily done by setting up the keyword ``dir_save_all_planes`` to an existing path directory, individually for these functions:
 * PW Matrix (nb_probes*17 fits for 1 DM testbed)
 * EFC Matrix (nb_actuator*17 fits for 1 DM testbed)
 * PW difference (nb_probes x17 fits for 1 DM testbed), at each iteration

--- a/source/run_asterix.rst
+++ b/source/run_asterix.rst
@@ -52,14 +52,14 @@ When you run Asterix, the first time several directories will be created:
 
 
 As with a lot of function in Asterix, ``runthd2()`` has been set up with a mode where each optical plane is save to .fits for debugging purposes.
-This can generate a lot of fits especially if in a loop so be careful. To use this options use keywords ``save_all_planes_to_fits = True`` and set up the directory ``dir_save_all_planes``.
+This can generate a lot of fits especially if in a loop so use with caution. To use this option, set up the keyword ``dir_save_all_planes`` to an existing path directory.
 What is saved if you activate this option in runthd2() was crefully thougth about, to avoid sending thousands of .fits per second:
 
 * Dark Hole Mask
 * PW Estimate at each iteration.
 * 1 full run through testbed (~17 fits for 1 DM testbed -one before and after each planes more or less-) at each iteration.
 
-What we are not saved by default, but can be easily done if adding save_all_planes_to_fits=True individually to these functions:
+What we are not saved by default, but can be easily done by setting up the keyword ``dir_save_all_planes`` to an existing path directory, individually for these functions:
 * PW Matrix (nb_probes*17 fits for 1 DM testbed)
 * EFC Matrix (nb_actuator*17 fits for 1 DM testbed)
 * PW difference (nb_probes x17 fits for 1 DM testbed), at each iteration

--- a/source/run_asterix.rst
+++ b/source/run_asterix.rst
@@ -51,6 +51,20 @@ When you run Asterix, the first time several directories will be created:
 * Labview/ Finally, if the parameter 'onbench' is set to True, the code will create a directory to put matrices in the format needed to control the THD2 testbed. 
 
 
+As with a lot of function in Asterix, ``runthd2()`` has been set up with a mode where each optical plane is save to .fits for debugging purposes.
+This can generate a lot of fits especially if in a loop so be careful. To use this options use keywords ``save_all_planes_to_fits = True`` and set up the directory ``dir_save_all_planes``.
+What is saved if you activate this option in runthd2() was crefully thougth about, to avoid sending thousands of .fits per second:
+
+* Dark Hole Mask
+* PW Estimate at each iteration.
+* 1 full run through testbed (~17 fits for 1 DM testbed -one before and after each planes more or less-) at each iteration.
+
+What we are not saved by default, but can be easily done if adding save_all_planes_to_fits=True individually to these functions:
+* PW Matrix (nb_probes*17 fits for 1 DM testbed)
+* EFC Matrix (nb_actuator*17 fits for 1 DM testbed)
+* PW difference (nb_probes x17 fits for 1 DM testbed), at each iteration
+
+
 Description of the parameter file
 +++++++++++++++++++++++
 


### PR DESCRIPTION
Added a save_all_planes_to_fits option to mainTHD2 to help debug (Raphael asked for it). I carefully selected what is saved by default if you activate it to avoid sending thousands of .fits per second:
- Mask
- PW Estimate
- 1 full run through testbed (~17 fits for 1 DM testbed -one before and after each planes more or less-).

What we are **not** saved by default, but can be easily done if adding save_all_planes_to_fits=True individually to these functions:
- PW difference (2*nb_probes*17 fits for 1 DM testbed)
- PW Matrix (nb_probes*17 fits for 1 DM testbed)
- EFC Matrix (nb_actuator*17 fits for 1 DM testbed)
