### PR TITLE
Polychromatic correction

### DIFF
--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -218,6 +218,16 @@ onbench=True
     # Estim_sampling = Science_sampling / Estim_bin_factor
     # be careful, this raise an error if Estim_sampling < 3
     Estim_bin_factor = 2 
+
+    # For polychromatic estimation / correction : 
+    # - 'centralwl': only the central bandwidth is used for estimation / correction.
+    # - 'broadband': the images used for estimation / and correction are broadband (of BW Delta_wav)
+    # - 'multiwl': nb_wav images are used for estimation and there are nb_wav matrix of estimation / correction
+    # This parameter is only for the estimation / correction. The bandwidth of the images are
+    # still parametrized in [modelconfig] (nb_wav, Delta_wav)
+    # If monochromatic images (nb_wav = 1 or Delta_wav = 0), all these options are equivalent
+    # Not case sensitive
+    polychromatic = 'centralwl'
     
     #PW parameters
     #Amplitude of PW probes (in nm)

--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -14,7 +14,7 @@ onbench=True
     wavelength_0 = 783.25e-9
 
     # Spectral band (in meters) I think should be in percent...
-    Delta_wav = 0#10e-9
+    Delta_wav = 0#30e-9
 
     # Number of monochromatic images in the spectral band.
     # Ignored if Delta_wav = 0
@@ -221,7 +221,7 @@ onbench=True
 
     # For polychromatic estimation / correction : 
     # - 'centralwl': only the central bandwidth is used for estimation / correction.
-    # - 'broadband': the images used for estimation / and correction are broadband (of BW Delta_wav)
+    # - 'broadband_pwprobes': probes images used for PW are broadband (of BW Delta_wav). Matrixes are at central bandwidth
     # - 'multiwl': nb_wav images are used for estimation and there are nb_wav matrix of estimation / correction
     # This parameter is only for the estimation / correction. The bandwidth of the images are
     # still parametrized in [modelconfig] (nb_wav, Delta_wav)

--- a/Asterix/Param_configspec.ini
+++ b/Asterix/Param_configspec.ini
@@ -83,6 +83,7 @@ onbench = boolean(default=False)
 [Estimationconfig]
     estimation=string(default='Perfect')
     Estim_bin_factor = integer(default=1)   #  smapling in science image / sampling in the PW/EFC images
+    polychromatic=string(default='centralwl')
     amplitudePW = float(default=34.)
     posprobes = int_list(default=list(466,498))
     cut=float(default=5.e4)

--- a/Asterix/optics/optical_systems.py
+++ b/Asterix/optics/optical_systems.py
@@ -75,9 +75,8 @@ class OpticalSystem:
             self.wav_vec = np.array([self.wavelength_0])
             self.nb_wav = 1
 
-        self.string_os = '_dimPP' + str(int(self.dim_overpad_pupil)) + '_wl' + str(
-            int(self.wavelength_0 * 1e9)) + "_resFP" + str(round(self.Science_sampling, 2)) + "_dimFP" + str(
-                int(self.dimScience))
+        self.string_os = '_dimPP' + str(int(self.dim_overpad_pupil)) + "_resFP" + str(
+            round(self.Science_sampling, 2)) + "_dimFP" + str(int(self.dimScience))
 
     #We define functions that all OpticalSystem object can use.
     # These can be overwritten for a subclass if need be

--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -308,7 +308,7 @@ def correction_loop_1matrix(testbed: Testbed,
         resultatestimation = estimator.estimate(testbed,
                                                 voltage_vector=thisloop_voltages_DMs[-1],
                                                 entrance_EF=input_wavefront,
-                                                wavelength=testbed.wavelength_0,
+                                                wavelengths=testbed.wavelength_0,
                                                 perfect_estimation=Search_best_Mode,
                                                 **kwargs)
 

--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -308,7 +308,6 @@ def correction_loop_1matrix(testbed: Testbed,
         resultatestimation = estimator.estimate(testbed,
                                                 voltage_vector=thisloop_voltages_DMs[-1],
                                                 entrance_EF=input_wavefront,
-                                                wavelengths=testbed.wavelength_0,
                                                 perfect_estimation=Search_best_Mode,
                                                 **kwargs)
 

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -121,8 +121,13 @@ class Corrector:
                 print("Creating directory " + realtestbed_dir)
                 os.makedirs(realtestbed_dir)
 
+            if estimator.polychrom in ['centralwl', 'broadband_pwprobes']:
+                number_wl_in_matrix = 1
+            else:
+                number_wl_in_matrix = 3
+
             if testbed.DM1.active & testbed.DM3.active:
-                fits.writeto(os.path.join(realtestbed_dir, "Direct_Matrix_2DM.fits"),
+                fits.writeto(os.path.join(realtestbed_dir, f"Direct_Matrix_2DM_wl{number_wl_in_matrix}.fits"),
                              self.Gmatrix,
                              overwrite=True)
                 fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM1.fits"),
@@ -134,7 +139,8 @@ class Corrector:
                 number_Active_testbeds = 13
 
             elif testbed.DM1.active:
-                fits.writeto(os.path.join(realtestbed_dir, "Direct_Matrix_DM1only.fits"),
+                fits.writeto(os.path.join(realtestbed_dir,
+                                          f"Direct_Matrix_DM1only_wl{number_wl_in_matrix}.fits"),
                              self.Gmatrix,
                              overwrite=True)
                 fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM1.fits"),
@@ -142,7 +148,8 @@ class Corrector:
                              overwrite=True)
                 number_Active_testbeds = 1
             elif testbed.DM3.active:
-                fits.writeto(os.path.join(realtestbed_dir, "Direct_Matrix_DM3only.fits"),
+                fits.writeto(os.path.join(realtestbed_dir,
+                                          f"Direct_Matrix_DM3only_wl{number_wl_in_matrix}.fits"),
                              self.Gmatrix,
                              overwrite=True)
                 fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM3.fits"),
@@ -161,8 +168,11 @@ class Corrector:
                     raise Exception(f"Nbmodes_OnTestbed ({Correctionconfig['Nbmodes_OnTestbed']})" +
                                     " in inversion for THD is probably too high for 1DM")
 
-            thd_quick_invert.THD_quick_invert(Correctionconfig["Nbmodes_OnTestbed"], number_Active_testbeds,
-                                              realtestbed_dir, self.regularization)
+            thd_quick_invert.THD_quick_invert(Correctionconfig["Nbmodes_OnTestbed"],
+                                              number_Active_testbeds,
+                                              realtestbed_dir,
+                                              self.regularization,
+                                              number_wl_in_matrix=number_wl_in_matrix)
 
             fits.writeto(os.path.join(realtestbed_dir, "DH_mask.fits"),
                          self.MaskEstim.astype(np.float32),
@@ -231,15 +241,23 @@ class Corrector:
                                                      initial_DM_voltage=initial_DM_voltage,
                                                      input_wavefront=input_wavefront,
                                                      MatrixType=self.MatrixType,
-                                                     dir_save_all_planes=None)
+                                                     polychrom=estimator.polychrom,
+                                                     dir_save_all_planes=None,
+                                                     visu=False)
 
             self.Gmatrix = wfc.crop_interaction_matrix_to_dh(interMat, self.MaskEstim)
 
             if self.correction_algorithm in ["em", "steepest", "sm"]:
+                pixel_in_mask = int(np.sum(self.MaskEstim))
+                number_wl_matrix = self.Gmatrix.shape[0] // (2 * pixel_in_mask)
 
-                self.G = np.zeros((int(np.sum(self.MaskEstim)), self.Gmatrix.shape[1]), dtype=complex)
-                self.G = (self.Gmatrix[0:int(self.Gmatrix.shape[0] / 2), :] +
-                          1j * self.Gmatrix[int(self.Gmatrix.shape[0] / 2):, :])
+                self.G = np.zeros((number_wl_matrix * pixel_in_mask, self.Gmatrix.shape[1]), dtype=complex)
+
+                for i in range(number_wl_matrix):
+                    self.G[i * pixel_in_mask:(i + 1) * pixel_in_mask, :] = (
+                        self.Gmatrix[2 * i * pixel_in_mask:(2 * i + 1) * pixel_in_mask, :] +
+                        1j * self.Gmatrix[(2 * i + 1) * pixel_in_mask:(2 * i + 2) * pixel_in_mask, :])
+
                 transposecomplexG = np.transpose(np.conjugate(self.G))
                 self.M0 = np.real(np.dot(transposecomplexG, self.G))
                 self.Gmatrix = 0.
@@ -257,8 +275,9 @@ class Corrector:
         testbed :  OpticalSystem.Testbed
             Testbed object which describe your testbed
 
-        estimate: 2D complex array 
-            Array of size of sixe [dimEstim, dimEstim]. 
+        estimate: list of 2D complex array 
+            list is the number of wl in the estimation, usually 1 or testbed.nb_wav
+            Each arrays are of size of sixe [dimEstim, dimEstim]. 
             This is the result of Estimator.estimate, from which this function 
             send a command to the DM
         

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -107,37 +107,7 @@ class Estimator:
             self.posprobes = list(Estimationconfig["posprobes"])
             cutsvdPW = Estimationconfig["cut"]
 
-            if hasattr(testbed, 'name_DM_to_probe_in_PW'):
-                if testbed.name_DM_to_probe_in_PW not in testbed.name_of_DMs:
-                    raise Exception("Cannot use this DM for PW, this testbed has no DM named " +
-                                    testbed.name_DM_to_probe_in_PW)
-            # If name_DM_to_probe_in_PW is not set,
-            # automatically check which DM to use to probe in this case
-            # this is only done once.
-            if len(testbed.name_of_DMs) == 0:
-                raise Exception("you need at least one activated DM to do PW")
-            #If only one DM, we use this one, independenlty of its position
-            elif len(testbed.name_of_DMs) == 1:
-                testbed.name_DM_to_probe_in_PW = testbed.name_of_DMs[0]
-            else:
-                #If several DMs we check if there is at least one in PP
-                number_DMs_in_PP = 0
-                for DM_name in testbed.name_of_DMs:
-                    DM = vars(testbed)[DM_name]  # type: DeformableMirror
-                    if DM.z_position == 0.:
-                        number_DMs_in_PP += 1
-                        testbed.name_DM_to_probe_in_PW = DM_name
-
-                #If there are several DMs in PP, error, you need to set name_DM_to_probe_in_PW
-                if number_DMs_in_PP > 1:
-                    raise Exception(
-                        "You have several DM in PP, choose one for the PW probes using testbed.name_DM_to_probe_in_PW"
-                    )
-                #Several DMS, none in PP, error, you need to set name_DM_to_probe_in_PW
-                if number_DMs_in_PP == 0:
-                    raise Exception(
-                        "You have several DMs none in PP, choose one for the PW probes using testbed.name_DM_to_probe_in_PW"
-                    )
+            testbed.name_DM_to_probe_in_PW = self.find_DM_to_probe(testbed)
 
             self.PWMatrix = wfs.create_pw_matrix(testbed,
                                                  self.amplitudePW,
@@ -284,3 +254,58 @@ class Estimator:
 
         else:
             raise Exception("This estimation algorithm is not yet implemented")
+
+        def find_DM_to_probe(self, testbed: Testbed):
+            """
+            function to find which DM to use for the PW probes
+
+            AUTHOR : Johan Mazoyer
+
+            Parameters
+            ----------
+            testbed :  OpticalSystem.Testbed
+                Testbed object which describe your testbed
+            
+            Returns
+            ----------
+            name_DM_to_probe_in_PW: string
+                name of the DM to probe in PW
+
+
+            """
+
+            # we chose it already. We only check its existence
+            if hasattr(testbed, 'name_DM_to_probe_in_PW'):
+                if testbed.name_DM_to_probe_in_PW not in testbed.name_of_DMs:
+                    raise Exception("Cannot use this DM for PW, this testbed has no DM named " +
+                                    testbed.name_DM_to_probe_in_PW)
+                return testbed.name_DM_to_probe_in_PW
+
+            # If name_DM_to_probe_in_PW is not already set,
+            # automatically check which DM to use to probe in this case
+            # this is only done once.
+            if len(testbed.name_of_DMs) == 0:
+                raise Exception("you need at least one activated DM to do PW")
+            #If only one DM, we use this one, independenlty of its position
+            elif len(testbed.name_of_DMs) == 1:
+                name_DM_to_probe_in_PW = testbed.name_of_DMs[0]
+            else:
+                #If several DMs we check if there is at least one in PP
+                number_DMs_in_PP = 0
+                for DM_name in testbed.name_of_DMs:
+                    DM = vars(testbed)[DM_name]  # type: DeformableMirror
+                    if DM.z_position == 0.:
+                        number_DMs_in_PP += 1
+                        name_DM_to_probe_in_PW = DM_name
+
+                #If there are several DMs in PP, error, you need to set name_DM_to_probe_in_PW
+                if number_DMs_in_PP > 1:
+                    raise Exception(
+                        "You have several DM in PP, choose one for the PW probes using testbed.name_DM_to_probe_in_PW"
+                    )
+                #Several DMS, none in PP, error, you need to set name_DM_to_probe_in_PW
+                if number_DMs_in_PP == 0:
+                    raise Exception(
+                        "You have several DMs none in PP, choose one for the PW probes using testbed.name_DM_to_probe_in_PW"
+                    )
+            return name_DM_to_probe_in_PW

--- a/Asterix/wfsc/thd_quick_invert.py
+++ b/Asterix/wfsc/thd_quick_invert.py
@@ -1,6 +1,7 @@
 # pylint: disable=invalid-name
 # pylint: disable=trailing-whitespace
 
+import glob
 import sys
 import os
 import time
@@ -11,7 +12,7 @@ from astropy.io import fits
 from Asterix.utils import invert_svd
 
 
-def THD_quick_invert(Nbmodes, name_active_DM, matrix_directory, regularization):
+def THD_quick_invert(Nbmodes, name_active_DM, matrix_directory, regularization, number_wl_in_matrix=1):
     """
         This code invert the matrix just in the case of THD testbed
         The goal is to be able to invert the matrix directly on the RTC to be 
@@ -59,6 +60,10 @@ def THD_quick_invert(Nbmodes, name_active_DM, matrix_directory, regularization):
                             singular values are truncated
             if 'tikhonov': when goal is set to 'c', the modes with the highest inverse
                             singular values are smoothed (low pass filter)
+        
+        number_wl_in_matrix : int, default 1
+            number of wavelength in the direct matrix
+        
 
         Returns
         ------
@@ -66,16 +71,19 @@ def THD_quick_invert(Nbmodes, name_active_DM, matrix_directory, regularization):
         """
 
     if name_active_DM in (13, 31):
-        Gmatrix = fits.getdata(os.path.join(matrix_directory, "Direct_Matrix_2DM.fits"))
+        Gmatrix = fits.getdata(
+            os.path.join(matrix_directory, f"Direct_Matrix_2DM_wl{number_wl_in_matrix}.fits"))
         DM1_basis = fits.getdata(os.path.join(matrix_directory, "Base_Matrix_DM1.fits"))
         DM3_basis = fits.getdata(os.path.join(matrix_directory, "Base_Matrix_DM3.fits"))
 
     elif name_active_DM == 1:
-        Gmatrix = fits.getdata(os.path.join(matrix_directory, "Direct_Matrix_DM1only.fits"))
+        Gmatrix = fits.getdata(
+            os.path.join(matrix_directory, f"Direct_Matrix_DM1only_wl{number_wl_in_matrix}.fits"))
         DM1_basis = fits.getdata(os.path.join(matrix_directory, "Base_Matrix_DM1.fits"))
 
     elif name_active_DM == 3:
-        Gmatrix = fits.getdata(os.path.join(matrix_directory, "Direct_Matrix_DM3only.fits"))
+        Gmatrix = fits.getdata(
+            os.path.join(matrix_directory, f"Direct_Matrix_DM3only_wl{number_wl_in_matrix}.fits"))
         DM3_basis = fits.getdata(os.path.join(matrix_directory, "Base_Matrix_DM3.fits"))
 
     else:

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -136,7 +136,8 @@ def create_interaction_matrix(testbed: Testbed,
 
         basis_str = DM_small_str + "_" + DM.basis_type + "Basis" + str(DM.basis_size)
 
-        fileDirectMatrix = headfile + basis_str + '_dimEstim' + str(dimEstim) + string_testbed_without_DMS
+        fileDirectMatrix = headfile + basis_str + '_dimEstim' + str(
+            dimEstim) + string_testbed_without_DMS + '_wl' + str(int(testbed.wavelength_0 * 1e9))
 
         # We only save the 'first' matrix meaning the one with no initial DM voltages
         # Matrix is saved/loaded for each DM independetly which allow quick switch

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -23,10 +23,135 @@ def create_interaction_matrix(testbed: Testbed,
                               initial_DM_voltage=0.,
                               input_wavefront=1.,
                               MatrixType='',
+                              polychrom='centralwl',
                               dir_save_all_planes=None,
                               visu=False):
     """
     Create the jacobian matrix for Electric Field Conjugation. The Matrix is not
+    limited to the DH size but to the whole FP [dimEstim, dimEstim]. 
+    First half is real part, second half is imag part.
+
+    The matrix size is therefore [total(DM.basis_size), 2*dimEstim^2]
+
+    We save the matrix in .fits independently for each DMs, only if the initial 
+    wavefront and DMs are flat.
+
+    This code works for all testbeds without prior assumption (if we have at 
+    least 1 DM of course). We have optimized the code to only do once the optical 
+    elements before the DM movement and repeat only what is after the DMS
+    
+    AUTHOR : Johan Mazoyer
+
+    Sept 2022 : created 
+
+    Parameters
+    ----------
+
+    testbed: Testbed Optical_element
+        testbed structure with at least 1 DM
+    
+    dimEstim: int
+        size of the output image in teh estimator
+    
+    amplitudeEFC: float
+        amplitude of the EFC probe on the DM
+    
+    matrix_dir : path. 
+        save all the matrices here
+    
+    MatrixType: string
+        'smallphase' (when applying modes on the DMs we, do a small phase assumption : exp(i phi) = 1+ i.phi) 
+        or 'perfect' (we keep exp(i phi)).
+        in both case, if the DMs are not initially flat (non zero initial_DM_voltage), 
+        we do not make the small phase assumption for initial DM phase
+    
+    polychrom: string
+        For polychromatic estimation / correction : 
+        - 'centralwl': only the central bandwidth is used for estimation / correction. 1 Interation Matrix
+        - 'broadband_pwprobes': probes images PW are broadband but matrixes are at central bandwidth: 1 Interation Matrix
+        - 'multiwl': nb_wav images are used for estimation and there are nb_wav matrices of estimation / correction: 3 Interation Matrices
+
+    initial_DM_voltage: 1D-array real
+        initial DM voltage for all DMs
+    
+    input_wavefront: 
+        input wavefront in pupil plane
+    
+    dir_save_all_planes : default None. 
+        If not None, directory to save all planes in fits for debugging purposes.
+        This can generate a lot of fits especially if in a loop, use with caution
+    
+    visu : bool default false
+        if true show the focal plane intensity in 2D for each mode
+
+    Returns
+    ------
+    InterMat: 2D array of size [total(DM.basis_size), 2*dimEstim^2]
+        jacobian matrix for Electric Field Conjugation.
+
+    """
+
+    ## careful here if we do not want the matrix done exactly at the same wl as the testbed
+    if isinstance(input_wavefront, (float, int)):
+        input_wavefront = np.repeat(input_wavefront, testbed.nb_wav)
+    elif input_wavefront.shape == testbed.wav_vec.shape:
+        pass
+    elif input_wavefront.shape == (testbed.dim_overpad_pupil, testbed.dim_overpad_pupil):
+        input_wavefront = np.repeat(input_wavefront[np.newaxis, ...], testbed.nb_wav, axis=0)
+    elif input_wavefront.shape == (testbed.nb_wav, testbed.dim_overpad_pupil, testbed.dim_overpad_pupil):
+        pass
+    else:
+        raise Exception(""""input_wavefront must be scalar (same for all WL), or a nb_wav scalars or a
+                    2D array of size (dim_overpad_pupil, dim_overpad_pupil) or a 3D array of size
+                    (nb_wav, dim_overpad_pupil, dim_overpad_pupil)""")
+
+    return_matrix = []
+
+    if polychrom in ['centralwl', 'broadband_pwprobes']:
+        return_matrix.append(
+            create_singlewl_interaction_matrix(testbed,
+                                             dimEstim,
+                                             amplitudeEFC,
+                                             testbed.wavelength_0,
+                                             matrix_dir,
+                                             initial_DM_voltage=initial_DM_voltage,
+                                             input_wavefront=input_wavefront[testbed.wav_vec.tolist().index(
+                                                 testbed.wavelength_0)],
+                                             MatrixType=MatrixType,
+                                             dir_save_all_planes=dir_save_all_planes,
+                                             visu=visu))
+
+    elif polychrom == 'multiwl':
+        for i, wave_i in enumerate(testbed.wav_vec):
+            return_matrix.append(
+                create_singlewl_interaction_matrix(testbed,
+                                                 dimEstim,
+                                                 amplitudeEFC,
+                                                 wave_i,
+                                                 matrix_dir,
+                                                 initial_DM_voltage=initial_DM_voltage,
+                                                 input_wavefront=input_wavefront[i],
+                                                 MatrixType=MatrixType,
+                                                 dir_save_all_planes=dir_save_all_planes,
+                                                 visu=visu))
+    else:
+        raise Exception(polychrom + " is not a valid polychromatic estimation/correction mode")
+
+    return return_matrix
+
+
+def create_singlewl_interaction_matrix(testbed: Testbed,
+                                     dimEstim,
+                                     amplitudeEFC,
+                                     wavelength,
+                                     matrix_dir,
+                                     initial_DM_voltage=0.,
+                                     input_wavefront=1.,
+                                     MatrixType='',
+                                     dir_save_all_planes=None,
+                                     visu=False):
+    """
+    Create the jacobian matrix for Electric Field Conjugation for one wavelength. The Matrix is not
     limited to the DH size but to the whole FP [dimEstim, dimEstim]. 
     First half is real part, second half is imag part.
 
@@ -53,6 +178,9 @@ def create_interaction_matrix(testbed: Testbed,
     amplitudeEFC: float
         amplitude of the EFC probe on the DM
     
+    wavelength : float
+        wavelength in m.
+    
     matrix_dir : path. 
         save all the matrices here
     
@@ -62,10 +190,10 @@ def create_interaction_matrix(testbed: Testbed,
         in both case, if the DMs are not initially flat (non zero initial_DM_voltage), 
         we do not make the small phase assumption for initial DM phase
 
-    input_wavefront: 1D-array real
+    initial_DM_voltage: 1D-array real
         initial DM voltage for all DMs
     
-    input_wavefront: 2D-array complex
+    input_wavefront: 
         input wavefront in pupil plane
     
     dir_save_all_planes : default None. 
@@ -84,7 +212,7 @@ def create_interaction_matrix(testbed: Testbed,
     if isinstance(initial_DM_voltage, (int, float)):
         initial_DM_voltage = np.zeros(testbed.number_act) + float(initial_DM_voltage)
 
-    wavelength = testbed.wavelength_0
+    # wavelength = testbed.wavelength_0
     normalisation_testbed_EF_contrast = np.sqrt(
         testbed.norm_monochrom[testbed.wav_vec.tolist().index(wavelength)])
 
@@ -103,7 +231,7 @@ def create_interaction_matrix(testbed: Testbed,
 
         DM = vars(testbed)[DM_name]  # type: DeformableMirror
         total_number_basis_modes += DM.basis_size
-        DM_small_str = "_" + "_".join(DM.string_os.split("_")[5:])
+        DM_small_str = "_" + "_".join(DM.string_os.split("_")[4:])
         string_testbed_without_DMS = string_testbed_without_DMS.replace(DM_small_str, '')
         #attach the initial phase for each DM
         DM.phase_init = DM_phase_init[i]
@@ -137,7 +265,7 @@ def create_interaction_matrix(testbed: Testbed,
         basis_str = DM_small_str + "_" + DM.basis_type + "Basis" + str(DM.basis_size)
 
         fileDirectMatrix = headfile + basis_str + '_dimEstim' + str(
-            dimEstim) + string_testbed_without_DMS + '_wl' + str(int(testbed.wavelength_0 * 1e9))
+            dimEstim) + string_testbed_without_DMS + '_wl' + str(int(wavelength * 1e9))
 
         # We only save the 'first' matrix meaning the one with no initial DM voltages
         # Matrix is saved/loaded for each DM independetly which allow quick switch
@@ -227,7 +355,8 @@ def create_interaction_matrix(testbed: Testbed,
                         save_plane_in_fits(dir_save_all_planes, name_plane, OpticSysbefore.phase_init)
 
                 else:
-                    wavefrontupstream = OpticSysbefore.EF_through(entrance_EF=wavefrontupstream)
+                    wavefrontupstream = OpticSysbefore.EF_through(entrance_EF=wavefrontupstream,
+                                                                  wavelength=wavelength)
 
                 if dir_save_all_planes is not None:
                     # save PP plane after this subsystem
@@ -240,7 +369,7 @@ def create_interaction_matrix(testbed: Testbed,
             if DM.z_position != 0:
 
                 wavefrontupstreaminDM = crop_or_pad_image(
-                    prop.prop_angular_spectrum(wavefrontupstream, DM.wavelength_0, DM.z_position,
+                    prop.prop_angular_spectrum(wavefrontupstream, wavelength, DM.z_position,
                                                DM.diam_pup_in_m / 2, DM.prad), DM.dim_overpad_pupil)
 
             if visu:
@@ -258,8 +387,8 @@ def create_interaction_matrix(testbed: Testbed,
                 if MatrixType == 'perfect':
                     if DM.z_position == 0:
 
-                        wavefront = wavefrontupstream * DM.EF_from_phase_and_ampl(phase_abb=phasesBasis[i] +
-                                                                                  DM.phase_init)
+                        wavefront = wavefrontupstream * DM.EF_from_phase_and_ampl(
+                            phase_abb=phasesBasis[i] + DM.phase_init, wavelengths=wavelength)
 
                         if dir_save_all_planes is not None:
                             name_plane = 'Phase_on_' + DM_name + f'_wl{int(wavelength * 1e9)}'
@@ -269,9 +398,9 @@ def create_interaction_matrix(testbed: Testbed,
 
                         wavefront = crop_or_pad_image(
                             prop.prop_angular_spectrum(
-                                wavefrontupstreaminDM *
-                                DM.EF_from_phase_and_ampl(phase_abb=phasesBasis[i] + DM.phase_init),
-                                DM.wavelength_0, -DM.z_position, DM.diam_pup_in_m / 2, DM.prad),
+                                wavefrontupstreaminDM * DM.EF_from_phase_and_ampl(
+                                    phase_abb=phasesBasis[i] + DM.phase_init, wavelengths=wavelength),
+                                wavelength, -DM.z_position, DM.diam_pup_in_m / 2, DM.prad),
                             DM.dim_overpad_pupil)
 
                 if MatrixType == 'smallphase':
@@ -279,14 +408,15 @@ def create_interaction_matrix(testbed: Testbed,
                     # removed. Need to be tested with and without on the testbed
                     if DM.z_position == 0:
                         wavefront = (1 + 1j * phasesBasis[i]) * wavefrontupstream * DM.EF_from_phase_and_ampl(
-                            phase_abb=DM.phase_init)
+                            phase_abb=DM.phase_init, wavelengths=wavelength)
                     else:
 
                         wavefront = crop_or_pad_image(
                             prop.prop_angular_spectrum(
                                 wavefrontupstreaminDM * (1 + 1j * phasesBasis[i]) *
-                                DM.EF_from_phase_and_ampl(phase_abb=DM.phase_init), DM.wavelength_0,
-                                -DM.z_position, DM.diam_pup_in_m / 2, DM.prad), DM.dim_overpad_pupil)
+                                DM.EF_from_phase_and_ampl(phase_abb=DM.phase_init, wavelengths=wavelength),
+                                wavelength, -DM.z_position, DM.diam_pup_in_m / 2, DM.prad),
+                            DM.dim_overpad_pupil)
 
                 if dir_save_all_planes is not None:
                     name_plane = 'EF_PP_after_' + DM_name + f'_wl{int(wavelength * 1e9)}'
@@ -312,7 +442,7 @@ def create_interaction_matrix(testbed: Testbed,
                                 save_plane_in_fits(dir_save_all_planes, name_plane, OpticSysAfter.phase_init)
 
                         else:
-                            wavefront = OpticSysAfter.EF_through(entrance_EF=wavefront)
+                            wavefront = OpticSysAfter.EF_through(entrance_EF=wavefront, wavelength=wavelength)
 
                         if dir_save_all_planes is not None:
                             name_plane = 'EF_PP_after_' + osname + f'_wl{int(wavelength * 1e9)}'
@@ -328,7 +458,8 @@ def create_interaction_matrix(testbed: Testbed,
                         # wavelength for the whole testbed. This is the same normalization as G0.
 
                         Gvector = resizing(
-                            OpticSysAfter.todetector(entrance_EF=wavefront, in_contrast=False) /
+                            OpticSysAfter.todetector(
+                                entrance_EF=wavefront, wavelength=wavelength, in_contrast=False) /
                             normalisation_testbed_EF_contrast, dimEstim)
 
                         if dir_save_all_planes is not None:
@@ -397,17 +528,24 @@ def crop_interaction_matrix_to_dh(FullInteractionMatrix: np.ndarray, mask: np.nd
         matrix only inside the DH. first half is real part, second half is imag part
 
     """
-    size_full_matrix = FullInteractionMatrix.shape[0]
 
-    size_DH_matrix = 2 * int(np.sum(mask))
+    number_wl_matrix = len(FullInteractionMatrix)
+    twice_size_FP_pix = FullInteractionMatrix[0].shape[0]
+    number_actu = FullInteractionMatrix[0].shape[1]
+
+    size_DH_pix = int(np.sum(mask))
     where_mask_flatten = np.where(mask.flatten() == 1.)
-    DHInteractionMatrix = np.zeros((size_DH_matrix, FullInteractionMatrix.shape[1]), dtype=float)
+    DHInteractionMatrix = np.zeros((2 * size_DH_pix * number_wl_matrix, number_actu), dtype=float)
 
-    for i in range(FullInteractionMatrix.shape[1]):
-        DHInteractionMatrix[:int(size_DH_matrix / 2), i] = FullInteractionMatrix[:int(size_full_matrix / 2),
-                                                                                 i][where_mask_flatten]
-        DHInteractionMatrix[int(size_DH_matrix / 2):, i] = FullInteractionMatrix[int(size_full_matrix / 2):,
-                                                                                 i][where_mask_flatten]
+    for i in range(number_actu):
+        for j_wave in range(number_wl_matrix):
+
+            DHInteractionMatrix[2 * j_wave * int(size_DH_pix):(2 * j_wave + 1) * int(size_DH_pix),
+                                i] = FullInteractionMatrix[j_wave][:int(twice_size_FP_pix) // 2,
+                                                                   i][where_mask_flatten]
+            DHInteractionMatrix[(2 * j_wave + 1) * int(size_DH_pix):(2 * j_wave + 2) * int(size_DH_pix),
+                                i] = FullInteractionMatrix[j_wave][int(twice_size_FP_pix) // 2:,
+                                                                   i][where_mask_flatten]
 
     return DHInteractionMatrix
 
@@ -424,8 +562,10 @@ def calc_efc_solution(mask, Result_Estimate, inversed_jacobian, testbed: Testbed
     mask:   2D Binary mask 
         dark hole region
 
-    Result_Estimate:    2D array 
-        can be complex, focal plane electric field
+    Result_Estimate:  list of 2D complex array 
+        list is the number of wl in the estimation, usually 1 or testbed.nb_wav
+        Each arrays are of size of sixe [dimEstim, dimEstim]. 
+        estimation of focal plane EF
 
     inversed_jacobian:  2D array
         inverse of the jacobian matrix linking the
@@ -440,11 +580,15 @@ def calc_efc_solution(mask, Result_Estimate, inversed_jacobian, testbed: Testbed
                     voltage to apply on each deformable mirror actuator
 
     """
+    EF_vector = np.zeros(2 * int(np.sum(mask)) * len(Result_Estimate))
 
-    EF_vector = np.zeros(2 * int(np.sum(mask)))
-    Resultat_cropdh = Result_Estimate[np.where(mask == 1)]
-    EF_vector[0:int(np.sum(mask))] = np.real(Resultat_cropdh).flatten()
-    EF_vector[int(np.sum(mask)):] = np.imag(Resultat_cropdh).flatten()
+    for i_wave, estimate_at_this_wave in enumerate(Result_Estimate):
+        Resultat_cropdh = estimate_at_this_wave[np.where(mask == 1)]
+        EF_vector[i_wave * 2 * int(np.sum(mask)):(i_wave * 2 + 1) *
+                  int(np.sum(mask))] = np.real(Resultat_cropdh).flatten()
+        EF_vector[(i_wave * 2 + 1) * int(np.sum(mask)):(i_wave * 2 + 2) *
+                  int(np.sum(mask))] = np.imag(Resultat_cropdh).flatten()
+
     produit_mat = np.dot(inversed_jacobian, EF_vector)
 
     return testbed.basis_vector_to_act_vector(produit_mat)
@@ -462,8 +606,10 @@ def calc_em_solution(mask, Result_Estimate, Hessian_Matrix, Jacobian, testbed: T
     mask:               Binary mask
              corresponding to the dark hole region
 
-    Result_Estimate:    2D array
-             can be complex, focal plane electric field
+    Result_Estimate: list of 2D complex array 
+        list is the number of wl in the estimation, usually 1 or testbed.nb_wav
+        Each arrays are of size of sixe [dimEstim, dimEstim]. 
+        estimation of focal plane EF
 
     Hessian_Matrix:     2D array 
             Hessian matrix of the DH energy
@@ -481,9 +627,12 @@ def calc_em_solution(mask, Result_Estimate, Hessian_Matrix, Jacobian, testbed: T
         voltage to apply on each deformable mirror actuator
 
     """
+    # probably not working in polychromatic yet
+    if len(Result_Estimate)>1:
+        raise Exception("EM correction does not workin polychromatic")
 
     # With notations from Potier PhD eq 4.74 p78:
-    Eab = Result_Estimate[np.where(mask == 1)]
+    Eab = Result_Estimate[0][np.where(mask == 1)]
     realb0 = np.real(np.dot(np.transpose(np.conjugate(Jacobian)), Eab)).flatten()
     produit_mat = np.dot(Hessian_Matrix, realb0)
 
@@ -504,8 +653,10 @@ def calc_strokemin_solution(mask, Result_Estimate, Jacob_trans_Jacob, Jacobian, 
     mask:               Binary mask
              corresponding to the dark hole region
 
-    Result_Estimate:    2D array
-             can be complex, focal plane electric field
+    Result_Estimate: list of 2D complex array 
+        list is the number of wl in the estimation, usually 1 or testbed.nb_wav
+        Each arrays are of size of sixe [dimEstim, dimEstim]. 
+        estimation of focal plane EF
 
     Jacob_trans_Jacob:     2D array 
             Jabobian.Transpose(Jabobian) matrix
@@ -536,12 +687,14 @@ def calc_strokemin_solution(mask, Result_Estimate, Jacob_trans_Jacob, Jacobian, 
     pixel_in_mask = np.sum(mask)
 
     # With notations from Potier PhD eq 4.74 p78:
-    Eab = Result_Estimate[np.where(mask == 1)]
+    Eab = np.zeros(int(np.sum(mask)) * len(Result_Estimate), dtype=complex)
+    for i_wave, estimate_at_this_wave in enumerate(Result_Estimate):
+        Eab[i_wave * int(np.sum(mask)):(i_wave + 1) *
+            int(np.sum(mask))] = estimate_at_this_wave[np.where(mask == 1)]
 
     d0 = np.sum(np.abs(Eab)**2) / pixel_in_mask
     M0 = Jacob_trans_Jacob / pixel_in_mask
     realb0 = np.real(np.dot(np.transpose(np.conjugate(Jacobian)), Eab)).flatten() / pixel_in_mask
-
     Identity_M0size = np.identity(M0.shape[0])
 
     # we put this keyword to True to do at least 1 try
@@ -612,8 +765,10 @@ def calc_steepest_solution(mask, Result_Estimate, Hessian_Matrix, Jacobian, test
     ----------
     mask: Binary mask 
         corresponding to the dark hole region
-    Result_Estimate: 2D array 
-        can be complex, focal plane electric field
+    Result_Estimate: list of 2D complex array 
+        list is the number of wl in the estimation, usually 1 or testbed.nb_wav
+        Each arrays are of size of sixe [dimEstim, dimEstim]. 
+        estimation of focal plane EF
     Hessian_Matrix: 2D array 
          Hessian matrix of the DH energy
     
@@ -629,9 +784,12 @@ def calc_steepest_solution(mask, Result_Estimate, Hessian_Matrix, Jacobian, test
          voltage to apply on each deformable mirror actuator
    
     """
+    # probably not working in polychromatic yet
+    if len(Result_Estimate)>1:
+        raise Exception("steepest correction does not workin polychromatic")
 
     Eab = np.zeros(int(np.sum(mask)))
-    Resultat_cropdh = Result_Estimate[np.where(mask == 1)]
+    Resultat_cropdh = Result_Estimate[0][np.where(mask == 1)]
     Eab = np.real(np.dot(np.transpose(np.conjugate(Jacobian)), Resultat_cropdh)).flatten()
     pas = 2e3
     solution = pas * 2 * Eab

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -7,7 +7,7 @@ from Asterix.utils import resizing, invert_svd, save_plane_in_fits
 from Asterix.optics import DeformableMirror, Testbed
 
 
-def create_pw_matrix(testbed: Testbed, amplitude, posprobes, dimEstim, cutsvd, wavelength, **kwargs):
+def create_pw_matrix(testbed: Testbed, amplitude, posprobes, dimEstim, cutsvd, wavelengths=None, **kwargs):
     """
     Build the interaction matrix for pair-wise probing.
 
@@ -25,8 +25,9 @@ def create_pw_matrix(testbed: Testbed, amplitude, posprobes, dimEstim, cutsvd, w
             size of the output image after resizing in pixels
     cutsvd:     float
             value not to exceed for the inverse eigeinvalues at each pixels
-    wavelength: float
-            wavelength in meter
+    wavelengths : float or list of floats. 
+            Default is all the wl of the testbed testbed.wav_vec
+            wavelengths in m.
 
 
     Returns
@@ -40,6 +41,28 @@ def create_pw_matrix(testbed: Testbed, amplitude, posprobes, dimEstim, cutsvd, w
                 before regularization
     
     """
+
+    if 'wavelength' in kwargs:
+            raise Exception("""create_pw_matrix() function is polychromatic, 
+                do not use wavelength keyword.
+                Use wavelengths keyword even for monochromatic intensity""")
+
+    if wavelengths is None:
+        wavelength_vec = testbed.wav_vec
+
+    elif isinstance(wavelengths, (float, int)):
+        wavelength_vec = [wavelengths]
+    else:
+        wavelength_vec = wavelengths
+    if wavelengths is None:
+        wavelength_vec = testbed.wav_vec
+
+    elif isinstance(wavelengths, (float, int)):
+        wavelength_vec = [wavelengths]
+    else:
+        wavelength_vec = wavelengths
+
+
     numprobe = len(posprobes)
     deltapsik = np.zeros((numprobe, dimEstim, dimEstim), dtype=complex)
     probephase = np.zeros((numprobe, testbed.dim_overpad_pupil, testbed.dim_overpad_pupil))
@@ -51,7 +74,7 @@ def create_pw_matrix(testbed: Testbed, amplitude, posprobes, dimEstim, cutsvd, w
 
     psi0 = testbed.todetector()
     k = 0
-
+    
     for i in posprobes:
 
         Voltage_probe = np.zeros(DM_probe.number_act)

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -22,6 +22,9 @@ def create_pw_matrix(testbed: Testbed,
     Build the interaction matrix for pair-wise probing.
 
     AUTHOR : Axel Potier
+    Modified by Johan Mazoyer
+
+    Sept 2022 : .fits file saving directly in the function to clean up estimator
 
     Parameters
     ----------


### PR DESCRIPTION
added estimation and correction in polychromatic light. 

For polychromatic estimation / correction : 
 - 'centralwl': only the central bandwidth is used for estimation / correction. Can work with pw and perfect estimation
 - 'broadband_pwprobes': probes images used for PW are broadband (of BW Delta_wav). Matrixes are at central bandwidth. Only for pw, this is ~ what we did on sphere on sky
 - 'multiwl': nb_wav images are used for estimation and there are nb_wav matrix of estimation / correction
This parameter is only for the estimation / correction. The bandwidth of the images are
still parametrized in [modelconfig] (nb_wav, Delta_wav)
If monochromatic images (nb_wav = 1 or Delta_wav = 0), all these options are equivalent

I've tested it and caught a lot of bugs but I'd be happy if you review it both and play with it with wrapped vortex before merging it to be sure its doing what's expected ! 
    
    