### PR TITLE
Option to pre calculate mft matrices or not

### DIFF
--- a/Asterix/optics/coronagraph.py
+++ b/Asterix/optics/coronagraph.py
@@ -214,6 +214,7 @@ class Coronagraph(optsy.OpticalSystem):
                 self.nbrs_res_list,
                 real_dim_input=int(2 * self.prad),
                 returnAAsBBs=True,
+                shift=(0, 0),
                 filter_order=15,
                 alpha=1.5)
 
@@ -480,7 +481,9 @@ class Coronagraph(optsy.OpticalSystem):
                                                                    FPmsk,
                                                                    self.nbrs_res_list,
                                                                    real_dim_input=int(2 * self.prad),
-                                                                   shift=(0, 0))
+                                                                   shift=(0, 0),
+                                                                   filter_order=15,
+                                                                   alpha=1.5)
 
         else:
             raise ValueError(f"{self.prop_apod2lyot} is not a known `prop_apod2lyot` propagation method")


### PR DESCRIPTION
Some options are not possible if we precalculate the MFT matrices (like introducing an offset in the focal plane in `prop_fpm_regional_sampling`). For this reason, this PR introduce a hardcoded parameter `precalculate_mft_matrices` for all `OpticalSystem`s which allow us to easily go back to the option of recalculating the matrices all the times. This is slower but allow more freedom for  advanced users. 

We pytested both case precalculate_mft_matrices = True and precalculate_mft_matrices = False

precalculate_mft_matrices = True is still the default (faster but you cannot do more advanced stuff in the propagation)
