### PR TITLE
Remove type hints from code

### DIFF
--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 from astropy.io import fits
 
 from Asterix.utils import plot_contrast_curves, from_param_to_header
-from Asterix.optics import DeformableMirror, Testbed
+from Asterix.optics import Testbed
 
 import Asterix.wfsc.corrector as corrector_mod
 import Asterix.wfsc.estimator as estimator_mod

--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -469,7 +469,7 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
 
         fits.writeto(os.path.join(result_dir, f"{DM_name}_strokes.fits"), DMstrokes[j], header, overwrite=True)
 
-        DM = vars(testbed)[DM_name]  # type: DeformableMirror
+        DM = vars(testbed)[DM_name]
         voltage_DMs_tosave = voltage_DMs_nparray[:, indice_acum_number_act:indice_acum_number_act + DM.number_act]
         indice_acum_number_act += DM.number_act
 

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -77,7 +77,7 @@ class Corrector:
         self.total_number_modes = 0
 
         for DM_name in testbed.name_of_DMs:
-            DM = vars(testbed)[DM_name]  # type: DeformableMirror
+            DM = vars(testbed)[DM_name]
             DM.basis = DM.create_DM_basis(basis_type=basis_type)
             DM.basis_size = DM.basis.shape[0]
             self.total_number_modes += DM.basis_size
@@ -162,7 +162,7 @@ class Corrector:
         # DM for a given voltage when using DM.voltage_to_phase
 
         for DM_name in testbed.name_of_DMs:
-            DM = vars(testbed)[DM_name]  # type: DeformableMirror
+            DM = vars(testbed)[DM_name]
             if DM.misregistration:
                 print(DM_name + " Misregistration!")
                 DM.DM_pushact = DM.creatingpushact(DM.DMconfig)
@@ -280,7 +280,7 @@ class Corrector:
             # for num_DM, DM_name in enumerate(testbed.name_of_DMs):
 
             #     # we access each DM object individually
-            #     DM = vars(testbed)[DM_name]  # type: DeformableMirror
+            #     DM = vars(testbed)[DM_name]
 
             #     # we multpily each DM by a specific DM gain
             #     solutionefc[
@@ -340,7 +340,7 @@ class Corrector:
             # for num_DM, DM_name in enumerate(testbed.name_of_DMs):
 
             #     # we access each DM object individually
-            #     DM = vars(testbed)[DM_name]  # type: DeformableMirror
+            #     DM = vars(testbed)[DM_name]
 
             #     # we multpily each DM by a specific DM gain
             #     solutionSM[

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -3,7 +3,7 @@ import numpy as np
 from astropy.io import fits
 
 from Asterix.utils import invert_svd
-from Asterix.optics import OpticalSystem, DeformableMirror, Testbed
+from Asterix.optics import OpticalSystem, Testbed
 
 import Asterix.wfsc.estimator as estimator_mod
 import Asterix.wfsc.thd_quick_invert as thd_quick_invert

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -331,7 +331,7 @@ class Estimator:
             # If several DMs we check if there is at least one in PP
             number_DMs_in_PP = 0
             for DM_name in testbed.name_of_DMs:
-                DM = vars(testbed)[DM_name]  # type: DeformableMirror
+                DM = vars(testbed)[DM_name]
                 if DM.z_position == 0.:
                     number_DMs_in_PP += 1
                     name_DM_to_probe_in_PW = DM_name

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -3,7 +3,7 @@ import numpy as np
 from astropy.io import fits
 
 from Asterix.utils import resizing
-from Asterix.optics import OpticalSystem, DeformableMirror, Testbed
+from Asterix.optics import OpticalSystem, Testbed
 
 import Asterix.wfsc.wf_sensing_functions as wfs
 

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -12,6 +12,7 @@ from Asterix.utils import resizing, crop_or_pad_image, save_plane_in_fits, progr
 import Asterix.optics.propagation_functions as prop
 from Asterix.optics import OpticalSystem, DeformableMirror, Testbed
 
+
 def create_interaction_matrix(testbed: Testbed,
                               dimEstim,
                               amplitudeEFC,
@@ -224,7 +225,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
 
     for i, DM_name in enumerate(testbed.name_of_DMs):
 
-        DM = vars(testbed)[DM_name]
+        DM = vars(testbed)[DM_name]  # type: DeformableMirror
         total_number_basis_modes += DM.basis_size
         DM_small_str = "_" + "_".join(DM.string_os.split("_")[4:])
         string_testbed_without_DMS = string_testbed_without_DMS.replace(DM_small_str, '')
@@ -254,7 +255,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
 
     for DM_name in testbed.name_of_DMs:
 
-        DM = vars(testbed)[DM_name]
+        DM = vars(testbed)[DM_name]  # type: DeformableMirror
         DM_small_str = "_" + "_".join(DM.string_os.split("_")[5:])
 
         basis_str = DM_small_str + "_" + DM.basis_type + "Basis" + str(DM.basis_size)
@@ -494,7 +495,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
 
     # clean to save memory
     for i, DM_name in enumerate(testbed.name_of_DMs):
-        DM = vars(testbed)[DM_name]
+        DM = vars(testbed)[DM_name]  # type: DeformableMirror
         DM.phase_init = 0
 
     return InterMat

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -224,7 +224,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
 
     for i, DM_name in enumerate(testbed.name_of_DMs):
 
-        DM = vars(testbed)[DM_name]  # type: DeformableMirror
+        DM = vars(testbed)[DM_name]
         total_number_basis_modes += DM.basis_size
         DM_small_str = "_" + "_".join(DM.string_os.split("_")[4:])
         string_testbed_without_DMS = string_testbed_without_DMS.replace(DM_small_str, '')
@@ -254,7 +254,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
 
     for DM_name in testbed.name_of_DMs:
 
-        DM = vars(testbed)[DM_name]  # type: DeformableMirror
+        DM = vars(testbed)[DM_name]
         DM_small_str = "_" + "_".join(DM.string_os.split("_")[5:])
 
         basis_str = DM_small_str + "_" + DM.basis_type + "Basis" + str(DM.basis_size)
@@ -494,7 +494,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
 
     # clean to save memory
     for i, DM_name in enumerate(testbed.name_of_DMs):
-        DM = vars(testbed)[DM_name]  # type: DeformableMirror
+        DM = vars(testbed)[DM_name]
         DM.phase_init = 0
 
     return InterMat

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -139,7 +139,7 @@ def create_singlewl_pw_matrix(testbed: Testbed, amplitude, posprobes, dimEstim, 
     PWMatrix = np.zeros((dimEstim**2, 2, numprobe))
     SVD = np.zeros((2, dimEstim, dimEstim))
 
-    DM_probe = vars(testbed)[testbed.name_DM_to_probe_in_PW]  # type: DeformableMirror
+    DM_probe = vars(testbed)[testbed.name_DM_to_probe_in_PW]
 
     #### TODO Careful. right now, you can only do estimation at the wl that are in
     ### the testbed.wav_vec vector. If you're not, you'll run into a bug in
@@ -285,7 +285,7 @@ def simulate_pw_difference(input_wavefront,
         indice_acum_number_act = 0
 
         for DM_name in testbed.name_of_DMs:
-            DM = vars(testbed)[DM_name]  # type: DeformableMirror
+            DM = vars(testbed)[DM_name]
 
             if DM_name == testbed.name_DM_to_probe_in_PW:
                 Voltage_probeDMprobe = np.zeros(DM.number_act)

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -5,7 +5,7 @@ import numpy as np
 from astropy.io import fits
 
 from Asterix.utils import resizing, invert_svd, save_plane_in_fits
-from Asterix.optics import DeformableMirror, Testbed
+from Asterix.optics import Testbed
 
 
 def create_pw_matrix(testbed: Testbed,


### PR DESCRIPTION
Something changed in the package or CI setup so that the classes imported for type hinting are now flagged as unused imports, an issue we have not had before. Discovered while working on #124, one failed run here:
https://github.com/johanmazoyer/Asterix/actions/runs/3567127502/jobs/5994434054

So just removing them for now until we either figure something out or just carry on like this.