### PR TITLE
Install pyan3 in source/conf.py to make it run in read the doc

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -15,6 +15,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath('../..'))
 sys.path.append('/Users/jmazoyer/GitProjects/my_projects/Asterix/Asterix/')
+os.system('pip install pyan3')
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
Exceptionally bypassing review because very small modification changing only the source documentation to be able to run Read the Docs