### PR TITLE
Add inclination option to wrapped vortex phase mask

### DIFF
--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -1,7 +1,7 @@
 import os
 
 from Asterix.utils import create_experiment_dir, get_data_dir, read_parameter_file
-from Asterix.optics import Pupil, Coronagraph, DeformableMirror, Testbed
+from Asterix.optics import THD2
 from Asterix.wfsc import Estimator, Corrector, MaskDH, correction_loop, save_loop_results
 
 
@@ -60,9 +60,6 @@ def runthd2(parameter_file,
 
     Data_dir = get_data_dir(config_in=config["Data_dir"])
     onbench = config["onbench"]
-    modelconfig = config["modelconfig"]
-    DMconfig = config["DMconfig"]
-    Coronaconfig = config["Coronaconfig"]
     Estimationconfig = config["Estimationconfig"]
     Correctionconfig = config["Correctionconfig"]
     Loopconfig = config["Loopconfig"]
@@ -75,17 +72,8 @@ def runthd2(parameter_file,
     result_dir = os.path.join(Data_dir, "Results", Name_Experiment)
     labview_dir = os.path.join(Data_dir, "Labview")
 
-    # Create all optical elements of the THD
-    entrance_pupil = Pupil(modelconfig,
-                           PupType=modelconfig['filename_instr_pup'],
-                           angle_rotation=modelconfig['entrance_pup_rotation'],
-                           Model_local_dir=model_local_dir)
-    DM1 = DeformableMirror(modelconfig, DMconfig, Name_DM='DM1', Model_local_dir=model_local_dir)
-    DM3 = DeformableMirror(modelconfig, DMconfig, Name_DM='DM3', Model_local_dir=model_local_dir)
-    corono = Coronagraph(modelconfig, Coronaconfig, Model_local_dir=model_local_dir)
-
     # Concatenate into the full testbed optical system
-    thd2 = Testbed([entrance_pupil, DM1, DM3, corono], ["entrancepupil", "DM1", "DM3", "corono"])
+    thd2 = THD2(parameter_file, NewMODELconfig, NewDMconfig, NewCoronaconfig)
 
     # The following line can be used to change the DM which applies PW probes. This could be used to use the DM out of
     # the pupil plane.

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -58,19 +58,19 @@ def runthd2(parameter_file,
                                  NewLoopconfig=NewLoopconfig,
                                  NewSIMUconfig=NewSIMUconfig)
 
-    Data_dir = get_data_dir(config_in=config["Data_dir"])
+    data_dir = get_data_dir(config_in=config["Data_dir"])
     onbench = config["onbench"]
     Estimationconfig = config["Estimationconfig"]
     Correctionconfig = config["Correctionconfig"]
     Loopconfig = config["Loopconfig"]
     SIMUconfig = config["SIMUconfig"]
-    Name_Experiment = create_experiment_dir(append=SIMUconfig["Name_Experiment"])
+    name_experiment = create_experiment_dir(append=SIMUconfig["Name_Experiment"])
 
     # Initialize all directories
-    model_local_dir = os.path.join(Data_dir, "Model_local")
-    matrix_dir = os.path.join(Data_dir, "Interaction_Matrices")
-    result_dir = os.path.join(Data_dir, "Results", Name_Experiment)
-    labview_dir = os.path.join(Data_dir, "Labview")
+    model_local_dir = os.path.join(data_dir, "Model_local")
+    matrix_dir = os.path.join(data_dir, "Interaction_Matrices")
+    result_dir = os.path.join(data_dir, "Results", name_experiment)
+    labview_dir = os.path.join(data_dir, "Labview")
 
     # Concatenate into the full testbed optical system
     thd2 = THD2(parameter_file, NewMODELconfig, NewDMconfig, NewCoronaconfig)

--- a/Asterix/optics/__init__.py
+++ b/Asterix/optics/__init__.py
@@ -5,6 +5,7 @@ from .pupil import *
 from .coronagraph import *
 from .deformable_mirror import *
 from .testbed import *
+from .thd import *
 
 from .phase_amplitude_functions import *
 from .propagation_functions import *

--- a/Asterix/optics/coronagraph.py
+++ b/Asterix/optics/coronagraph.py
@@ -383,7 +383,8 @@ class Coronagraph(optsy.OpticalSystem):
                 fpm_array = FPmsk
             lyotplane_before_lyot = prop.prop_fpm_regional_sampling(input_wavefront_after_apod,
                                                                     fpm_array,
-                                                                    nbres=np.array([0.1, 5, 50, 100]))
+                                                                    nbres=np.array([0.1, 5, 50, 100]),
+                                                                    shift=(0, 0))
 
         else:
             raise ValueError(f"{self.prop_apod2lyot} is not a known `prop_apod2lyot` propagation method")

--- a/Asterix/optics/coronagraph.py
+++ b/Asterix/optics/coronagraph.py
@@ -493,7 +493,7 @@ class Coronagraph(optsy.OpticalSystem):
 
         return vortex
 
-    def WrappedVortex(self, offset=0, cen_shift=(0, 0), inclination_x=None, inclination_y=None):
+    def WrappedVortex(self, offset=0, cen_shift=(0, 0), inclination_x=0, inclination_y=0):
         """Create a wrapped vortex coronagraph.
 
         Parameters
@@ -502,9 +502,9 @@ class Coronagraph(optsy.OpticalSystem):
             General offset to the whole ramp; default 0.
         cen_shift : tuple of floats
             x- and y-shift of the center of the mask with respect to the center of the array; default (0,0).
-        inclination_x : float, default None
+        inclination_x : float, default 0
             Inclination of the phase mask around the x-axis in degrees.
-        inclination_y : float, default None
+        inclination_y : float, default 0
             Inclination of the phase mask around the y-axis in degrees.
 
         Returns
@@ -659,7 +659,7 @@ def fqpm_mask(dim):
 
 
 def create_wrapped_vortex_mask(dim, thval, phval, jump, return_1d=False, piperiodic=True, offset=0, cen_shift=(0, 0),
-                               inclination_x=None, inclination_y=None):
+                               inclination_x=0, inclination_y=0):
     """Create a wrapped vortex phase mask.
 
     Analytical calculation of this phase mask coronagraph see [Galicher2020]_.
@@ -689,9 +689,9 @@ def create_wrapped_vortex_mask(dim, thval, phval, jump, return_1d=False, piperio
     cen_shift : tuple of floats
         x- and y-shift of the center of the mask with respect to the center of the array, which is between pixels as
         long as 'dim' is even; default (0,0).
-    inclination_x : float, default None
+    inclination_x : float, default 0
         Inclination of the phase mask around the x-axis in degrees.
-    inclination_y : float, default None
+    inclination_y : float, default 0
         Inclination of the phase mask around the y-axis in degrees.
 
     Returns
@@ -735,9 +735,11 @@ def create_wrapped_vortex_mask(dim, thval, phval, jump, return_1d=False, piperio
         ty = (np.arange(dim) - dim / 2 - cen_shift[0] + 0.5)
         tx = (np.arange(dim) - dim / 2 - cen_shift[1] + 0.5)
 
-        if inclination_x is not None:
+        if np.abs(inclination_x > 90) and np.abs(inclination_y > 90):
+            raise ValueError("Inclination angles should be between -90 and 90 degrees.")
+        if inclination_x != 0:
             tx /= np.cos(np.deg2rad(inclination_x))
-        if inclination_y is not None:
+        if inclination_y != 0:
             ty /= np.cos(np.deg2rad(inclination_y))
 
         xx, yy = np.meshgrid(ty, tx)

--- a/Asterix/optics/coronagraph.py
+++ b/Asterix/optics/coronagraph.py
@@ -493,7 +493,7 @@ class Coronagraph(optsy.OpticalSystem):
 
         return vortex
 
-    def WrappedVortex(self, offset=0, cen_shift=(0, 0)):
+    def WrappedVortex(self, offset=0, cen_shift=(0, 0), inclination_x=None, inclination_y=None):
         """Create a wrapped vortex coronagraph.
 
         Parameters
@@ -502,6 +502,10 @@ class Coronagraph(optsy.OpticalSystem):
             General offset to the whole ramp; default 0.
         cen_shift : tuple of floats
             x- and y-shift of the center of the mask with respect to the center of the array; default (0,0).
+        inclination_x : float, default None
+            Inclination of the phase mask around the x-axis in degrees.
+        inclination_y : float, default None
+            Inclination of the phase mask around the y-axis in degrees.
 
         Returns
         -------
@@ -522,7 +526,9 @@ class Coronagraph(optsy.OpticalSystem):
                                                              phval=phval,
                                                              jump=jump,
                                                              offset=offset,
-                                                             cen_shift=cen_shift)
+                                                             cen_shift=cen_shift,
+                                                             inclination_x=inclination_x,
+                                                             inclination_y=inclination_y)
 
         wrapped_vortex = list()
         for i, wav in enumerate(self.wav_vec):
@@ -652,7 +658,8 @@ def fqpm_mask(dim):
     return fqpm_thick
 
 
-def create_wrapped_vortex_mask(dim, thval, phval, jump, return_1d=False, piperiodic=True, offset=0, cen_shift=(0, 0)):
+def create_wrapped_vortex_mask(dim, thval, phval, jump, return_1d=False, piperiodic=True, offset=0, cen_shift=(0, 0),
+                               inclination_x=None, inclination_y=None):
     """Create a wrapped vortex phase mask.
 
     Analytical calculation of this phase mask coronagraph see [Galicher2020]_.
@@ -682,6 +689,10 @@ def create_wrapped_vortex_mask(dim, thval, phval, jump, return_1d=False, piperio
     cen_shift : tuple of floats
         x- and y-shift of the center of the mask with respect to the center of the array, which is between pixels as
         long as 'dim' is even; default (0,0).
+    inclination_x : float, default None
+        Inclination of the phase mask around the x-axis in degrees.
+    inclination_y : float, default None
+        Inclination of the phase mask around the y-axis in degrees.
 
     Returns
     -------
@@ -723,6 +734,12 @@ def create_wrapped_vortex_mask(dim, thval, phval, jump, return_1d=False, piperio
         # Define the 2D theta array
         ty = (np.arange(dim) - dim / 2 - cen_shift[0] + 0.5)
         tx = (np.arange(dim) - dim / 2 - cen_shift[1] + 0.5)
+
+        if inclination_x is not None:
+            tx /= np.cos(np.deg2rad(inclination_x))
+        if inclination_y is not None:
+            ty /= np.cos(np.deg2rad(inclination_y))
+
         xx, yy = np.meshgrid(ty, tx)
         theta = (-(np.arctan2(yy, xx) - np.pi) + offset) % (2 * np.pi)
 

--- a/Asterix/optics/propagation_functions.py
+++ b/Asterix/optics/propagation_functions.py
@@ -591,7 +591,7 @@ def prop_fpm_regional_sampling(pup, fpm, nbres=np.array([0.1, 5, 50, 100]), shif
     nbres : 1D array or list
         List of the number of resolution elements in the total image plane for all propagation layers.
     shift : tuple, default (0, 0)
-        Shift of FPM with respect to opcial axis in pixels. This is done by introducing a tip/tilt on the input
+        Shift of FPM with respect to optcial axis in pixels. This is done by introducing a tip/tilt on the input
         wavefront in the pupil that is subsequently taken out in the Lyot plane after the full propagation.
     samp_outer : float
         Sampling in the outermost layer of propagations.

--- a/Asterix/optics/propagation_functions.py
+++ b/Asterix/optics/propagation_functions.py
@@ -618,6 +618,7 @@ def prop_fpm_regional_sampling(pup, fpm, nbres=np.array([0.1, 5, 50, 100]), shif
     phase_ramp = shift_phase_ramp(dim_pup, shift[0], shift[1])
     inverted_phase_ramp = shift_phase_ramp(dim_pup, -shift[0], -shift[1])
 
+    pup = np.array(pup, copy=True, dtype='complex128')
     pup *= phase_ramp
 
     # Innermost part of the focal plane

--- a/Asterix/optics/thd.py
+++ b/Asterix/optics/thd.py
@@ -1,0 +1,62 @@
+import os
+
+from Asterix.utils import get_data_dir, read_parameter_file
+from Asterix.optics import Pupil, Coronagraph, DeformableMirror, Testbed
+
+
+class THD2(Testbed):
+    """Testbed object configured for THD2, from input configfile.
+
+    AUTHOR : ILa
+
+    Attributes
+    ----------
+    config : dict
+        A read-in .ini parameter file.
+    entrance_pupil : Pupil
+    dm1 : DeformableMirror
+    dm3 : DeformableMirror
+    corono : Coronagraph
+    """
+
+    def __init__(self,
+                 parameter_file,
+                 new_model_config={},
+                 new_dm_config={},
+                 new_corona_config={},
+                 ):
+        """
+        Parameters
+        ----------
+        parameter_file : string
+            Absolute path to an .ini parameter file.
+        new_model_config : dict, optional
+            Can be used to directly change a parameter in the MODELconfig section of the input parameter file.
+        new_dm_config : dict, optional
+            Can be used to directly change a parameter in the DMconfig section of the input parameter file.
+        new_corona_config : dict, optional
+            Can be used to directly change a parameter in the Coronaconfig section of the input parameter file.
+        """
+
+        # Load configuration file
+        self.config = read_parameter_file(parameter_file,
+                                          NewMODELconfig=new_model_config,
+                                          NewDMconfig=new_dm_config,
+                                          NewCoronaconfig=new_corona_config)
+
+        model_config = self.config["modelconfig"]
+        dm_config = self.config["DMconfig"]
+        corona_config = self.config["Coronaconfig"]
+        model_local_dir = os.path.join(get_data_dir(config_in=self.config["Data_dir"]), "Model_local")
+
+        # Create all optical elements of the THD
+        self.entrance_pupil = Pupil(model_config,
+                                    PupType=model_config["filename_instr_pup"],
+                                    angle_rotation=model_config["entrance_pup_rotation"],
+                                    Model_local_dir=model_local_dir)
+        self.dm1 = DeformableMirror(model_config, dm_config, Name_DM="DM1", Model_local_dir=model_local_dir)
+        self.dm3 = DeformableMirror(model_config, dm_config, Name_DM="DM3", Model_local_dir=model_local_dir)
+        self.corono = Coronagraph(model_config, corona_config, Model_local_dir=model_local_dir)
+
+        # Concatenate into the full testbed optical system
+        super().__init__([self.entrance_pupil, self.dm1, self.dm3, self.corono], ["entrancepupil", "DM1", "DM3", "corono"])

--- a/Asterix/optics/thd.py
+++ b/Asterix/optics/thd.py
@@ -13,10 +13,6 @@ class THD2(Testbed):
     ----------
     config : dict
         A read-in .ini parameter file.
-    entrance_pupil : Pupil
-    dm1 : DeformableMirror
-    dm3 : DeformableMirror
-    corono : Coronagraph
     """
 
     def __init__(self,
@@ -50,13 +46,13 @@ class THD2(Testbed):
         model_local_dir = os.path.join(get_data_dir(config_in=self.config["Data_dir"]), "Model_local")
 
         # Create all optical elements of the THD
-        self.entrance_pupil = Pupil(model_config,
-                                    PupType=model_config["filename_instr_pup"],
-                                    angle_rotation=model_config["entrance_pup_rotation"],
-                                    Model_local_dir=model_local_dir)
-        self.dm1 = DeformableMirror(model_config, dm_config, Name_DM="DM1", Model_local_dir=model_local_dir)
-        self.dm3 = DeformableMirror(model_config, dm_config, Name_DM="DM3", Model_local_dir=model_local_dir)
-        self.corono = Coronagraph(model_config, corona_config, Model_local_dir=model_local_dir)
+        entrance_pupil = Pupil(model_config,
+                               PupType=model_config["filename_instr_pup"],
+                               angle_rotation=model_config["entrance_pup_rotation"],
+                               Model_local_dir=model_local_dir)
+        dm1 = DeformableMirror(model_config, dm_config, Name_DM="DM1", Model_local_dir=model_local_dir)
+        dm3 = DeformableMirror(model_config, dm_config, Name_DM="DM3", Model_local_dir=model_local_dir)
+        corono = Coronagraph(model_config, corona_config, Model_local_dir=model_local_dir)
 
         # Concatenate into the full testbed optical system
-        super().__init__([self.entrance_pupil, self.dm1, self.dm3, self.corono], ["entrancepupil", "DM1", "DM3", "corono"])
+        super().__init__([entrance_pupil, dm1, dm3, corono], ["entrancepupil", "DM1", "DM3", "corono"])

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -49,15 +49,21 @@ def save_plane_in_fits(dir_save_fits, name_plane, image):
 
 
 def quickfits(tab, folder='', name='tmp'):
-    """Johan's quick function.
+    """Quickly save an image to a fits file.
 
-    Function to quickly save in fits.
     By default, it will save on the desktop with a random name to avoid overwriting.
-    Not sure the default saving on Desktop works for windows OS, but it work on mac and linux
+    Not sure if the default saving on Desktop works for Windows, but it works fine on MacOS and Linux.
 
-    tab: array to be saved
-    folder (optional): directory where to save the .fits. by default the Desktop.
-    name (optional): name of the .fits. By defaut tmp_currenttimeinms.fits
+    AUTHOR: Johan Mazoyer
+
+    Parameters
+    ----------
+    tab : ndarray
+        Image to be saved to disk.
+    folder : string
+        Path to save file location.
+    name : string
+        File name of images to save to disk.
     """
 
     if folder == '':
@@ -69,12 +75,12 @@ def quickfits(tab, folder='', name='tmp'):
             # of you are french are you ?
             folder = bureau
         else:
-            raise FileNotFoundError("I cannot find your desktop, please give me a folder to save the .fits file")
+            raise FileNotFoundError("I cannot find your desktop, please give me a folder to save the fits file to.")
 
     if name == 'tmp':
         current_time_str = datetime.datetime.today().strftime('_%H_%M_%S_%f')[:-3]
         name = name + current_time_str
-    fits.writeto(os.path.join(folder, name + '.fits'), tab, overwrite=True)
+    fits.writeto(os.path.join(folder, f'{name}.fits'), tab, overwrite=True)
 
 
 def progress(count, total, status=''):

--- a/notebooks/beginner-tutorial_optical-components-and-systems.ipynb
+++ b/notebooks/beginner-tutorial_optical-components-and-systems.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "from Asterix import Asterix_root\n",
     "from Asterix.utils import read_parameter_file\n",
-    "from Asterix.optics import Pupil, Coronagraph, DeformableMirror, Testbed"
+    "from Asterix.optics import Pupil, Coronagraph, DeformableMirror, Testbed, THD2"
    ]
   },
   {
@@ -774,7 +774,7 @@
    "source": [
     "# Create testbed with RST pupil\n",
     "testbed_1DM_romanpup = Testbed([pup_roman, DM3, corono],\n",
-    "                                     [\"entrancepupil\", \"DM3\", \"corono\"])\n",
+    "                               [\"entrancepupil\", \"DM3\", \"corono\"])\n",
     "psf_after_roman_testbed = testbed_1DM_romanpup.todetector_intensity(entrance_EF=aberrated_EF, DM3phase=phase)\n",
     "\n",
     "plt.imshow(psf_after_roman_testbed, cmap='inferno', norm=LogNorm())\n",
@@ -887,7 +887,7 @@
    "source": [
     "# And then just concatenate:\n",
     "thd2 = Testbed([pup_round_larger, DM1, DM3, corono_thd],\n",
-    "                     [\"entrancepupil\", \"DM1\", \"DM3\", \"corono\"])"
+    "               [\"entrancepupil\", \"DM1\", \"DM3\", \"corono\"])"
    ]
   },
   {
@@ -981,9 +981,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "65b457e4",
+   "metadata": {},
+   "source": [
+    "### Pre-defined THD2 class\n",
+    "\n",
+    "Note how there exists also a pre-defined THD2 class with which you cna instantiate a THD2 testbed object directly from the configfile."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8d129b0",
+   "id": "2d4f5d6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thd2 = THD2(parameter_file_ex)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c33c097",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/shift_wrapped_vortex.ipynb
+++ b/notebooks/shift_wrapped_vortex.ipynb
@@ -187,8 +187,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# With aberrations like above\n",
     "experiment_dir = os.path.join(data_dir, 'Results', '20221108_14-09-40_My_fourth_experiment')\n",
-    "dh_iteration = 8"
+    "dh_iteration = 8\n",
+    "\n",
+    "# Without aberrations\n",
+    "# experiment_dir = os.path.join(data_dir, 'Results', '20221108_17-00-47_My_fourth_experiment')\n",
+    "# dh_iteration = 11"
    ]
   },
   {
@@ -221,7 +226,7 @@
     "                                    photon_noise=False, voltage_vector=dm_voltages)\n",
     "\n",
     "plt.figure(figsize=(6, 6))\n",
-    "plt.imshow(coro_dh/norm, cmap='inferno', norm=LogNorm(vmin=1e-10, vmax=1e-4), origin='lower')\n",
+    "plt.imshow(coro_dh/norm, cmap='inferno', norm=LogNorm(vmin=1e-8, vmax=1e-6), origin='lower')\n",
     "plt.colorbar()\n",
     "\n",
     "fname = '0x_0y'\n",

--- a/notebooks/shift_wrapped_vortex.ipynb
+++ b/notebooks/shift_wrapped_vortex.ipynb
@@ -183,6 +183,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fc30be8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_out = '20221109_WV_shifts_phase'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "630acc86",
    "metadata": {},
    "outputs": [],
@@ -229,9 +239,9 @@
     "plt.imshow(coro_dh/norm, cmap='inferno', norm=LogNorm(vmin=1e-8, vmax=1e-6), origin='lower')\n",
     "plt.colorbar()\n",
     "\n",
-    "fname = '0x_0y'\n",
-    "# plt.savefig(os.path.join(data_dir, 'Results', '20221108_WV_shifts_inclinations', f'{fname}.pdf'))\n",
-    "# fits.writeto(os.path.join(data_dir, 'Results', '20221108_WV_shifts_inclinations', f'{fname}.fits'), coro_dh/norm, overwrite=True)"
+    "fname = '0x_02y'\n",
+    "plt.savefig(os.path.join(data_dir, 'Results', data_out, f'{fname}.pdf'))\n",
+    "fits.writeto(os.path.join(data_dir, 'Results', data_out, f'{fname}.fits'), coro_dh/norm, overwrite=True)"
    ]
   },
   {
@@ -257,13 +267,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imgs = []\n",
-    "for i in range(4):\n",
-    "    for j in range(4):\n",
-    "        fname = f'{i}x_{j}y'\n",
-    "        print(fname)\n",
-    "        im = fits.getdata(os.path.join(data_dir, 'Results', '20221108_WV_shifts_inclinations', 'shifts', 'fits', f'{fname}.fits'))\n",
-    "        imgs.append(im)"
+    "# imgs = []\n",
+    "# for i in range(4):\n",
+    "#     for j in range(4):\n",
+    "#         fname = f'{i}x_{j}y'\n",
+    "#         print(fname)\n",
+    "#         im = fits.getdata(os.path.join(data_dir, 'Results', data_out, 'shifts', 'fits', f'{fname}.fits'))\n",
+    "#         imgs.append(im)"
    ]
   },
   {
@@ -275,17 +285,17 @@
    },
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(10, 10))\n",
-    "for i in range(4):\n",
-    "    for j in range(4):\n",
-    "        plt.subplot(4, 4, 4*i + j + 1)\n",
-    "        fname = f'{i}x_{j}y'\n",
-    "        plt.imshow(imgs[4*i+j], cmap='inferno', norm=LogNorm(vmin=1e-8, vmax=1e-6), origin='lower')\n",
-    "        plt.text(150, 350, fname, color='k', fontweight='bold', size=15)\n",
-    "        plt.axis('off')\n",
-    "plt.tight_layout()\n",
-    "#plt.show()\n",
-    "#plt.savefig(os.path.join(data_dir, 'Results', '20221108_WV_shifts_inclinations', 'shifts', f'full_grid.pdf'))"
+    "# plt.figure(figsize=(10, 10))\n",
+    "# for i in range(4):\n",
+    "#     for j in range(4):\n",
+    "#         plt.subplot(4, 4, 4*i + j + 1)\n",
+    "#         fname = f'{i}x_{j}y'\n",
+    "#         plt.imshow(imgs[4*i+j], cmap='inferno', norm=LogNorm(vmin=1e-8, vmax=1e-6), origin='lower')\n",
+    "#         plt.text(150, 350, fname, color='k', fontweight='bold', size=15)\n",
+    "#         plt.axis('off')\n",
+    "# plt.tight_layout()\n",
+    "# #plt.show()\n",
+    "# #plt.savefig(os.path.join(data_dir, 'Results', data_out, 'shifts', f'full_grid.pdf'))"
    ]
   },
   {
@@ -303,14 +313,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vals = [10, 13, 15, 16, 17, 18, 20, 22]\n",
-    "imgs = []\n",
-    "for deg in vals:\n",
-    "    fname = f'incl_x_{deg}deg'\n",
-    "    print(fname)\n",
-    "    im = fits.getdata(os.path.join(data_dir, 'Results', '20221108_WV_shifts_inclinations', 'inclinations',\n",
-    "                                   'fits', f'{fname}.fits'))\n",
-    "    imgs.append(im)"
+    "# vals = [10, 13, 15, 16, 17, 18, 20, 22]\n",
+    "# imgs = []\n",
+    "# for deg in vals:\n",
+    "#     fname = f'incl_x_{deg}deg'\n",
+    "#     print(fname)\n",
+    "#     im = fits.getdata(os.path.join(data_dir, 'Results', data_out, 'inclinations',\n",
+    "#                                    'fits', f'{fname}.fits'))\n",
+    "#     imgs.append(im)"
    ]
   },
   {
@@ -320,16 +330,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(18, 9))\n",
-    "for i, deg in enumerate(vals):\n",
-    "    plt.subplot(2, 4, i+1)\n",
-    "    fname = f'{deg}deg'\n",
-    "    plt.imshow(imgs[i], cmap='inferno', norm=LogNorm(vmin=1e-8, vmax=1e-6), origin='lower')\n",
-    "    plt.text(150, 350, fname, color='k', fontweight='bold', size=25)\n",
-    "    plt.axis('off')\n",
-    "plt.tight_layout()\n",
-    "#plt.show()\n",
-    "#plt.savefig(os.path.join(data_dir, 'Results', '20221108_WV_shifts_inclinations', 'inclinations', f'full_grid.pdf'))"
+    "# plt.figure(figsize=(18, 9))\n",
+    "# for i, deg in enumerate(vals):\n",
+    "#     plt.subplot(2, 4, i+1)\n",
+    "#     fname = f'{deg}deg'\n",
+    "#     plt.imshow(imgs[i], cmap='inferno', norm=LogNorm(vmin=1e-8, vmax=1e-6), origin='lower')\n",
+    "#     plt.text(150, 350, fname, color='k', fontweight='bold', size=25)\n",
+    "#     plt.axis('off')\n",
+    "# plt.tight_layout()\n",
+    "# #plt.show()\n",
+    "# #plt.savefig(os.path.join(data_dir, 'Results', data_out, 'inclinations', f'full_grid.pdf'))"
    ]
   },
   {

--- a/notebooks/shift_wrapped_vortex.ipynb
+++ b/notebooks/shift_wrapped_vortex.ipynb
@@ -225,8 +225,16 @@
     "plt.colorbar()\n",
     "\n",
     "fname = '0x_0y'\n",
-    "# plt.savefig(os.path.join(data_dir, 'Results', '20221108_WV_shifts', f'{fname}.pdf'))\n",
-    "# fits.writeto(os.path.join(data_dir, 'Results', '20221108_WV_shifts', f'{fname}.fits'), coro_dh/norm, overwrite=True)"
+    "# plt.savefig(os.path.join(data_dir, 'Results', '20221108_WV_shifts_inclinations', f'{fname}.pdf'))\n",
+    "# fits.writeto(os.path.join(data_dir, 'Results', '20221108_WV_shifts_inclinations', f'{fname}.fits'), coro_dh/norm, overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab34a73b",
+   "metadata": {},
+   "source": [
+    "## Plotting"
    ]
   },
   {
@@ -234,7 +242,7 @@
    "id": "ddf4c7da",
    "metadata": {},
    "source": [
-    "### Read them all and plot on a grid"
+    "### Read and plot purely shifted images on a grid"
    ]
   },
   {
@@ -249,7 +257,7 @@
     "    for j in range(4):\n",
     "        fname = f'{i}x_{j}y'\n",
     "        print(fname)\n",
-    "        im = fits.getdata(os.path.join(data_dir, 'Results', '20221108_WV_shifts', 'fits', f'{fname}.fits'))\n",
+    "        im = fits.getdata(os.path.join(data_dir, 'Results', '20221108_WV_shifts_inclinations', 'shifts', 'fits', f'{fname}.fits'))\n",
     "        imgs.append(im)"
    ]
   },
@@ -268,17 +276,61 @@
     "        plt.subplot(4, 4, 4*i + j + 1)\n",
     "        fname = f'{i}x_{j}y'\n",
     "        plt.imshow(imgs[4*i+j], cmap='inferno', norm=LogNorm(vmin=1e-8, vmax=1e-6), origin='lower')\n",
-    "        plt.text(150, 350, fname, color='w', fontweight='bold', size=15)\n",
+    "        plt.text(150, 350, fname, color='k', fontweight='bold', size=15)\n",
     "        plt.axis('off')\n",
     "plt.tight_layout()\n",
     "#plt.show()\n",
-    "#plt.savefig(os.path.join(data_dir, 'Results', '20221108_WV_shifts', f'full_grid.pdf'))"
+    "#plt.savefig(os.path.join(data_dir, 'Results', '20221108_WV_shifts_inclinations', 'shifts', f'full_grid.pdf'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55ec43cb",
+   "metadata": {},
+   "source": [
+    "### Read and plot purely inclined images on a grid"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "deba8016",
+   "id": "347b45c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vals = [10, 13, 15, 16, 17, 18, 20, 22]\n",
+    "imgs = []\n",
+    "for deg in vals:\n",
+    "    fname = f'incl_x_{deg}deg'\n",
+    "    print(fname)\n",
+    "    im = fits.getdata(os.path.join(data_dir, 'Results', '20221108_WV_shifts_inclinations', 'inclinations',\n",
+    "                                   'fits', f'{fname}.fits'))\n",
+    "    imgs.append(im)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a85ad3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(18, 9))\n",
+    "for i, deg in enumerate(vals):\n",
+    "    plt.subplot(2, 4, i+1)\n",
+    "    fname = f'{deg}deg'\n",
+    "    plt.imshow(imgs[i], cmap='inferno', norm=LogNorm(vmin=1e-8, vmax=1e-6), origin='lower')\n",
+    "    plt.text(150, 350, fname, color='k', fontweight='bold', size=25)\n",
+    "    plt.axis('off')\n",
+    "plt.tight_layout()\n",
+    "#plt.show()\n",
+    "#plt.savefig(os.path.join(data_dir, 'Results', '20221108_WV_shifts_inclinations', 'inclinations', f'full_grid.pdf'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2948ecc3",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/shift_wrapped_vortex.ipynb
+++ b/notebooks/shift_wrapped_vortex.ipynb
@@ -1,0 +1,253 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "37424f7f",
+   "metadata": {},
+   "source": [
+    "# Simulate wrapped vortex shifts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df75b284",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from astropy.io import fits\n",
+    "import matplotlib as mpl\n",
+    "from matplotlib.colors import LogNorm\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from Asterix import Asterix_root\n",
+    "from Asterix.optics import THD2\n",
+    "from Asterix.utils import create_experiment_dir, get_data_dir, read_parameter_file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46b360b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Some setup for pretty plotting\n",
+    "mpl.rc('image', origin='lower',   # Put the origin in the lower left corner.\n",
+    "       interpolation=None)        # Do not interpolate between pixels in the display."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dec51f2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_dir = get_data_dir()\n",
+    "your_directory = Asterix_root\n",
+    "your_parameter_file_name = 'Example_param_file.ini'\n",
+    "parameter_file_path = os.path.join(your_directory, your_parameter_file_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cbba0966",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Individual readings needed from parameter file\n",
+    "config = read_parameter_file(parameter_file_path)\n",
+    "simu_config = config[\"SIMUconfig\"]\n",
+    "model_local_dir = os.path.join(data_dir, 'Model_local')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52f78b03",
+   "metadata": {},
+   "source": [
+    "### Create THD2 simulator instance\n",
+    "\n",
+    "Do not forget to set the grey pupil parameter in parameterfile to True."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51721570",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thd2 = THD2(parameter_file_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "494b81d5",
+   "metadata": {},
+   "source": [
+    "### Add aberrations to model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a75df0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Phase upstream of the coronagraph (entrance pup)\n",
+    "phase_abb_up = thd2.generate_phase_aberr(simu_config, up_or_down='up', Model_local_dir=model_local_dir)\n",
+    "\n",
+    "# Phase downstream of the coronagraph (Lyot stop)\n",
+    "phase_abb_do = thd2.generate_phase_aberr(simu_config, up_or_down='do', Model_local_dir=model_local_dir)\n",
+    "\n",
+    "# Amplitude upstream of the coronagraph (entrance pup)\n",
+    "ampl_abb_up = thd2.generate_ampl_aberr(simu_config, Model_local_dir=model_local_dir)\n",
+    "\n",
+    "### Create the wavefronts including the phase and amplitude aberrations\n",
+    "# WF in the testbed entrance pupil\n",
+    "input_wavefront = thd2.EF_from_phase_and_ampl(phase_abb=phase_abb_up, ampl_abb=ampl_abb_up)\n",
+    "\n",
+    "# WF in the testbed Lyot stop\n",
+    "wavefront_in_LS = thd2.EF_from_phase_and_ampl(phase_abb=phase_abb_do)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41e04fc3",
+   "metadata": {},
+   "source": [
+    "### Direct PSF for normalization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29f27fb5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "direct = thd2.todetector_intensity(in_contrast=True, entrance_EF=input_wavefront, EF_aberrations_introduced_in_LS=wavefront_in_LS,\n",
+    "                                    photon_noise=False, noFPM=True)\n",
+    "norm = direct.max()\n",
+    "print(norm)\n",
+    "\n",
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.imshow(direct/norm, cmap='inferno', norm=LogNorm(), origin='lower')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51063178",
+   "metadata": {},
+   "source": [
+    "### Coro PSF with flat wavefronts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dad6bb3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "psf_coro = thd2.todetector_intensity(in_contrast=True, entrance_EF=input_wavefront, EF_aberrations_introduced_in_LS=wavefront_in_LS,\n",
+    "                                     photon_noise=False)\n",
+    "\n",
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.imshow(psf_coro/norm, cmap='inferno', norm=LogNorm(), origin='lower')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50dbac72",
+   "metadata": {},
+   "source": [
+    "### Coro PSF with applied DH\n",
+    "\n",
+    "These are DM voltages from a WFS&C run in which the wrapped vortex FPM was perfectly centered. You can play with FPM shifts by restarting the kernel rerunning the entire notebook after adapting the Asterix scripts and configfile."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "630acc86",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiment_dir = os.path.join(data_dir, 'Results', '20221108_14-09-40_My_fourth_experiment')\n",
+    "dh_iteration = 8"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89cc2354",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read DM commands to apply\n",
+    "dm1_voltages = fits.getdata(os.path.join(experiment_dir, 'DM1_voltages.fits'))[dh_iteration - 1]\n",
+    "dm3_voltages = fits.getdata(os.path.join(experiment_dir, 'DM3_voltages.fits'))[dh_iteration - 1]\n",
+    "\n",
+    "# Concatenate into single array\n",
+    "dm_voltages = np.concatenate((dm1_voltages, dm3_voltages))\n",
+    "\n",
+    "print(f'Numer of actuators in testbed: {thd2.number_act}')\n",
+    "print(f'Number of actuators read in: {dm_voltages.shape[0]}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c5e49c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Calculate DH image\n",
+    "coro_dh = thd2.todetector_intensity(in_contrast=True, entrance_EF=input_wavefront, EF_aberrations_introduced_in_LS=wavefront_in_LS,\n",
+    "                                    photon_noise=False, voltage_vector=dm_voltages)\n",
+    "\n",
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.imshow(coro_dh/norm, cmap='inferno', norm=LogNorm(vmin=1e-10, vmax=1e-4), origin='lower')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ead6d432",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/shift_wrapped_vortex.ipynb
+++ b/notebooks/shift_wrapped_vortex.ipynb
@@ -222,13 +222,63 @@
     "\n",
     "plt.figure(figsize=(6, 6))\n",
     "plt.imshow(coro_dh/norm, cmap='inferno', norm=LogNorm(vmin=1e-10, vmax=1e-4), origin='lower')\n",
-    "plt.colorbar()"
+    "plt.colorbar()\n",
+    "\n",
+    "fname = '0x_0y'\n",
+    "# plt.savefig(os.path.join(data_dir, 'Results', '20221108_WV_shifts', f'{fname}.pdf'))\n",
+    "# fits.writeto(os.path.join(data_dir, 'Results', '20221108_WV_shifts', f'{fname}.fits'), coro_dh/norm, overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddf4c7da",
+   "metadata": {},
+   "source": [
+    "### Read them all and plot on a grid"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ead6d432",
+   "id": "1637ad39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imgs = []\n",
+    "for i in range(4):\n",
+    "    for j in range(4):\n",
+    "        fname = f'{i}x_{j}y'\n",
+    "        print(fname)\n",
+    "        im = fits.getdata(os.path.join(data_dir, 'Results', '20221108_WV_shifts', 'fits', f'{fname}.fits'))\n",
+    "        imgs.append(im)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c78480e6",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 10))\n",
+    "for i in range(4):\n",
+    "    for j in range(4):\n",
+    "        plt.subplot(4, 4, 4*i + j + 1)\n",
+    "        fname = f'{i}x_{j}y'\n",
+    "        plt.imshow(imgs[4*i+j], cmap='inferno', norm=LogNorm(vmin=1e-8, vmax=1e-6), origin='lower')\n",
+    "        plt.text(150, 350, fname, color='w', fontweight='bold', size=15)\n",
+    "        plt.axis('off')\n",
+    "plt.tight_layout()\n",
+    "#plt.show()\n",
+    "#plt.savefig(os.path.join(data_dir, 'Results', '20221108_WV_shifts', f'full_grid.pdf'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "deba8016",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/shift_wrapped_vortex.ipynb
+++ b/notebooks/shift_wrapped_vortex.ipynb
@@ -5,7 +5,12 @@
    "id": "37424f7f",
    "metadata": {},
    "source": [
-    "# Simulate wrapped vortex shifts"
+    "# Simulate wrapped vortex shifts\n",
+    "\n",
+    "In the configfile, you need:\n",
+    "\n",
+    "```grey_pupils = True```  \n",
+    "```corona_type = 'wrapped_vortex'```"
    ]
   },
   {

--- a/notebooks/wv_mask_inclination.ipynb
+++ b/notebooks/wv_mask_inclination.ipynb
@@ -1,0 +1,108 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ea85ad86",
+   "metadata": {},
+   "source": [
+    "# Wrapped vortex mask inclination\n",
+    "\n",
+    "Testing the implementation of grid inclination for the wrapped vortex phase mask."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fc53f98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib as mpl\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from Asterix.optics import create_wrapped_vortex_mask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4581f2b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Overall WV parameters\n",
+    "thval = np.array([0, 3, 4, 5, 8]) * np.pi / 8\n",
+    "phval = np.array([3, 0, 1, 2, 1]) * np.pi\n",
+    "jump = np.array([2, 2, 2, 2]) * np.pi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43a01b8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# inclination = 0 deg\n",
+    "_, fpm = create_wrapped_vortex_mask(dim=512,\n",
+    "                                    thval=thval,\n",
+    "                                    phval=phval,\n",
+    "                                    jump=jump)\n",
+    "\n",
+    "# non-zero inclination of FPM\n",
+    "incl_x = 50  # deg\n",
+    "incl_y = 0\n",
+    "_, fpm_incl = create_wrapped_vortex_mask(dim=512,\n",
+    "                                    thval=thval,\n",
+    "                                    phval=phval,\n",
+    "                                    jump=jump,\n",
+    "                                    inclination_x=incl_x,\n",
+    "                                    inclination_y=incl_y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cfce1199",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(16, 8))\n",
+    "plt.subplot(1, 2, 1)\n",
+    "plt.imshow(fpm, cmap='RdBu', origin='lower')\n",
+    "plt.subplot(1, 2, 2)\n",
+    "plt.imshow(fpm_incl, cmap='RdBu', origin='lower')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96a807af",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Depends on #85.

Replaced by #118.

> This PR adds the option to incline the wrapped vortex phase mask along either of the two axes. Below is an example of inclining it by 50 degrees around the x axis (right), compared to no inclination (left):
> ![Screen Shot 2022-11-08 at 17 21 43](https://user-images.githubusercontent.com/29508965/200619797-3e85d45c-3905-419e-b1d5-defa0842e503.png)

> I also committed the notebooks here that I used to test this, and in which I ran some tests to investigate the effect of a shifted and/or inclined phase mask.

Note how the notebooks used the `THD2` class introduced in #85.