### PR TITLE
Enable zoom-in sampling for Asterix

### DIFF
--- a/Asterix/optics/propagation_functions.py
+++ b/Asterix/optics/propagation_functions.py
@@ -600,6 +600,12 @@ def prop_fpm_regional_sampling(pup, fpm, nbres=np.array([0.1, 5, 50, 100]), samp
     -------
     array : E-field before the Lyot stop.
     """
+    if samp_outer != 2:
+        raise ValueError(f"samp_outer' needs to be 2, otherwise we cut off the high-spatial frequencies and the"
+                         f"simulation turns out bad. This can become a variable parameter in the future if we allow"
+                         f"the array sizes to be adapted in this function as well, in order to retain the original"
+                         f"spatial frequency content in the outer sampling layer.")
+
     dim_pup = pup.shape[0]
     dim_fpm = fpm.shape[0]
 

--- a/Asterix/optics/propagation_functions.py
+++ b/Asterix/optics/propagation_functions.py
@@ -601,14 +601,14 @@ def prop_fpm_regional_sampling(pup, fpm, nbres=np.array([0.1, 5, 50, 100]), samp
     array : E-field before the Lyot stop.
     """
     dim_pup = pup.shape[0]
-    dim_fpm = dim_pup  # fpm.shape[0]  # TODO: come back and test this
+    dim_fpm = fpm.shape[0]
 
     # Innermost part of the focal plane
     but_inner = butterworth_circle(dim_fpm, dim_fpm / alpha, filter_order, -0.5, -0.5)
     efield_before_fpm_inner = mft(pup, real_dim_input=dim_pup, dim_output=dim_fpm, nbres=nbres[0])
     efield_before_ls = mft(efield_before_fpm_inner * fpm * but_inner,
                            real_dim_input=dim_fpm,
-                           dim_output=dim_fpm,
+                           dim_output=dim_pup,
                            nbres=nbres[0],
                            inverse=True)
 
@@ -622,7 +622,7 @@ def prop_fpm_regional_sampling(pup, fpm, nbres=np.array([0.1, 5, 50, 100]), samp
         ef_pre_fpm = mft(pup, real_dim_input=dim_pup, dim_output=dim_fpm, nbres=nbres[k + 1])
         ef_pre_ls = mft(ef_pre_fpm * fpm * but,
                         real_dim_input=dim_fpm,
-                        dim_output=dim_fpm,
+                        dim_output=dim_pup,
                         nbres=nbres[k + 1],
                         inverse=True)
 
@@ -634,8 +634,9 @@ def prop_fpm_regional_sampling(pup, fpm, nbres=np.array([0.1, 5, 50, 100]), samp
     sizebut_outer = dim_fpm / alpha * nbres[-1] / nbres_outer
     but_outer = 1 - butterworth_circle(dim_fpm, sizebut_outer, filter_order, xshift=-0.5, yshift=-0.5)
 
-    ef_pre_fpm_outer = crop_or_pad_image(fft_choosecenter(pup, inverse=True), dim_fpm)
-    ef_pre_ls_outer = crop_or_pad_image(fft_choosecenter(ef_pre_fpm_outer * fpm * but_outer, inverse=True), dim_fpm)
+    ef_pre_fpm_outer = mft(pup, real_dim_input=dim_pup, dim_output=dim_fpm, nbres=nbres_outer)
+    ef_pre_ls_outer = mft(ef_pre_fpm_outer * fpm * but_outer, real_dim_input=dim_fpm, dim_output=dim_pup,
+                          nbres=nbres_outer, inverse=True)
 
     # Total E-field before the LS
     efield_before_ls += ef_pre_ls_outer

--- a/Asterix/tests/test_propagations.py
+++ b/Asterix/tests/test_propagations.py
@@ -60,7 +60,7 @@ def test_butterworth():
 def test_prop_area_sampling():
     dim = 512
     rad = dim / 2
-    samp_outer = 4
+    samp_outer = 2
     nbres_direct = dim / samp_outer
 
     pup = roundpupil(dim, rad, grey_pup_bin_factor=10)

--- a/Asterix/tests/test_propagations.py
+++ b/Asterix/tests/test_propagations.py
@@ -90,4 +90,4 @@ def test_prop_area_sampling():
 
     # Comparison
     assert np.sum(np.abs(post_ls_areas)**2) < np.sum(np.abs(post_ls_uniform)**2)
-    assert (np.max(coro_psf_areas) / np.max(coro_psf_uniform)) < 3e-2
+    assert (np.max(coro_psf_areas) / np.max(coro_psf_uniform)) < 9e-4

--- a/notebooks/coronagraph_propagation.ipynb
+++ b/notebooks/coronagraph_propagation.ipynb
@@ -155,7 +155,9 @@
     "plt.subplot(1,2,2)\n",
     "plt.imshow(coro_psf/max_psf, cmap='inferno', norm=LogNorm(), origin='lower')\n",
     "plt.title('Coronagraphic PSF')\n",
-    "plt.colorbar()"
+    "plt.colorbar()\n",
+    "\n",
+    "print(np.max(coro_psf/max_psf))"
    ]
   },
   {
@@ -180,7 +182,9 @@
     "\n",
     "plt.imshow(coro_psf_after_testbed/norm_thd2, cmap='inferno', origin='lower', norm=LogNorm())\n",
     "plt.title('Full testbed PSF')\n",
-    "plt.colorbar()"
+    "plt.colorbar()\n",
+    "\n",
+    "print(np.max(coro_psf_after_testbed/norm_thd2))"
    ]
   },
   {

--- a/notebooks/zoom-in_sampling_coro.ipynb
+++ b/notebooks/zoom-in_sampling_coro.ipynb
@@ -104,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "psam_pre_ls_builtin = prop_fpm_regional_sampling(pup, np.exp(1j*fpm), nbres=res_list, samp_outer=2)\n",
+    "psam_pre_ls_builtin = prop_fpm_regional_sampling(pup, np.exp(1j*fpm), nbres=res_list)\n",
     "\n",
     "display_complex(psam_pre_ls_builtin)\n",
     "plt.suptitle('Pre-LS E-field')"


### PR DESCRIPTION
The zoom-in sampling function was fixed in #101 but it does  not accommodate separate sizes for the pupil and FPM, which is required for use in Asterix. This PR fixes that. I also lowered the test threshold now that it's working better and did minor updates to the notebooks.