### PR TITLE
Transform exception in warning for number of modes in THD matrices

### DIFF
--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -132,14 +132,14 @@ class Corrector:
             else:
                 raise ValueError("No active DMs")
 
-            if testbed.DM1.active & testbed.DM3.active:
-                if Correctionconfig["Nbmodes_OnTestbed"] < 500:
-                    raise ValueError(f"Nbmodes_OnTestbed ({Correctionconfig['Nbmodes_OnTestbed']})" +
-                                     " in inversion for THD is probably too low for 2DM")
-            if not testbed.DM1.active & testbed.DM3.active:
-                if Correctionconfig["Nbmodes_OnTestbed"] > 500:
-                    raise ValueError(f"Nbmodes_OnTestbed ({Correctionconfig['Nbmodes_OnTestbed']})" +
-                                     " in inversion for THD is probably too high for 1DM")
+#            if testbed.DM1.active & testbed.DM3.active:
+#                if Correctionconfig["Nbmodes_OnTestbed"] < 500:
+#                    raise Exception(f"Nbmodes_OnTestbed ({Correctionconfig['Nbmodes_OnTestbed']})" +
+#                                    " in inversion for THD is probably too low for 2DM")
+#            if not testbed.DM1.active & testbed.DM3.active:
+#                if Correctionconfig["Nbmodes_OnTestbed"] > 500:
+#                    raise Exception(f"Nbmodes_OnTestbed ({Correctionconfig['Nbmodes_OnTestbed']})" +
+#                                    " in inversion for THD is probably too high for 1DM")
 
             thd_quick_invert.THD_quick_invert(Correctionconfig["Nbmodes_OnTestbed"],
                                               number_Active_testbeds,

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -132,14 +132,16 @@ class Corrector:
             else:
                 raise ValueError("No active DMs")
 
-#            if testbed.DM1.active & testbed.DM3.active:
-#                if Correctionconfig["Nbmodes_OnTestbed"] < 500:
-#                    raise Exception(f"Nbmodes_OnTestbed ({Correctionconfig['Nbmodes_OnTestbed']})" +
-#                                    " in inversion for THD is probably too low for 2DM")
-#            if not testbed.DM1.active & testbed.DM3.active:
-#                if Correctionconfig["Nbmodes_OnTestbed"] > 500:
-#                    raise Exception(f"Nbmodes_OnTestbed ({Correctionconfig['Nbmodes_OnTestbed']})" +
-#                                    " in inversion for THD is probably too high for 1DM")
+            if testbed.DM1.active & testbed.DM3.active:
+                if Correctionconfig["Nbmodes_OnTestbed"] < 500:
+                    input(f"Nbmodes_OnTestbed ({Correctionconfig['Nbmodes_OnTestbed']})" +
+                          " in inversion for THD is probably too low for 2DM. " +
+                          "This is just a warning, if you kown what your are doing, " + "press any key to continue")
+            if not testbed.DM1.active & testbed.DM3.active:
+                if Correctionconfig["Nbmodes_OnTestbed"] > 500:
+                    input(f"Nbmodes_OnTestbed ({Correctionconfig['Nbmodes_OnTestbed']})" +
+                          " in inversion for THD is probably too high for 1DM. " +
+                          "This is just a warning, if you kown what your are doing, " + "press any key to continue")
 
             thd_quick_invert.THD_quick_invert(Correctionconfig["Nbmodes_OnTestbed"],
                                               number_Active_testbeds,


### PR DESCRIPTION
@rgalicher I transformed the exception in a warning in the number of mode for the testbed :
 
"Nbmodes_OnTestbed (550) in inversion for THD is probably too high for 1DM. This is just a warning, if you kown what your are doing, press any key to continue"

This is a very special case (CNRS DH won't happen everyday) so this should be just fine. 