### PR TITLE
Match WV phase mask orientation on THD2 testbed

### DIFF
--- a/Asterix/optics/coronagraph.py
+++ b/Asterix/optics/coronagraph.py
@@ -532,6 +532,9 @@ class Coronagraph(optsy.OpticalSystem):
                                                              inclination_x=inclination_x,
                                                              inclination_y=inclination_y)
 
+        # Match the orientation of the phase mask to THD2
+        phase_wrapped_vortex = np.rot90(phase_wrapped_vortex)
+
         wrapped_vortex = list()
         for i, wav in enumerate(self.wav_vec):
             if self.prop_apod2lyot == "fft":


### PR DESCRIPTION
See title.

I did this by comparing to the code setup of a commit that creates matrices that work on the testbed and manage to create a DH.

The phase masks look like this:
<img width="976" alt="phase_masks" src="https://user-images.githubusercontent.com/29508965/208973754-30d852f3-2517-4be4-8ceb-fef7eb083206.png">
Left the old commit (213d669b) from fits file including a flip and a rotation, center the correctly rotated phase mask from Asterix to match that, here on this branch, right their difference normalized by the max of the fits-file version (left).

(Note how commit 08b91a is now [79fc551](https://github.com/johanmazoyer/Asterix/pull/145/commits/79fc551edcf252a4cbea6b5dc50753d8b6ae1008) because I rebased.)

This is completely unrelated to the type of propagation, we are going to test matrices generated with this but using MFTs on the hardware. If that works (🤞 ), we can focus on figuring out what's up with our zoom-in sampled propagations (see #142 and #144).

Below a comparison of interaction matrices from both commits. I take a random piece of the DM3 interaction matrix for Labview, as calcualted on commit 213d669b and calculated on this branch, subtract them, then normalize by the max of the commit 213d669b matrix. **Both matrices have been generated with MFT propagations.** Their relative difference is very small.
<img width="495" alt="jacobians" src="https://user-images.githubusercontent.com/29508965/208975202-6aff5e4e-4487-4eee-b9f0-e61096a8cd46.png">