### PR TITLE
Update coronagraph tests

### DIFF
--- a/Asterix/tests/test_coronagraph.py
+++ b/Asterix/tests/test_coronagraph.py
@@ -17,7 +17,7 @@ def test_all_coronagraphs():
 
     # Set coronagraph to be tested
     coros_to_test = ["fqpm", "wrapped_vortex", "classiclyot", "knife", "hlc"]#, "vortex]  # Vortex is only non-perfect coronagraph left.
-    expected_attenuation = [1e-6, 1e-6, 1e-2, 1e-1, 1e-2]  # Note that these are for the 80 px pupil below
+    expected_attenuation = [1e-20, 1e-5, 1e-2, 1e-1, 1e-2]  # Note that these are for the 80 px pupil below
 
     for i, coro in enumerate(coros_to_test):
         Coronaconfig.update({"corona_type": coro})

--- a/Asterix/tests/test_coronagraph.py
+++ b/Asterix/tests/test_coronagraph.py
@@ -6,7 +6,7 @@ from Asterix.utils import read_parameter_file
 from Asterix.optics import Coronagraph, create_wrapped_vortex_mask, fqpm_mask
 
 
-def test_default_coronagraph():
+def test_fqpm_coronagraph():
     # Load the example parameter file
     parameter_file_ex = os.path.join(Asterix_root, "Example_param_file.ini")
     config = read_parameter_file(parameter_file_ex)
@@ -15,16 +15,19 @@ def test_default_coronagraph():
     modelconfig = config["modelconfig"]
     Coronaconfig = config["Coronaconfig"]
 
+    # Set coronagraph to be tested
+    Coronaconfig.update({"corona_type": "fqpm"})
+
     # Update the pixels across the pupil
     modelconfig.update({'diam_pup_in_pix': 80})
     # Define a round pupil in the apodization plane
-    Coronaconfig.update({'filename_instr_apod': "RoundPup"})
+    Coronaconfig.update({"filename_instr_apod": "RoundPup"})
 
     # Create the coronagraph
     corono = Coronagraph(modelconfig, Coronaconfig)
-    coro_psf = corono.todetector_intensity(center_on_pixel=True)
+    coro_psf = corono.todetector_intensity(center_on_pixel=True, in_contrast=True)
 
-    assert np.max(coro_psf) == 0.0, "A perfect coronagraph should return an empty array."
+    assert np.max(coro_psf) < 1e-6
 
 
 def test_wrapped_vortex_phase_mask():

--- a/Asterix/tests/test_coronagraph.py
+++ b/Asterix/tests/test_coronagraph.py
@@ -16,8 +16,9 @@ def test_all_coronagraphs():
     Coronaconfig = config["Coronaconfig"]
 
     # Set coronagraph to be tested
-    coros_to_test = ["fqpm", "wrapped_vortex", "classiclyot", "knife", "hlc"]#, "vortex]  # Vortex is only non-perfect coronagraph left.
-    expected_attenuation = [1e-20, 1e-5, 1e-2, 1e-1, 1e-2]  # Note that these are for the 80 px pupil below
+    coros_to_test = ["fqpm", "wrapped_vortex", "classiclyot", "knife", "hlc", "vortex"]
+    expected_attenuation = [1e-20, 1e-5, 1e-2, 1e-1, 1e-2, 1e-20]  # Note that these are for the 80 px pupil below
+    atols = [0, 2e-19, 3e-18, np.nan, 3e-18, 0]   # zeros are for perfect coronagraphs
 
     for i, coro in enumerate(coros_to_test):
         Coronaconfig.update({"corona_type": coro})
@@ -32,6 +33,9 @@ def test_all_coronagraphs():
         coro_psf = corono.todetector_intensity(center_on_pixel=True, in_contrast=True)
 
         assert np.max(coro_psf) < expected_attenuation[i], f"Attenuation of '{coro}' not below expected {expected_attenuation[i]}."
+        if coro != 'knife':
+            assert np.allclose(coro_psf, np.transpose(coro_psf), atol=atols[i],
+                               rtol=0), f"Coronagraphic image is not symmetric in transpose for '{coro}'."
 
 
 def test_wrapped_vortex_phase_mask():


### PR DESCRIPTION
I split up #121 after all since we want to progress on the CI tests.

This PR modifies the test for the "default" coronagraph to include all coronagraph options of Asterix, significantly increasing test coverage. And I adapt the test for the zoom-in sampled propagation function to also test on the wrapped vortex coro, not just on the FQPM.

Notes for later:
- this does *not* change the FQPM default propagation, it sticks with MFTs, but also an artificial perfect coronagraph
- the fact that the FQPM is artifically set to produce zero light means I changed its expected attenuation to 1e-20, which will need to be changed if we ever change the propagation the FQPM uses
- equally, if we ever set the pupils to default to grey pupils, we can improve the expected attenuation factor of tthe WV coro