### PR TITLE
Time-stamped sub folders and commit hash for Labview matrices

### DIFF
--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -1,6 +1,6 @@
 import os
 
-from Asterix.utils import create_experiment_dir, get_data_dir, read_parameter_file
+from Asterix.utils import create_experiment_dir, get_data_dir, get_git_description, read_parameter_file
 from Asterix.optics import Pupil, Coronagraph, DeformableMirror, Testbed
 from Asterix.wfsc import Estimator, Corrector, MaskDH, correction_loop, save_loop_results
 
@@ -87,6 +87,9 @@ def runthd2(parameter_file_path,
         Whether to silence correction loop outputs; default False.
     """
 
+    # Get git commit hash
+    commit = get_git_description()
+
     # Load configuration file
     config = read_parameter_file(parameter_file_path,
                                  NewMODELconfig=NewMODELconfig,
@@ -109,7 +112,8 @@ def runthd2(parameter_file_path,
     model_local_dir = os.path.join(data_dir, "Model_local")
     matrix_dir = os.path.join(data_dir, "Interaction_Matrices")
     result_dir = os.path.join(data_dir, "Results", name_experiment)
-    labview_dir = os.path.join(data_dir, "Labview", create_experiment_dir(append=config["Coronaconfig"]["corona_type"]))
+    labview_dir = os.path.join(data_dir, "Labview",
+                               create_experiment_dir(append=config["Coronaconfig"]["corona_type"]) + f"_{commit}")
 
     # Concatenate into the full testbed optical system
     thd2 = THD2(config, model_local_dir)

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -109,7 +109,7 @@ def runthd2(parameter_file_path,
     model_local_dir = os.path.join(data_dir, "Model_local")
     matrix_dir = os.path.join(data_dir, "Interaction_Matrices")
     result_dir = os.path.join(data_dir, "Results", name_experiment)
-    labview_dir = os.path.join(data_dir, "Labview")
+    labview_dir = os.path.join(data_dir, "Labview", create_experiment_dir(append=config["Coronaconfig"]["corona_type"]))
 
     # Concatenate into the full testbed optical system
     thd2 = THD2(config, model_local_dir)

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -2,6 +2,8 @@ import errno
 import sys
 import os
 import time
+import subprocess
+import warnings
 
 import datetime
 import numpy as np
@@ -254,3 +256,21 @@ def create_experiment_dir(append=''):
 
     experiment_folder = date_time_string + append
     return experiment_folder
+
+
+def get_git_description():
+    """ Return git description of current branch and commit. """
+
+    # Ensure we run this in the code repo, regardless of current working dir
+    codedir = os.path.dirname(__file__)
+
+    def get_output_wrapper(cmd):
+        return subprocess.check_output(cmd.split(), universal_newlines=True, cwd=codedir).strip()
+
+    try:
+        desc = get_output_wrapper('git rev-parse --short HEAD')
+    except Exception:
+        warnings.warn("Unable to get git description")
+        desc = 'unable to get git hash'
+
+    return desc

--- a/Asterix/wfsc/thd_quick_invert.py
+++ b/Asterix/wfsc/thd_quick_invert.py
@@ -23,7 +23,7 @@ def THD_quick_invert(Nbmodes, name_active_DM, matrix_directory, regularization, 
             - Base_Matrix_DM1.fits
             - Direct_Matrix_2DM.fits
 
-    Save the following fits files (that can be read by the testbed controls):
+    Save the following fits files (that can be read by the testbed RTC):
         if DM1 only is active:
             - Matrix_control_EFC_DM1.fits
         if DM3 only is active:

--- a/Asterix/wfsc/thd_quick_invert.py
+++ b/Asterix/wfsc/thd_quick_invert.py
@@ -8,11 +8,10 @@ from Asterix.utils import invert_svd
 
 
 def THD_quick_invert(Nbmodes, name_active_DM, matrix_directory, regularization, number_wl_in_matrix=1):
-    """This code invert the matrix just in the case of THD testbed The goal is
-    to be able to invert the matrix directly on the RTC to be able to do it
-    during correction.
+    """This code invert the matrix just in the case of THD testbed.
 
-    Need the following fits (automatically created in corrector.py is onbench = True):
+    The goal is to be able to invert the matrix directly on the RTC to be able to do it during correction.
+    Needs the following fits files (automatically created in corrector.py if onbench == True):
         if DM1 only is active:
             - Base_Matrix_DM1.fits
             - Direct_Matrix_DM1only.fits
@@ -24,7 +23,7 @@ def THD_quick_invert(Nbmodes, name_active_DM, matrix_directory, regularization, 
             - Base_Matrix_DM1.fits
             - Direct_Matrix_2DM.fits
 
-    Save the following fits (that can be read by the testbed):
+    Save the following fits files (that can be read by the testbed controls):
         if DM1 only is active:
             - Matrix_control_EFC_DM1.fits
         if DM3 only is active:
@@ -37,24 +36,18 @@ def THD_quick_invert(Nbmodes, name_active_DM, matrix_directory, regularization, 
 
     Parameters
     ----------
-
-    Nbmodes: int
+    Nbmodes : int
         threshold to cut the singular values
-
     name_active_DM : int
         Simple code to identify which DMs are active
         1, 3 or 13 depending on the DM you want to access
-
     matrix_directory : str
-                    Directory where Direct matrices are read and Inverse matrices are saved
-                    Careful Windows and MacOS do not write path the same way
-
+        Directory where Direct matrices are read from and Inverse matrices are saved to.
     regularization : string, default 'truncation'
         if 'truncation': when goal is set to 'c', the modes with the highest inverse
                         singular values are truncated
         if 'tikhonov': when goal is set to 'c', the modes with the highest inverse
                         singular values are smoothed (low pass filter)
-
     number_wl_in_matrix : int, default 1
         number of wavelength in the direct matrix
     """


### PR DESCRIPTION
I would like to save the matrix files created for the Labview controls to individual sub-folders each time they are generated, with each sub-folder getting a time stamp much like the data result folders. This prevents over-writing when running several simulated experiments sequentially. I also added the coronagraph type to the directory name to have at least some initial info, but I am keeping the file names purposefully simple, leaving it up to the user to rename them as needed, since this will likely always be needed.

The second thing added to the sub-folder name is the short commit hash of the repo version the data has been created with.

This will allow us to create a bunch of hardware-ready matrix directories in one go, and trace which commit they have been created on.

Note how this does not distinguish between clean and dirty commits. This means if you are on a commit but you have uncommitted changes, those changes will be reflected in the created matrix but not in the code references (as it's uncommitted changes). We could add a flag for dirty commits but the version here should be sufficient for now.