### PR TITLE
Change the WLs to be equally spaced in a large bandwidth

### DIFF
--- a/Asterix/optics/optical_systems.py
+++ b/Asterix/optics/optical_systems.py
@@ -64,6 +64,9 @@ class OpticalSystem:
             if (self.nb_wav % 2 == 0) or self.nb_wav < 2:
                 raise ValueError("please set nb_wav parameter to an odd number > 1")
 
+            delta_wav_interval = self.Delta_wav / self.nb_wav
+            self.wav_vec = self.wavelength_0 + (np.arange(self.nb_wav) - self.nb_wav // 2) * delta_wav_interval
+
             self.wav_vec = np.linspace(self.wavelength_0 - self.Delta_wav / 2,
                                        self.wavelength_0 + self.Delta_wav / 2,
                                        num=self.nb_wav,

--- a/Asterix/optics/optical_systems.py
+++ b/Asterix/optics/optical_systems.py
@@ -67,10 +67,6 @@ class OpticalSystem:
             delta_wav_interval = self.Delta_wav / self.nb_wav
             self.wav_vec = self.wavelength_0 + (np.arange(self.nb_wav) - self.nb_wav // 2) * delta_wav_interval
 
-            self.wav_vec = np.linspace(self.wavelength_0 - self.Delta_wav / 2,
-                                       self.wavelength_0 + self.Delta_wav / 2,
-                                       num=self.nb_wav,
-                                       endpoint=True)
         else:
             self.wav_vec = np.array([self.wavelength_0])
             self.nb_wav = 1

--- a/Asterix/optics/optical_systems.py
+++ b/Asterix/optics/optical_systems.py
@@ -70,10 +70,6 @@ class OpticalSystem:
             delta_wav_interval = self.Delta_wav / self.nb_wav
             self.wav_vec = self.wavelength_0 + (np.arange(self.nb_wav) - self.nb_wav // 2) * delta_wav_interval
 
-            self.wav_vec = np.linspace(self.wavelength_0 - self.Delta_wav / 2,
-                                       self.wavelength_0 + self.Delta_wav / 2,
-                                       num=self.nb_wav,
-                                       endpoint=True)
         else:
             self.wav_vec = np.array([self.wavelength_0])
             self.nb_wav = 1

--- a/Asterix/optics/optical_systems.py
+++ b/Asterix/optics/optical_systems.py
@@ -67,6 +67,13 @@ class OpticalSystem:
             delta_wav_interval = self.Delta_wav / self.nb_wav
             self.wav_vec = self.wavelength_0 + (np.arange(self.nb_wav) - self.nb_wav // 2) * delta_wav_interval
 
+            delta_wav_interval = self.Delta_wav / self.nb_wav
+            self.wav_vec = self.wavelength_0 + (np.arange(self.nb_wav) - self.nb_wav // 2) * delta_wav_interval
+
+            self.wav_vec = np.linspace(self.wavelength_0 - self.Delta_wav / 2,
+                                       self.wavelength_0 + self.Delta_wav / 2,
+                                       num=self.nb_wav,
+                                       endpoint=True)
         else:
             self.wav_vec = np.array([self.wavelength_0])
             self.nb_wav = 1


### PR DESCRIPTION
With parameters lambda0 = 783nm, bw = 30nm, nlam = 3:
**Previous implementation** (wrong): the 3 wl were : [lambda0 - bw/2, lambda0, lambda0 + bw/2] so [768, 783, 798].

**New implementation** (better), we split the BW in small bandwidths of equal sizes small_bw = bw/nlam and we take the centers of each of these small bw. With the same parameters, the 3 wl are : [lambda0 - small_bw, lambda0, lambda0 + small_bw] so [773, 783, 793].