### PR TITLE
Add option to use custom-made DH mask with text "CNRS"

### DIFF
--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -247,7 +247,7 @@ onbench=True
     
     # Dark Hole Mask parameters
 
-    # "circle", "square" or "noDH"
+    # "circle", "square", "noDH" or "custom"
     # Not case sensitive
     DH_shape = "circle"
 
@@ -255,7 +255,7 @@ onbench=True
     # Position of the corners of the DH in lambda/Entrance_pupil_diameter
     corner_pos = 2.7,11.7,-11.7,11.7 # xmin, xmax, ymin, ymax
 
-    #if DH_shape == 'circle'
+    # if DH_shape == 'circle'
     # "Full", "Left", "Right", "Top", "Bottom" to select one side of the fov.
     # Not case sensitive
     DH_side = "Full"
@@ -263,9 +263,12 @@ onbench=True
     Sep_Min_Max = 3.5,10
     #if circle inner and outer radii of the circle DH size in lambda/D
 
-    #if circle
+    #if DH_shape == 'circle;
     circ_offset = 0 # if circ_side != "Full", remove separation closer than circ_offset (in lambda/Entrance_pupil_diameter)
-    circ_angle = 15 # if circ_side != "Full", we remove the angles closer than circ_angle (in degrees) from the DH 
+    circ_angle = 15 # if circ_side != "Full", we remove the angles closer than circ_angle (in degrees) from the DH
+
+    # if DH_shape == 'custom'
+    dh_mask_fname = <your-path-and-fname>
 
     # Actuator basis: currently 'fourier' or 'actuator'
     # Same parameter for all DMs

--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -263,7 +263,7 @@ onbench=True
     Sep_Min_Max = 3.5,10
     #if circle inner and outer radii of the circle DH size in lambda/D
 
-    #if DH_shape == 'circle;
+    #if DH_shape == 'circle'
     circ_offset = 0 # if circ_side != "Full", remove separation closer than circ_offset (in lambda/Entrance_pupil_diameter)
     circ_angle = 15 # if circ_side != "Full", we remove the angles closer than circ_angle (in degrees) from the DH
 

--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -267,9 +267,6 @@ onbench=True
     circ_offset = 0 # if circ_side != "Full", remove separation closer than circ_offset (in lambda/Entrance_pupil_diameter)
     circ_angle = 15 # if circ_side != "Full", we remove the angles closer than circ_angle (in degrees) from the DH
 
-    # if DH_shape == 'custom'
-    dh_mask_fname = <your-path-and-fname>
-
     # Actuator basis: currently 'fourier' or 'actuator'
     # Same parameter for all DMs
     # Not case sensitive

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -90,7 +90,7 @@ def runthd2(parameter_file,
     # Concatenate into the full testbed optical system
     thd2 = Testbed([entrance_pupil, DM1, DM3, corono], ["entrancepupil", "DM1", "DM3", "corono"])
 
-    # The following line can be used to change the DM which aplpies PW probes. This could be used to use the DM out of
+    # The following line can be used to change the DM which applies PW probes. This could be used to use the DM out of
     # the pupil plane.
     # This is an unusual option so not in the param file and not well documented.
     # thd2.name_DM_to_probe_in_PW = "DM1"

--- a/Asterix/wfsc/maskDH.py
+++ b/Asterix/wfsc/maskDH.py
@@ -1,6 +1,7 @@
 # pylint: disable=invalid-name
 # pylint: disable=trailing-whitespace
 
+import platform
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 from Asterix.utils import save_plane_in_fits
@@ -75,8 +76,14 @@ class MaskDH:
             return maskDH
 
         elif self.DH_shape == "custom":
+            your_os = platform.system()
             img = Image.new(mode="L", size=(dimFP, dimFP))
-            fnt = ImageFont.truetype('/Library/Fonts/Arial Bold.ttf', size=int(dimFP / 4))
+            if your_os == "Darwin":
+                fnt = ImageFont.truetype('/Library/Fonts/Arial Bold.ttf', size=int(dimFP / 4))
+            elif your_os == "Linux":
+                fnt = ImageFont.truetype('/usr/share/fonts/truetype/freefont/FreeSerif.ttf', size=int(dimFP / 4))
+            else:
+                raise OSError("The path to fonts is not implemented for your OS yet.")
             d = ImageDraw.Draw(img)
             d.text((int(dimFP / 4), int(dimFP / 4)), "C N \nR S", font=fnt, fill=1)
             maskDH = np.flipud(np.asarray(img, dtype=float))

--- a/Asterix/wfsc/maskDH.py
+++ b/Asterix/wfsc/maskDH.py
@@ -76,9 +76,9 @@ class MaskDH:
 
         elif self.DH_shape == "custom":
             img = Image.new(mode="L", size=(dimFP, dimFP))
-            fnt = ImageFont.truetype('/Library/Fonts/Arial Black.ttf', size=int(dimFP / 4))
+            fnt = ImageFont.truetype('/Library/Fonts/Arial Bold.ttf', size=int(dimFP / 4))
             d = ImageDraw.Draw(img)
-            d.text((int(dimFP / 4), int(dimFP * 0.175)), "C N \nR S", font=fnt, fill=1)
+            d.text((int(dimFP / 4), int(dimFP / 4)), "C N \nR S", font=fnt, fill=1)
             maskDH = np.asarray(img, dtype=float)
 
         elif self.DH_shape == "square":

--- a/Asterix/wfsc/maskDH.py
+++ b/Asterix/wfsc/maskDH.py
@@ -69,7 +69,7 @@ class MaskDH:
 
         """
         maskDH = np.ones((dimFP, dimFP))
-        xx, yy = np.meshgrid(np.arange(dimFP) - (dimFP) / 2, np.arange(dimFP) - (dimFP) / 2)
+        xx, yy = np.meshgrid(np.arange(dimFP) - dimFP / 2, np.arange(dimFP) - dimFP / 2)
         rr = np.hypot(yy, xx)
 
         if self.DH_shape == "nodh":

--- a/Asterix/wfsc/maskDH.py
+++ b/Asterix/wfsc/maskDH.py
@@ -79,7 +79,7 @@ class MaskDH:
             fnt = ImageFont.truetype('/Library/Fonts/Arial Bold.ttf', size=int(dimFP / 4))
             d = ImageDraw.Draw(img)
             d.text((int(dimFP / 4), int(dimFP / 4)), "C N \nR S", font=fnt, fill=1)
-            maskDH = np.asarray(img, dtype=float)
+            maskDH = np.flipud(np.asarray(img, dtype=float))
 
         elif self.DH_shape == "square":
             maskDH[xx < self.corner_pos[0] * FP_sampling] = 0

--- a/notebooks/create_text_arrays.ipynb
+++ b/notebooks/create_text_arrays.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f7a918c4",
+   "metadata": {},
+   "source": [
+    "# Create array images with text\n",
+    "\n",
+    "Sources:\n",
+    "- https://code-maven.com/create-images-with-python-pil-pillow\n",
+    "- https://python.plainenglish.io/generating-text-on-image-with-python-eefe4430fe77\n",
+    "- https://pillow.readthedocs.io/en/stable/reference/Image.html\n",
+    "- https://pillow.readthedocs.io/en/stable/reference/ImageFont.html?highlight=ImageFont"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3cd097f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from PIL import Image, ImageDraw, ImageFont"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01c89fa2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dimFP = 400\n",
+    "\n",
+    "img = Image.new(mode=\"L\", size=(dimFP,dimFP))\n",
+    "fnt = ImageFont.truetype('/Library/Fonts/Arial Black.ttf', size=int(dimFP/4))\n",
+    "d = ImageDraw.Draw(img)\n",
+    "d.text((int(dimFP/4),int(dimFP*0.2)), \"C N \\nR S\", font=fnt, fill=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03e1cd9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(img, cmap='Greys_r', origin='lower')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d561e7e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im_data = np.asarray(img, dtype=float)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7e96c7f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/create_text_arrays.ipynb
+++ b/notebooks/create_text_arrays.ipynb
@@ -27,6 +27,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "661e3ce5",
+   "metadata": {},
+   "source": [
+    "## CNRS"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "01c89fa2",
@@ -38,7 +46,8 @@
     "img = Image.new(mode=\"L\", size=(dimFP,dimFP))\n",
     "fnt = ImageFont.truetype('/Library/Fonts/Arial Black.ttf', size=int(dimFP/4))\n",
     "d = ImageDraw.Draw(img)\n",
-    "d.text((int(dimFP/4),int(dimFP*0.2)), \"C N \\nR S\", font=fnt, fill=1)"
+    "d.text((int(dimFP/4),int(dimFP*0.2)), \"C N \\nR S\", font=fnt, fill=1)\n",
+    "img = np.flipud(np.asarray(img, dtype=float))"
    ]
   },
   {
@@ -50,6 +59,49 @@
    "source": [
     "plt.imshow(img, cmap='Greys_r', origin='lower')\n",
     "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85297133",
+   "metadata": {},
+   "source": [
+    "## THD2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ff5c99b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dimFP = 400\n",
+    "\n",
+    "img = Image.new(mode=\"L\", size=(dimFP,dimFP))\n",
+    "fnt = ImageFont.truetype('/Library/Fonts/Arial Black.ttf', size=int(dimFP/4))\n",
+    "d = ImageDraw.Draw(img)\n",
+    "d.text((int(dimFP/10),int(dimFP*0.2)), \"T H D\\n2\", font=fnt, fill=1, align='right')\n",
+    "img = np.flipud(np.asarray(img, dtype=float))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6020b99d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(img, cmap='Greys_r', origin='lower')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9dc3db27",
+   "metadata": {},
+   "source": [
+    "## Convert to array if you want to save this to disk"
    ]
   },
   {


### PR DESCRIPTION
During the THD2 meeting today, @rgalicher and Pierre Baudoz were wondering whether we could dig a DH that spells out the text "CNRS" for the demo during the CNRS visit next week, like they did it once with "THD2". This PR adds this possibility.

The text "CNRS" is hard-coded for now but if there is ever another need for a custom DH with a text, this can be adapted. The DH created looks like this on the simulator:
![Screen Shot 2022-10-03 at 15 32 20](https://user-images.githubusercontent.com/29508965/193590927-b1118543-a621-435a-a6f2-65df4b013c9d.png)

I also added a notebook in which one can play around with how to create the DH mask you want.