### PR TITLE
Write out FPM in zoom-in propagation when requested

### DIFF
--- a/Asterix/optics/coronagraph.py
+++ b/Asterix/optics/coronagraph.py
@@ -381,6 +381,17 @@ class Coronagraph(optsy.OpticalSystem):
                 fpm_array = np.ones((self.dimScience, self.dimScience))
             else:
                 fpm_array = FPmsk
+
+                if dir_save_all_planes is not None:
+                    name_plane = 'FPM' + f'_wl{int(wavelength * 1e9)}'
+                    save_plane_in_fits(dir_save_all_planes, name_plane, FPmsk)
+
+                    name_plane = 'FPMphase' + f'_wl{int(wavelength * 1e9)}'
+                    save_plane_in_fits(dir_save_all_planes, name_plane, np.angle(FPmsk))
+
+                    name_plane = 'FPMmod' + f'_wl{int(wavelength * 1e9)}'
+                    save_plane_in_fits(dir_save_all_planes, name_plane, np.abs(FPmsk))
+
             lyotplane_before_lyot = prop.prop_fpm_regional_sampling(input_wavefront_after_apod,
                                                                     fpm_array,
                                                                     nbres=np.array([0.1, 5, 50, 100]),


### PR DESCRIPTION
I hadn't implemented any writing out of intermediary planes in the focal plane when we merged the zoom-in sampling, this PR adds the option to write out the FPM when the appropriate keyword is set.

I tested this with the wrapped vortex coronagraph and it works fine.