### PR TITLE
Make default location for output data not inside repo

### DIFF
--- a/Asterix/__init__.py
+++ b/Asterix/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-Asterix_root = os.path.dirname(os.path.realpath(__file__)) + os.path.sep
-model_dir = os.path.join(Asterix_root, "model") + os.path.sep
+Asterix_root = os.path.dirname(os.path.realpath(__file__))
+model_dir = os.path.join(Asterix_root, "model")
 
 __version__ = "2.4"

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -3,7 +3,7 @@
 
 import os
 
-from Asterix.utils import read_parameter_file
+from Asterix.utils import get_data_dir, read_parameter_file
 from Asterix.optics import Pupil, Coronagraph, DeformableMirror, Testbed
 from Asterix.wfsc import Estimator, Corrector, MaskDH, correction_loop, save_loop_results
 
@@ -61,7 +61,7 @@ def runthd2(parameter_file,
                                  NewLoopconfig=NewLoopconfig,
                                  NewSIMUconfig=NewSIMUconfig)
 
-    Data_dir = config["Data_dir"]
+    Data_dir = get_data_dir(config_in=config["Data_dir"])
     onbench = config["onbench"]
     modelconfig = config["modelconfig"]
     DMconfig = config["DMconfig"]

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -248,3 +248,37 @@ def from_param_to_header(config):
         for scalar in config[str(sect)].scalars:
             header[str(scalar)[:8]] = str(config[str(sect)][str(scalar)])
     return header
+
+
+def get_data_dir(env_var_name="THD2_DATA_PATH", datadir="thd2_data"):
+    """
+    Create a path to local data directory.
+
+    If the environment variable `THD2_DATA_PATH` exists, this is returned as the full data path and the input 'datadir'
+    is ignored. You can set this individually on your OS.
+    If the environment variable does not exist (default for all new users) but the user adapted the ini file, the
+    configfile entry is returned.
+    If the environment variable does not exist and the Data_dir entry in the ini file is '.', the directory 'datadir'
+    is appended to the user's home directory and returned as an absolute path.
+    On MacOS of user 'myuser' for example, this would return:
+        '/Users/myuser/thd2_data'
+
+    Parameters
+    ----------
+    env_var_name : string
+        Environment variable for optional override.
+    datadir : string
+        Name of the top-level data directory.
+
+    Returns
+    -------
+    Absolute path to top-level data directory.
+    """
+    try:
+        ret_path = os.environ[env_var_name]
+        print(f"Using the following data path from env var {env_var_name}: '{ret_path}'")
+        return ret_path
+    except KeyError:
+        pass
+
+    return os.path.abspath(os.path.join(os.path.expanduser("~"), datadir))

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -222,7 +222,7 @@ def read_parameter_file(parameter_file,
                 continue
             for key, value in section.items():
                 if not value:
-                    raise Exception(f'In section [{name}], parameter "{key}" is not properly defined')
+                    raise ValueError(f'In section [{name}], parameter "{key}" is not properly defined')
 
     return config
 

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -168,30 +168,31 @@ def read_parameter_file(parameter_file,
                         NewLoopconfig={},
                         NewSIMUconfig={}):
     """
-    check existence of the parameter file, read it and check validity
+    Check existence of the given parameter file, read it and check validity.
     
     AUTHOR: Johan Mazoyer
 
     Parameters
     ----------
-    parameter_file: path 
-        path to a .ini parameter file
-    
-    NewMODELconfig: dict
-    NewDMconfig: dict
-    NewCoronaconfig: dict
-    NewEstimationconfig: dict
-    NewCorrectionconfig: dict
-    NewSIMUconfig: dict
-        Can be used to directly change a parameter if needed, outside of the param file    
-
-
+    parameter_file: string
+        Absolute path to a .ini parameter file.
+    NewMODELconfig: dict, optional
+        Can be used to directly change a parameter in the MODELconfig section of the input parameter file.
+    NewDMconfig: dict, optional
+        Can be used to directly change a parameter in the DMconfig section of the input parameter file.
+    NewCoronaconfig: dict, optional
+        Can be used to directly change a parameter in the Coronaconfig section of the input parameter file.
+    NewEstimationconfig: dict, optional
+        Can be used to directly change a parameter in the Estimationconfig section of the input parameter file.
+    NewCorrectionconfig: dict, optional
+        Can be used to directly change a parameter in the Correctionconfig section of the input parameter file.
+    NewSIMUconfig: dict, optional
+        Can be used to directly change a parameter in the SIMUconfig section of the input parameter file.
 
     Returns
     ------
     config: dict
-        parameter dictionnary
-
+        Parameter dictionary
     """
 
     if not os.path.exists(parameter_file):
@@ -202,7 +203,7 @@ def read_parameter_file(parameter_file,
     if not os.path.exists(configspec_file):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), configspec_file)
 
-    ### CONFIGURATION FILE
+    # Define configuration file
     config = ConfigObj(parameter_file, configspec=configspec_file, default_encoding="utf8")
 
     config["modelconfig"].update(NewMODELconfig)

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -251,17 +251,17 @@ def from_param_to_header(config):
     return header
 
 
-def get_data_dir(env_var_name="THD2_DATA_PATH", config_in=None, datadir="thd2_data"):
+def get_data_dir(env_var_name="ASTERIX_DATA_PATH", config_in=None, datadir="asterix_data"):
     """
     Create a path to the local data directory.
 
-    If the environment variable `THD2_DATA_PATH` exists, this is returned as the full data path and the input 'datadir'
+    If the environment variable `ASTERIX_DATA_PATH` exists, this is returned as the full data path and the input 'datadir'
         is ignored. You can set this individually on your OS.
     If the environment variable does not exist (default for all new users) but the user adapted the ini file and
         accesses the 'Data_dir' entry, the configfile entry is returned and 'datadir' is ignored.
     If the environment variable does not exist and the Data_dir entry in the ini file is not passed or set to '.',
         the directory 'datadir' is appended to the user's home directory and returned as an absolute path. On MacOS of
-        user 'myuser' for example, this would return: '/Users/myuser/thd2_data'
+        user 'myuser' for example, this would return: '/Users/myuser/asterix_data'
 
     Parameters
     ----------

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -250,18 +250,17 @@ def from_param_to_header(config):
     return header
 
 
-def get_data_dir(env_var_name="THD2_DATA_PATH", datadir="thd2_data"):
+def get_data_dir(env_var_name="THD2_DATA_PATH", config_in=None, datadir="thd2_data"):
     """
-    Create a path to local data directory.
+    Create a path to the local data directory.
 
     If the environment variable `THD2_DATA_PATH` exists, this is returned as the full data path and the input 'datadir'
-    is ignored. You can set this individually on your OS.
-    If the environment variable does not exist (default for all new users) but the user adapted the ini file, the
-    configfile entry is returned.
-    If the environment variable does not exist and the Data_dir entry in the ini file is '.', the directory 'datadir'
-    is appended to the user's home directory and returned as an absolute path.
-    On MacOS of user 'myuser' for example, this would return:
-        '/Users/myuser/thd2_data'
+        is ignored. You can set this individually on your OS.
+    If the environment variable does not exist (default for all new users) but the user adapted the ini file and
+        accesses the 'Data_dir' entry, the configfile entry is returned and 'datadir' is ignored.
+    If the environment variable does not exist and the Data_dir entry in the ini file is not passed or set to '.',
+        the directory 'datadir' is appended to the user's home directory and returned as an absolute path. On MacOS of
+        user 'myuser' for example, this would return: '/Users/myuser/thd2_data'
 
     Parameters
     ----------
@@ -281,4 +280,7 @@ def get_data_dir(env_var_name="THD2_DATA_PATH", datadir="thd2_data"):
     except KeyError:
         pass
 
-    return os.path.abspath(os.path.join(os.path.expanduser("~"), datadir))
+    if config_in is not None and config_in != '.':
+        return config_in
+    else:
+        return os.path.abspath(os.path.join(os.path.expanduser("~"), datadir))

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -284,4 +284,7 @@ def get_data_dir(env_var_name="THD2_DATA_PATH", config_in=None, datadir="thd2_da
     if config_in is not None and config_in != '.':
         return config_in
     else:
-        return os.path.abspath(os.path.join(os.path.expanduser("~"), datadir))
+        home_path = os.path.abspath(os.path.join(os.path.expanduser("~"), datadir))
+        if not os.path.isdir(home_path):
+            os.mkdir(home_path)
+        return home_path

--- a/source/run_asterix.rst
+++ b/source/run_asterix.rst
@@ -27,9 +27,9 @@ is set and outputs will be saved to some pre-defined default locations. There ar
 your own python file which calls ``main_THD.runthd2()``.
 
 2. Leave the parameter file entry ``Data_dir`` in whichever file you are reading set to '.', which will look for a
-directory called ``thd2_data`` in your home directory and save all data there. If the code can't find it, it will create one.
+directory called ``asterix_data`` in your home directory and save all data there. If the code can't find it, it will create one.
 
-3. You can create the environment variable ``THD2_DATA_PATH`` on your local machine which will define the top-level
+3. You can create the environment variable ``ASTERIX_DATA_PATH`` on your local machine which will define the top-level
 directory to which all your data outputs from Asterix will be saved.
 
 .. code-block:: python

--- a/source/run_asterix.rst
+++ b/source/run_asterix.rst
@@ -20,9 +20,17 @@ with the THD2 testbed, just run:
     main_THD.runthd2(os.path.join(Asterix_root, 'Example_param_file.ini'))
 
 Please avoid running Asterix directly in the Asterix install directory to avoid saving .fits files everywhere.
-The first parameter of the parameter file is ``Data_dir``. By default it is set to '.' which means it will save the files
-in the directory you currently are when you run this code. A good practice is therefore to create your own parameter file by
-copying Example_param_file.ini in another directory and create you own calling python file which call ``main_THD.runthd2()``.
+The first parameter of the parameter file is ``Data_dir``. By default it is set to '.' which means no target directory
+is set and outputs will be saved to some pre-defined default locations. There are several options for this:
+
+1. Create your own parameter file by copying ``Example_param_file.ini`` into another directory and to create
+your own python file which calls ``main_THD.runthd2()``.
+
+2. Leave the parameter file entry ``Data_dir`` in whichever file you are reading set to '.', which will look for a
+directory called ``thd2_data`` in your home directory and save all data there. If the code can't find it, it will create one.
+
+3. You can create the environment variable ``THD2_DATA_PATH`` on your local machine which will define the top-level
+directory to which all your data outputs from Asterix will be saved.
 
 .. code-block:: python
 
@@ -38,13 +46,13 @@ For example:
     main_THD.runthd2(os.path.join(path_to_my_param_file, 'my_param_file.ini'),
                      NewCoronaconfig={"corona_type" : 'fqpm'})
 
-will overide the current corona_type parameter and replace it with "fqpm", leaving all other parameters unchanged.
+will override the current corona_type parameter and replace it with "fqpm", leaving all other parameters unchanged.
 
 When you run Asterix, the first time several directories will be created:
 
 * Model_local/ contains all .fits files that are essentials to the correction but that can be measured, even if it can take a long time.
 
-* Interaction_Matrices/ is the directoy where Matrices are saved, both for estimation (e.g. pair wise) and correction (e.g. Interaction Matrices).
+* Interaction_Matrices/ is the directory where Matrices are saved, both for estimation (e.g. pair wise) and correction (e.g. Interaction Matrices).
 
 * Results/ where it will save the results of your correction. The code will automatically create a directory in Results/Name_Experiment/ where 'Name_Experiment' is a parameter in the .ini file.
 


### PR DESCRIPTION
Currently, the only way to set the saving location of the output files is by changing the appropriate entry (`Data_dir`) in the configfile. This means that the default location for this is inside the repository, which gets messy easily.

This PR makes the default location the user's home directory as long as the configfile entry is set to `Data_dir = '.'`, where it will automatically create the subfolder `asterix_data`. The user can still use the configfile to set the directory they want the data saved in, so everything stays the same in that regard.

As a plus, people can also set an environment variable on their local machine to control the location of the output data of Asterix, but this is not required.