### PR TITLE
Make FQPM use zoom-in propagation

### DIFF
--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -55,7 +55,7 @@ onbench=True
     # if True, all the pupils will be created 10x larger than diam_pup_in_pix and 
     # then rebinned to diam_pup_in_pix at the exception of pupils that are read in 
     # a fit file, which are always rebinned from the sixe of the .fits
-    grey_pupils = False
+    grey_pupils = True
 
 [DMconfig]
 

--- a/Asterix/optics/coronagraph.py
+++ b/Asterix/optics/coronagraph.py
@@ -60,7 +60,7 @@ class Coronagraph(optsy.OpticalSystem):
             # We do not need to be exact, the mft in science_focal_plane will be
 
         if self.corona_type == "fqpm":
-            self.prop_apod2lyot = 'mft'
+            self.prop_apod2lyot = 'regional-sampling'
             self.err_fqpm = coroconfig["err_fqpm"]
             self.achrom_fqpm = coroconfig["achrom_fqpm"]
             self.FPmsk = self.FQPM()
@@ -69,7 +69,7 @@ class Coronagraph(optsy.OpticalSystem):
             else:
                 str_achrom = "nonachrom"
             self.string_os += '_' + str_achrom
-            self.perfect_coro = True
+            self.perfect_coro = False
 
         elif self.corona_type in ("classiclyot", "hlc"):
             self.prop_apod2lyot = 'mft-babinet'

--- a/Asterix/tests/test_coronagraph.py
+++ b/Asterix/tests/test_coronagraph.py
@@ -6,7 +6,7 @@ from Asterix.utils import read_parameter_file
 from Asterix.optics import Coronagraph, create_wrapped_vortex_mask, fqpm_mask
 
 
-def test_default_coronagraph():
+def test_fqpm_coronagraph():
     # Load the example parameter file
     parameter_file_ex = os.path.join(Asterix_root, "Example_param_file.ini")
     config = read_parameter_file(parameter_file_ex)
@@ -15,16 +15,19 @@ def test_default_coronagraph():
     modelconfig = config["modelconfig"]
     Coronaconfig = config["Coronaconfig"]
 
+    # Set coronagraph to be tested
+    Coronaconfig.update({"corona_type": "fqpm"})
+
     # Update the pixels across the pupil
     modelconfig.update({'diam_pup_in_pix': 80})
     # Define a round pupil in the apodization plane
-    Coronaconfig.update({'filename_instr_apod': "RoundPup"})
+    Coronaconfig.update({"filename_instr_apod": "RoundPup"})
 
     # Create the coronagraph
     corono = Coronagraph(modelconfig, Coronaconfig)
-    coro_psf = corono.todetector_intensity(center_on_pixel=True)
+    coro_psf = corono.todetector_intensity(center_on_pixel=True, in_contrast=True)
 
-    assert np.max(coro_psf) == 0.0, "A perfect coronagraph should return an empty array."
+    assert np.max(coro_psf) < 1e-6
 
 
 def test_wrapped_vortex_phase_mask():


### PR DESCRIPTION
Fixes #89.

This PR changes the FQPM propagations to use the zoom-in sampling. The peak attenuation attained like this is somewhat better than 1e-6 for a 80 pixel round, grey pupil and somewhat better than 1e-7 for a 200 pixel round, grey pupil. I am unsure whether this is sufficient to motivate this change. By comparison the wrapped vortex doesn't do all that much better, the difference is approximately a factor of two.

I also set the pupil to a grey pupil by default in the parameter file. This is needed to make the zoom-in sampled propagation work. There was a question whether this would pose problems for the RST pupils but no, as they gery-scaling is only used for round pupils, not for read-in pupil files.

I also adapted some of the tests. If we don't want to keep the FQPM change after all, I would change this PR so that we can at least merge the updated tests.

If we do change the FQPM, the question arises as whether we should change the Vortex to use the zoom-in propagation too, as it would be the last remaining "perfect" coronagraph by default in Asterix. It yields about the same peak attenuation like the wrapped vortex.

It might be useful to tie the decisions (whether to change to the new propagation function) to a hardware test on THD2.

Needs discussion @johanmazoyer.