### PR TITLE
Sort results directories with timestamp

### DIFF
--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -303,7 +303,7 @@ onbench=True
 
 [SIMUconfig]
     #Simulation close loop parameters
-    Name_Experiment = 'thd_sim'
+    Name_Experiment = 'asterix_sim'
 
     #Amplitude aberrations
     set_amplitude_abb=True

--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -303,7 +303,7 @@ onbench=True
 
 [SIMUconfig]
     #Simulation close loop parameters
-    Name_Experiment = 'First_Simulation'
+    Name_Experiment = 'thd_sim'
 
     #Amplitude aberrations
     set_amplitude_abb=True

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -73,10 +73,10 @@ def runthd2(parameter_file,
     Name_Experiment = create_experiment_dir(append=SIMUconfig["Name_Experiment"])
 
     # Initialize all directories
-    model_local_dir = os.path.join(Data_dir, "Model_local") + os.path.sep
-    matrix_dir = os.path.join(Data_dir, "Interaction_Matrices") + os.path.sep
-    result_dir = os.path.join(Data_dir, "Results", Name_Experiment) + os.path.sep
-    labview_dir = os.path.join(Data_dir, "Labview") + os.path.sep
+    model_local_dir = os.path.join(Data_dir, "Model_local")
+    matrix_dir = os.path.join(Data_dir, "Interaction_Matrices")
+    result_dir = os.path.join(Data_dir, "Results", Name_Experiment)
+    labview_dir = os.path.join(Data_dir, "Labview")
 
     # Create all optical elements of the THD
     entrance_pupil = Pupil(modelconfig,

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -3,7 +3,7 @@
 
 import os
 
-from Asterix.utils import get_data_dir, read_parameter_file
+from Asterix.utils import create_experiment_dir, get_data_dir, read_parameter_file
 from Asterix.optics import Pupil, Coronagraph, DeformableMirror, Testbed
 from Asterix.wfsc import Estimator, Corrector, MaskDH, correction_loop, save_loop_results
 
@@ -70,7 +70,7 @@ def runthd2(parameter_file,
     Correctionconfig = config["Correctionconfig"]
     Loopconfig = config["Loopconfig"]
     SIMUconfig = config["SIMUconfig"]
-    Name_Experiment = SIMUconfig["Name_Experiment"]
+    Name_Experiment = create_experiment_dir(append=SIMUconfig["Name_Experiment"])
 
     # Initialize all directories
     model_local_dir = os.path.join(Data_dir, "Model_local") + os.path.sep

--- a/Asterix/optics/optical_systems.py
+++ b/Asterix/optics/optical_systems.py
@@ -23,7 +23,7 @@ class OpticalSystem:
 
     AUTHOR : Johan Mazoyer
 
-        """
+    """
 
     def __init__(self, modelconfig):
         """

--- a/Asterix/utils/hci_metrics.py
+++ b/Asterix/utils/hci_metrics.py
@@ -31,11 +31,13 @@ def plot_contrast_curves(reduced_data,
                          path='',
                          filename=''):
     """
-    Plot and save in pdf contrast curves from a image or a cube of images (assumed to be 
+    Plot contrast curves from image or image cube as pdf file to disk.
+
+    Plot and contrast curves from an image or a cube of images (assumed to be
     several iterations of a loop) using concentric rings.
-    You can chooose the center, the size of the rings, the type of contrast (mean or std)
+    You can choose the center, the size of the rings, the type of contrast (mean or std)
     The DH is set using a binary mask (1s where the DH is, 0 elsewhere)
-    The abcisse unit can be in pixel mas or in lambda/D.
+    The abscissa unit can be in pixel mas or in lambda/D.
 
     AUTHOR: J. Mazoyer
     16/03/2022
@@ -65,7 +67,7 @@ def plot_contrast_curves(reduced_data,
         resolution of the focal plane in # of pixel per lambda/D (useful for testbed)
         If set the absciss unit will be in lambda/D 
 
-    numberofmas_per_pix: float, defaut None
+    numberofmas_per_pix: float, default None
         resolution of the focal plane in # of mas per pixel  (useful for real instruments)
         If set the absciss unit will be in mas
         
@@ -79,7 +81,7 @@ def plot_contrast_curves(reduced_data,
         path where to save the pdf plot file
     
     filename: string, default ''
-        base of the file name to save the pdf plot file
+        Filename prefix for pdf files of the plots saved to disk.
     
     legend_labels: string array of the same number of images in the first cube, default None
         Name of the legend labels,
@@ -87,8 +89,10 @@ def plot_contrast_curves(reduced_data,
         If None and if the array is of dimension 3, we assume these are iterations
 
     """
-
-    filename = filename + '_ContrastCurve_DH'
+    if filename != '':
+        filename += '_ContrastCurve_DH'
+    else:
+        filename += 'ContrastCurve_DH'
 
     if numberofpix_per_loD is not None and numberofmas_per_pix is None:
         # absice is in lambda over D

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -292,6 +292,17 @@ def get_data_dir(env_var_name="ASTERIX_DATA_PATH", config_in=None, datadir="aste
 
 
 def create_experiment_dir(append=''):
+    """
+    Create the name for an experiment directory.
+
+    Create a timestamp including current year, month and day, as well as hour, minute and second. Add the passed
+    suffix 'append' before returning it.
+
+    Parameters
+    ----------
+    append : string
+        Filename suffix to add to timestamp, default is ''.
+    """
     time_stamp = time.time()
     date_time_string = datetime.datetime.fromtimestamp(time_stamp).strftime("%Y%m%d_%H-%M-%S")
 

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -256,7 +256,7 @@ def get_data_dir(env_var_name="ASTERIX_DATA_PATH", config_in=None, datadir="aste
     """
     Create a path to the local data directory.
 
-    If the environment variable `ASTERIX_DATA_PATH` exists, this is returned as the full data path and the input 'datadir'
+    If the environment variable `env_var_name` exists, this is returned as the full data path and the input 'datadir'
         is ignored. You can set this individually on your OS.
     If the environment variable does not exist (default for all new users) but the user adapted the ini file and
         accesses the 'Data_dir' entry, the configfile entry is returned and 'datadir' is ignored.
@@ -266,10 +266,12 @@ def get_data_dir(env_var_name="ASTERIX_DATA_PATH", config_in=None, datadir="aste
 
     Parameters
     ----------
-    env_var_name : string
-        Environment variable for optional override.
-    datadir : string
-        Name of the top-level data directory.
+    env_var_name : string, optional
+        Environment variable for optional override, default 'ASTERIX_DATA_PATH'.
+    config_in : string, optional
+        Directory name passed through from configuration file.
+    datadir : string, optional
+        Name of the top-level data directory, default "asterix_data".
 
     Returns
     -------

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -3,6 +3,7 @@
 import errno
 import sys
 import os
+import time
 
 import datetime
 import random
@@ -288,3 +289,14 @@ def get_data_dir(env_var_name="ASTERIX_DATA_PATH", config_in=None, datadir="aste
         if not os.path.isdir(home_path):
             os.mkdir(home_path)
         return home_path
+
+
+def create_experiment_dir(append=''):
+    time_stamp = time.time()
+    date_time_string = datetime.datetime.fromtimestamp(time_stamp).strftime("%Y%m%d_%H-%M-%S")
+
+    if append != "":
+        append = "_" + append
+
+    experiment_folder = date_time_string + append
+    return experiment_folder

--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -417,22 +417,22 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
     # SAVING...
     header = from_param_to_header(config)
 
-    fits.writeto(os.path.join(result_dir, "FocalPlane_Intensities" + ".fits"),
+    fits.writeto(os.path.join(result_dir, "FocalPlane_Intensities.fits"),
                  np.array(FP_Intensities),
                  header,
                  overwrite=True)
 
-    fits.writeto(os.path.join(result_dir, "Mean_Contrast_DH" + ".fits"),
+    fits.writeto(os.path.join(result_dir, "Mean_Contrast_DH.fits"),
                  np.array(meancontrast),
                  header,
                  overwrite=True)
 
-    fits.writeto(os.path.join(result_dir, "estimationFP_RE" + ".fits"),
+    fits.writeto(os.path.join(result_dir, "estimationFP_RE.fits"),
                  np.real(np.array(EF_estim)),
                  header,
                  overwrite=True)
 
-    fits.writeto(os.path.join(result_dir, "estimationFP_IM" + ".fits"),
+    fits.writeto(os.path.join(result_dir, "estimationFP_IM.fits"),
                  np.imag(np.array(EF_estim)),
                  header,
                  overwrite=True)
@@ -502,7 +502,7 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
     #                  header,
     #                  overwrite=True)
 
-    config.filename = os.path.join(result_dir, "Simulation_parameters" + ".ini")
+    config.filename = os.path.join(result_dir, "Simulation_parameters.ini")
     config.write()
 
     plt.figure()
@@ -510,7 +510,7 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
     plt.yscale("log")
     plt.xlabel("Number of iterations")
     plt.ylabel("Mean contrast in Dark Hole")
-    plt.savefig(os.path.join(result_dir, "Mean_Contrast_DH" + ".pdf"))
+    plt.savefig(os.path.join(result_dir, "Mean_Contrast_DH.pdf"))
     plt.close()
     plot_contrast_curves(np.asarray(FP_Intensities),
                          delta_raddii=3,

--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -384,25 +384,24 @@ def correction_loop_1matrix(testbed: Testbed,
 
 def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScience, result_dir):
     """
-    Save the result from a correction loop in result_dir.
+    Save the results from a correction loop into the directory 'result_dir'.
     
-    All fits files have all parameters in their header.
-    The config is also saved in an .ini file.
+    All fits files have all parameters in their header. The configfile is also saved, to an .ini file.
 
     AUTHOR : Johan Mazoyer
     
     Parameters
     ----------
-    CorrectionLoopResult: dict 
-        dictionary containing the results from correction_loop_1matrix() or correction_loop()
-    config: dict
-        complete parameter dictionary
-    testbed: OpticalSystem
-        an OpticalSystem object which describes your testbed
-    MaskScience: 2d numpy array
-        binary array of size [dimScience, dimScience] : dark hole mask
-    result_dir: path
-        directory where to save the results
+    CorrectionLoopResult : dict
+        Dictionary containing the results from correction_loop_1matrix() or correction_loop().
+    config : dict
+        Dictionary holding the configuration from the input parameter file.
+    testbed : OpticalSystem
+        An OpticalSystem object which describes your testbed.
+    MaskScience : 2d numpy array
+        Binary array of size [dimScience, dimScience]: dark hole mask.
+    result_dir : string
+        Directory to save the results to.
     """
 
     if not os.path.exists(result_dir):
@@ -415,26 +414,25 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
     nb_total_iter = CorrectionLoopResult["nb_total_iter"]
     EF_estim = CorrectionLoopResult["EF_estim"]
 
-    ## SAVING...
+    # SAVING...
     header = from_param_to_header(config)
 
-    current_time_str = datetime.datetime.today().strftime("%Y%m%d_%Hh%Mm%Ss")
-    fits.writeto(os.path.join(result_dir, current_time_str + "_FocalPlane_Intensities" + ".fits"),
+    fits.writeto(os.path.join(result_dir, "FocalPlane_Intensities" + ".fits"),
                  np.array(FP_Intensities),
                  header,
                  overwrite=True)
 
-    fits.writeto(os.path.join(result_dir, current_time_str + "_Mean_Contrast_DH" + ".fits"),
+    fits.writeto(os.path.join(result_dir, "Mean_Contrast_DH" + ".fits"),
                  np.array(meancontrast),
                  header,
                  overwrite=True)
 
-    fits.writeto(os.path.join(result_dir, current_time_str + "_estimationFP_RE" + ".fits"),
+    fits.writeto(os.path.join(result_dir, "estimationFP_RE" + ".fits"),
                  np.real(np.array(EF_estim)),
                  header,
                  overwrite=True)
 
-    fits.writeto(os.path.join(result_dir, current_time_str + "_estimationFP_IM" + ".fits"),
+    fits.writeto(os.path.join(result_dir, "estimationFP_IM" + ".fits"),
                  np.imag(np.array(EF_estim)),
                  header,
                  overwrite=True)
@@ -461,12 +459,12 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
     plt.figure()
 
     for j, DM_name in enumerate(testbed.name_of_DMs):
-        fits.writeto(os.path.join(result_dir, current_time_str + '_' + DM_name + "_phases" + ".fits"),
+        fits.writeto(os.path.join(result_dir, f"{DM_name}_phases.fits"),
                      DM_phases[j],
                      header,
                      overwrite=True)
 
-        fits.writeto(os.path.join(result_dir, current_time_str + '_' + DM_name + "_strokes" + ".fits"),
+        fits.writeto(os.path.join(result_dir, f"{DM_name}_strokes.fits"),
                      DMstrokes[j],
                      header,
                      overwrite=True)
@@ -476,7 +474,7 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
                                                  DM.number_act]
         indice_acum_number_act += DM.number_act
 
-        fits.writeto(os.path.join(result_dir, current_time_str + '_' + DM_name + "_voltages" + ".fits"),
+        fits.writeto(os.path.join(result_dir,  f"{DM_name}_voltages.fits"),
                      voltage_DMs_tosave,
                      header,
                      overwrite=True)
@@ -487,7 +485,7 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
     plt.xlabel("Number of iterations")
     plt.ylabel("DM Strokes (nm)")
     plt.legend()
-    plt.savefig(os.path.join(result_dir, current_time_str + "_DM_Strokes" + ".pdf"))
+    plt.savefig(os.path.join(result_dir, "DM_Strokes" + ".pdf"))
     plt.close()
     # TODO Now FP_Intensities are save with photon noise if it's on
     # We need to do them without just to save in the results
@@ -499,12 +497,12 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
     #             FP_Intensities[i] * testbed.normPupto1 *
     #             config["SIMUconfig"]["nb_photons"])
 
-    #     fits.writeto(os.path.join(result_dir , current_time_str + "_NoPhoton_noise" + ".fits"),
+    #     fits.writeto(os.path.join(result_dir, "NoPhoton_noise" + ".fits"),
     #                  FP_Intensities_photonnoise,
     #                  header,
     #                  overwrite=True)
 
-    config.filename = os.path.join(result_dir, current_time_str + "_Simulation_parameters" + ".ini")
+    config.filename = os.path.join(result_dir, "Simulation_parameters" + ".ini")
     config.write()
 
     plt.figure()
@@ -512,12 +510,11 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
     plt.yscale("log")
     plt.xlabel("Number of iterations")
     plt.ylabel("Mean contrast in Dark Hole")
-    plt.savefig(os.path.join(result_dir, current_time_str + "_Mean_Contrast_DH" + ".pdf"))
+    plt.savefig(os.path.join(result_dir, "Mean_Contrast_DH" + ".pdf"))
     plt.close()
     plot_contrast_curves(np.asarray(FP_Intensities),
                          delta_raddii=3,
                          numberofpix_per_loD=config["modelconfig"]["Science_sampling"],
                          type_of_contrast='mean',
                          mask_DH=MaskScience,
-                         path=result_dir,
-                         filename=current_time_str)
+                         path=result_dir)

--- a/source/correction.rst
+++ b/source/correction.rst
@@ -3,20 +3,20 @@
 Correction
 ---------------
 
-This section describes how to correct the electrical field in focal plane in Asterix. Several correction modes 
+This section describes how to correct the electrical field in the focal plane in Asterix. Several correction modes
 are possible in Asterix. Files can be found in :ref:`correctionfiles-label`;
 
 - an initialization (e.g. Jacobian matrix) ``Corrector.__init__`` : The initialization requires previous initialization of the testbed and of the estimator.
-- a matrix update function ``Corrector.update_matrices`` This function is called once during initalization abd then each time we need to recompute the Jacobian in the middle of the correction using usign differents DM voltages as starting point.
-- a correction function ``Corrector.toDM_voltage`` which takes the results of an estimation and returns the DM Voltage. 
+- a matrix update function ``Corrector.update_matrices`` This function is called once during initialization and then each time we need to recompute the Jacobian in the middle of the correction using different DM voltages as the starting point.
+- a correction function ``Corrector.toDM_voltage`` which takes the results of an estimation and returns the DM voltages.
 
 Dark Hole Mask Definition
 +++++++++++++++++++++++++++++++
 
 The estimation estimates the focal plane electrical field in a large zone larger than the
-correction zone achievable by the DMs. We can reduce the focal plane correction using binary mask
+correction zone achievable by the DMs. We can reduce the focal plane correction using a binary mask.
 
-``MaskDH`` is a very small class to do all the mask related stuff: retrieve parameters and measure the mask 
+``MaskDH`` is a very small class to do all the mask related stuff: retrieve parameters, measure the mask
 and measure the string to save matrices.
 
 .. code-block:: python
@@ -26,21 +26,21 @@ and measure the string to save matrices.
 
     Correctionconfig = config["Correctionconfig"]
     mask_dh = MaskDH(Correctionconfig) # read the configuration
-    science_mask_dh = mask_dh.creatingMaskDH(testbed.dimScience, testbed.Science_sampling, **kwargs) # create a mask at a given size and resolution
+    science_mask_dh = mask_dh.creatingMaskDH(testbed.dimScience, testbed.Science_sampling, **kwargs) # create a mask with a given size and resolution
 
 
                                             
-Several shape are possible for the DH using the parameter ``DH_shape``:
+Several shapes are possible for the DH using the input parameter ``DH_shape``:
 
-- "square" DH. Size can be defined using the position of the corners in :math:`{\lambda}`/ D with the parameter parameter ``corner_pos``: [xmin, xmax, ymin, ymax], with 0 beeing the star position. ``DH_side`` parameter is not used and the symetry of the DH is only set using the corners positions.
-- "circle" DH Size can be defined using parameters 
-    - ``Sep_Min_Max`` : 2 element array [iwa, owa] inner and outer working angle of the dark hole
+- "square" DH. Size can be defined using the position of the corners in :math:`{\lambda}`/ D with the parameter ``corner_pos``: [xmin, xmax, ymin, ymax], with 0 being the star position. ``DH_side`` parameter is not used and the symmetry of the DH is only set using the corners positions.
+- "circle" DH Size can be defined using the parameters
+    - ``Sep_Min_Max`` : 2 element array [iwa, owa], inner and outer working angle of the dark hole
     - ``circ_offset`` : if half DH, we remove separations closer than circ_offset (in :math:`{\lambda}`/ D) from the DH 
     - ``circ_angle`` : if half DH, we remove the angles closer than circ_angle (in degrees) from the DH 
     - ``DH_side`` : can be set to "top", "bottom", "left", "right" and "full" to create full and half dark hole.
 - "noDH" DH. In this mode, the mask is just 1 everywhere. 
 
-``creatingMaskDH()`` function has been set up with a mode where each optical plane is saved to .fits file for debugging purposes.
+``creatingMaskDH()`` function has been set up with a mode where each optical plane is saved to a .fits file for debugging purposes.
 To use this option, set up the keyword ``dir_save_all_planes`` to an existing path directory.
 
 Interaction Matrix
@@ -134,7 +134,7 @@ Correction loop
 +++++++++++++++++++++++++++++++
 
 ``correction_loop.py`` contains 3 functions. The first one is ``correction_loop_1matrix()`` which is a for loop repeated
-``Number_matrix`` , which update the Interference Matrix and run the ``correction_loop_1matrix()`` at each iteration.
+``Number_matrix`` of times , which updates the interaction matrix and runs ``correction_loop_1matrix()`` in each iteration.
 
 
 The ``correction_loop_1matrix()`` function is a loop running ``Nbiter_corr`` times that is basically doing:
@@ -145,6 +145,6 @@ The ``correction_loop_1matrix()`` function is a loop running ``Nbiter_corr`` tim
 
 * application on DM and measure of DM
 
-The results are stored in a dictionnary then sent to ``save_loop_results()`` for ploting and saving in the folder
-named '/Results/Name_experiement' where ``Name_Experiment`` is a parameter. All .fits saved have all parameters in the header. 
-The config (with updated parameters) is also saved in a .ini file, so you can run the same experiment. 
+The results are stored in a dictionary and then sent to ``save_loop_results()`` for plotting and saving in the folder
+named '/Results/timestamp-Name_experiement' where ``Name_Experiment`` is a parameter from the configuration file. All saved .fits files have all parameters in their headers.
+The config (with updated parameters) is also saved in a .ini file, so you can run the same experiment again at a later time.

--- a/source/run_asterix.rst
+++ b/source/run_asterix.rst
@@ -54,7 +54,7 @@ When you run Asterix, the first time several directories will be created:
 
 * Interaction_Matrices/ is the directory where Matrices are saved, both for estimation (e.g. pair wise) and correction (e.g. Interaction Matrices).
 
-* Results/ where it will save the results of your correction. The code will automatically create a directory in Results/Name_Experiment/ where 'Name_Experiment' is a parameter in the .ini file.
+* Results/ where it will save the results of your correction. The code will automatically create a directory in Results/Name_Experiment/ where 'Name_Experiment' is a parameter in the .ini file and will be preceded by a time stamp.
 
 * Labview/ Finally, if the parameter 'onbench' is set to True, the code will create a directory to put matrices in the format needed to control the THD2 testbed. 
 


### PR DESCRIPTION
PR for a suggestion:

The current output structure of experiments run by Asterix is as follows:
```bash
Interaction_Matrices
  |-- several .fits files
Labview
  |-- several .fits files
Model_local
  |-- several .fits files
Results
  |-- exp_dir1
  |-- exp_dir2
  |--...
```
where `exp_dir1` and so forth are strings put into the configuration file or passed to the experiment function at runtime. This means that for each new experiment, a new string must be passed manually, otherwise the results will be overwritten.

While this might be fine (although not recommended because you lose the option to compare to previous runs) when debugging, this can be extremely destructive when several different runs are intended to be kept on purpose for good, because it is easy to forget to change the experiment name.

This PR changes this in such a way that each experiment directory under `Results` gets a time stamp appended at the beginning of its name, to avoid overwriting of files. This will prevent any overwriting as different runs are started and looks like this:
```bash
Interaction_Matrices
  |-- several .fits files
Labview
  |-- several .fits files
Model_local
  |-- several .fits files
Results
  |-- 20221001_09-40-27_exp_dir1
  |-- 20221001_09-43-05_exp_dir2
  |--...
```

I believe the main objection might be that people could plaster their local drive with .fits files while running experiments over and over, but I argue that is is much easier and faster to go into your simulation directory regularly to clean out what you don't need while having the safety that you don't lose work you actually want, by accident, rather than to have to redo certain runs just because you forgot to change the experiment string.

In short, this PR creates the name of the experiment directory from the current date and time stamp, which avoids overwriting of result files.