### PR TITLE
Small vortex upgrade

### DIFF
--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -11,7 +11,7 @@ onbench=True
 [modelconfig]
 
     # central wavelength (in meters)
-    wavelength_0 = 783.6e-9
+    wavelength_0 = 783.6e-9 # 700e-9 # 670e-9 # 640e-9
 
     # Spectral band (in meters)
     Delta_wav = 0 #80e-9
@@ -27,7 +27,10 @@ onbench=True
     # Sampling in the detector science image
     #(lambda/Entrance_pupil_diameter in pixel
     # For THD2 testbed : 7.42 pix / L/D for the 783.6 laser
-    Science_sampling = 7.42
+    # For THD2 testbed : 6.62 pix / L/D for the 700 laser
+    # For THD2 testbed : 6.34 pix / L/D for the 670 laser
+    # For THD2 testbed : 6.06 pix / L/D for the 640 laser    
+    Science_sampling = 6.62
 
     # pupil diameter (in meters)
     diam_pup_in_m = 8.3e-3
@@ -210,7 +213,7 @@ onbench=True
     err_fqpm = 0
 
     #If Vortex, define the charge of the vortex
-    vortex_charge = 2
+    vortex_charge = 4
 
     # If phase coronagraph, we can choose to use it in achromatic mode (the coronagraph diplays
     # the same behavior for each wavelengths) or not (phase is introduced by material step and
@@ -253,7 +256,7 @@ onbench=True
     # Method 2: hand-pick selection. If estimation_wls parameter is not an empty list ('estimation_wls != ,')
     # then this parameter is used to individually hand pick the estimation / correction wavelengths
     # If polychromatic = 'singlewl' estimation_wls must be a unique element.
-    estimation_wls = , #753e-9, 783e-9, 813e-9
+    estimation_wls = ,#640e-9, 700e-9
 
     # if polychromatic = 'multiwl', this is the spectral bandwidth for the "monochromatic" 
     # probes this is only used for photon noise of the probes (in a ratio with Delta_wav parameter 
@@ -293,7 +296,7 @@ onbench=True
     # Not case sensitive
     DH_side = "Full"
 
-    Sep_Min_Max = 0,10
+    Sep_Min_Max = 0,12 # 11.46 # 12.54
     #if circle inner and outer radii of the circle DH size in lambda/D
 
     #if DH_shape == 'circle'

--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -26,11 +26,11 @@ onbench=True
 
     # Sampling in the detector science image
     #(lambda/Entrance_pupil_diameter in pixel
-    # For THD2 testbed : 7.42 pix / L/D for the 783.6 laser
-    # For THD2 testbed : 6.62 pix / L/D for the 700 laser
-    # For THD2 testbed : 6.34 pix / L/D for the 670 laser
-    # For THD2 testbed : 6.06 pix / L/D for the 640 laser    
-    Science_sampling = 6.62
+    # For THD2 testbed : 7.42 pix / L/D for the 783.6nm laser
+    # For THD2 testbed : 6.62 pix / L/D for the 700nm laser
+    # For THD2 testbed : 6.34 pix / L/D for the 670nm laser
+    # For THD2 testbed : 6.06 pix / L/D for the 640nm laser    
+    Science_sampling = 7.42
 
     # pupil diameter (in meters)
     diam_pup_in_m = 8.3e-3

--- a/Asterix/optics/coronagraph.py
+++ b/Asterix/optics/coronagraph.py
@@ -75,7 +75,7 @@ class Coronagraph(optsy.OpticalSystem):
             rad_LyotFP_pix = self.rad_lyot_fpm * self.Lyot_fpm_sampling
             self.dim_fpm = 2 * int(2.2 * rad_LyotFP_pix / 2)
 
-        elif self.corona_type in ("vortex", "wrapped_vortex"):
+        elif self.corona_type == "wrapped_vortex":
             self.prop_apod2lyot = 'regional-sampling'
             if self.prad < 100:
                 raise ValueError("In regional-sampling mode, [modelconfig]['diam_pup_in_pix'] parameter must "
@@ -86,7 +86,7 @@ class Coronagraph(optsy.OpticalSystem):
             self.dim_fpm = 300
             self.nbrs_res_list = [10, 78]
 
-        elif self.corona_type in ("fqpm", "knife"):
+        elif self.corona_type in ("vortex", "fqpm", "knife"):
             self.prop_apod2lyot = 'mft'
 
         else:
@@ -138,7 +138,7 @@ class Coronagraph(optsy.OpticalSystem):
             vortex_charge = coroconfig["vortex_charge"]
             self.string_os += '_charge' + str(int(vortex_charge))
             self.FPmsk = self.Vortex(vortex_charge=vortex_charge)
-            self.perfect_coro = False
+            self.perfect_coro = True
             if self.achrom_phase_coro:
                 self.string_os += '_' + "achrom"
 
@@ -570,6 +570,8 @@ class Coronagraph(optsy.OpticalSystem):
 
         if self.prop_apod2lyot == "fft":
             maxdimension_array_fpm = np.max(self.dim_fp_fft)
+        elif self.prop_apod2lyot == "mft":
+            maxdimension_array_fpm = self.dimScience
         else:
             maxdimension_array_fpm = self.dim_fpm
 
@@ -583,6 +585,8 @@ class Coronagraph(optsy.OpticalSystem):
         for i, wav in enumerate(self.wav_vec):
             if self.prop_apod2lyot == "fft":
                 dim_fp = self.dim_fp_fft[i]
+            elif self.prop_apod2lyot == "mft":
+                dim_fp = self.dimScience
             else:
                 dim_fp = self.dim_fpm
 

--- a/Asterix/thd2_setups/fqpm_parameters.ini
+++ b/Asterix/thd2_setups/fqpm_parameters.ini
@@ -27,6 +27,9 @@ onbench=True
     # Sampling in the detector science image
     #(lambda/Entrance_pupil_diameter in pixel
     # For THD2 testbed : 7.42 pix / L/D for the 783.6nm laser
+    # For THD2 testbed : 6.62 pix / L/D for the 700nm laser
+    # For THD2 testbed : 6.34 pix / L/D for the 670nm laser
+    # For THD2 testbed : 6.06 pix / L/D for the 640nm laser
     Science_sampling = 7.42
 
     # pupil diameter (in meters)

--- a/Asterix/thd2_setups/fqpm_parameters.ini
+++ b/Asterix/thd2_setups/fqpm_parameters.ini
@@ -27,9 +27,6 @@ onbench=True
     # Sampling in the detector science image
     #(lambda/Entrance_pupil_diameter in pixel
     # For THD2 testbed : 7.42 pix / L/D for the 783.6nm laser
-    # For THD2 testbed : 6.62 pix / L/D for the 700nm laser
-    # For THD2 testbed : 6.34 pix / L/D for the 670nm laser
-    # For THD2 testbed : 6.06 pix / L/D for the 640nm laser
     Science_sampling = 7.42
 
     # pupil diameter (in meters)

--- a/Asterix/thd2_setups/fqpm_parameters.ini
+++ b/Asterix/thd2_setups/fqpm_parameters.ini
@@ -26,7 +26,8 @@ onbench=True
 
     # Sampling in the detector science image
     #(lambda/Entrance_pupil_diameter in pixel
-    Science_sampling = 7.25
+    # For THD2 testbed : 7.42 pix / L/D for the 783.6nm laser
+    Science_sampling = 7.42
 
     # pupil diameter (in meters)
     diam_pup_in_m = 8.3e-3
@@ -184,9 +185,9 @@ onbench=True
     # lyot diameter (in meters). 
     # Only use in the case of a RoundPup Lyot stop.
     # not use for propagation. 
-    # Current value is 8.035mm = 8.1*0.97 
-    # (rayon Lyot * de-zoom entrance pupil plane / Lyopt plane)
-    diam_lyot_in_m  = 8.035e-3
+    # Current value is 7.985mm = 7.9*1.0107
+    # (radius physical Lyot * de-zoom entrance pupil plane / Lyot plane)
+    diam_lyot_in_m  = 7.985e-3
 
     #Can be fqpm or knife, vortex, wrapped_vortex, classiclyot or HLC
     corona_type ='fqpm'

--- a/Asterix/thd2_setups/wrapped_vortex_parameters.ini
+++ b/Asterix/thd2_setups/wrapped_vortex_parameters.ini
@@ -26,10 +26,6 @@ onbench=True
 
     # Sampling in the detector science image
     #(lambda/Entrance_pupil_diameter in pixel
-    # For THD2 testbed : 7.42 pix / L/D for the 783.6nm laser
-    # For THD2 testbed : 6.62 pix / L/D for the 700nm laser
-    # For THD2 testbed : 6.34 pix / L/D for the 670nm laser
-    # For THD2 testbed : 6.06 pix / L/D for the 640nm laser
     Science_sampling = 6.53
 
     # pupil diameter (in meters)

--- a/Asterix/thd2_setups/wrapped_vortex_parameters.ini
+++ b/Asterix/thd2_setups/wrapped_vortex_parameters.ini
@@ -26,6 +26,10 @@ onbench=True
 
     # Sampling in the detector science image
     #(lambda/Entrance_pupil_diameter in pixel
+    # For THD2 testbed : 7.42 pix / L/D for the 783.6nm laser
+    # For THD2 testbed : 6.62 pix / L/D for the 700nm laser
+    # For THD2 testbed : 6.34 pix / L/D for the 670nm laser
+    # For THD2 testbed : 6.06 pix / L/D for the 640nm laser
     Science_sampling = 6.53
 
     # pupil diameter (in meters)

--- a/Asterix/thd2_setups/wrapped_vortex_parameters.ini
+++ b/Asterix/thd2_setups/wrapped_vortex_parameters.ini
@@ -184,9 +184,9 @@ onbench=True
     # lyot diameter (in meters). 
     # Only use in the case of a RoundPup Lyot stop.
     # not use for propagation. 
-    # Current value is 8.035mm = 8.1*0.97 
-    # (rayon Lyot * de-zoom entrance pupil plane / Lyopt plane)
-    diam_lyot_in_m  = 8.035e-3
+    # Current value is 7.985mm = 7.9*1.0107
+    # (radius physical Lyot * de-zoom entrance pupil plane / Lyot plane)
+    diam_lyot_in_m  = 7.985e-3
 
     #Can be fqpm or knife, vortex, wrapped_vortex, classiclyot or HLC
     corona_type ='wrapped_vortex'


### PR DESCRIPTION
Smalls changes to make Vortex easier to use on the testbed:
- Vortex is now use by default in MFT propagation + perfect corono option (at all wl). 
- Adapted the parameter files with more default option for vortex