### PR TITLE
Fix warnings from pytest

### DIFF
--- a/Asterix/optics/coronagraph.py
+++ b/Asterix/optics/coronagraph.py
@@ -53,7 +53,7 @@ class Coronagraph(optsy.OpticalSystem):
 
         # dim_fp_fft definition only use if prop_apod2lyot == 'fft'
         self.corono_fpm_sampling = self.Science_sampling
-        self.dim_fp_fft = np.zeros(len(self.wav_vec), dtype=np.int)
+        self.dim_fp_fft = np.zeros(len(self.wav_vec), dtype=int)
         for i, wav in enumerate(self.wav_vec):
             self.dim_fp_fft[i] = int(np.ceil(self.prad * self.corono_fpm_sampling * self.wavelength_0 / wav)) * 2
             # we take the ceil to be sure that we measure at least the good resolution

--- a/Asterix/optics/deformable_mirror.py
+++ b/Asterix/optics/deformable_mirror.py
@@ -145,7 +145,7 @@ class DeformableMirror(optsy.OpticalSystem):
         if wavelength is None:
             wavelength = self.wavelength_0
 
-        if isinstance(DMphase, (int, float, np.float)):
+        if isinstance(DMphase, (int, float)):
             DMphase = np.full((self.dim_overpad_pupil, self.dim_overpad_pupil), np.float(DMphase))
 
         if dir_save_all_planes is not None:

--- a/Asterix/optics/optical_systems.py
+++ b/Asterix/optics/optical_systems.py
@@ -131,7 +131,7 @@ class OpticalSystem:
             Electric field in the pupil plane a the exit of the system
         """
 
-        if not isinstance(entrance_EF, (float, np.float, np.ndarray)):
+        if not isinstance(entrance_EF, (float, np.ndarray)):
             print(entrance_EF)
             raise TypeError("entrance_EF should be a float of a numpy array of floats")
 

--- a/Asterix/utils/hci_metrics.py
+++ b/Asterix/utils/hci_metrics.py
@@ -234,8 +234,8 @@ def contrast_curves(reduced_data, xcen=None, ycen=None, delta_raddii=3, type_of_
     dim = reduced_data.shape[1]
 
     # create rho2D for the rings
-    x = np.arange(dim, dtype=np.float)[None, :] - xcen
-    y = np.arange(dim, dtype=np.float)[:, None] - ycen
+    x = np.arange(dim, dtype=float)[None, :] - xcen
+    y = np.arange(dim, dtype=float)[:, None] - ycen
     rho2d = np.sqrt(x**2 + y**2)
 
     contrast_curve = []

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -35,7 +35,7 @@ def save_plane_in_fits(dir_save_fits, name_plane, image):
         raise FileNotFoundError("Please define an existing directory for dir_save_fits keyword or None")
 
     # sometimes the image can be a single float (0 for phase or 1 for EF).
-    if isinstance(image, (int, float, np.float)):
+    if isinstance(image, (int, float)):
         print(name_plane + " is a constant, not save in fits")
         return
 


### PR DESCRIPTION
np.int and np.float are now deprecated https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
This cause warnings in the tests. This PR replace np.int -> int and np.float -> float. No more warning when pytest on my machine