### PR TITLE
Force the `diam_pup_in_pix` parameter to an even value (for now)

### DIFF
--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -32,7 +32,7 @@ onbench=True
     diam_pup_in_m = 8.3e-3
 
     # pupil diameter (in pixels)
-    diam_pup_in_pix = 125
+    diam_pup_in_pix = 100
 
     # overpadding pupil plane factor
     overpadding_pupilplane_factor = 2.0

--- a/Asterix/optics/optical_systems.py
+++ b/Asterix/optics/optical_systems.py
@@ -35,6 +35,10 @@ class OpticalSystem:
 
         """
 
+        if (modelconfig["diam_pup_in_pix"] % 2 == 1) :
+            raise ValueError("Please set diam_pup_in_pix parameter to an even number.")
+        
+
         # pupil in pixel
         self.prad = modelconfig["diam_pup_in_pix"] / 2
 


### PR DESCRIPTION
Odd number in the `diam_pup_in_pix` parameter lead to `self.prad` value to be non integer.
I thought this was not a problem (I actually released this constraint a few PRs ago ) if the pupil radius is not exactly a pixel number.

The problem came from MFTs that come back to pupil plane, with parameter `dim_output = int(2 * self.prad)` therefore an odd number. When padded to `dim_overpad_pupil` this lead to an offset (odd dimension array padded into an even dimension array). The solution should be simple (`prad` can be non integer but the pupil plane must always be of even size). For now a quick fix is to force the `diam_pup_in_pix` parameter to an even value. 
