### PR TITLE
Option to change the complex precision

### DIFF
--- a/Asterix/example_run_asterix.py
+++ b/Asterix/example_run_asterix.py
@@ -29,7 +29,6 @@ print("")
 print("")
 print("")
 
-
 start_time = time.time()
 main_THD.runthd2(parameter_file_path,
                  NewDMconfig={'DM1_active': False},

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -40,7 +40,7 @@ class THD2(Testbed):
         model_config['mandatory_wls'] = sorted(
             np.unique(np.array(model_config['mandatory_wls'] + config["Estimationconfig"]["estimation_wls"])).tolist())
 
-        # The following line can be added to change the precision of the complex number. complex64 is faster be can be 
+        # The following line can be added to change the precision of the complex number. complex64 is faster be can be
         # slightly different at the 10-10 contrast level.
         # model_config['complex_precision'] = 'complex128'
 

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -40,6 +40,10 @@ class THD2(Testbed):
         model_config['mandatory_wls'] = sorted(
             np.unique(np.array(model_config['mandatory_wls'] + config["Estimationconfig"]["estimation_wls"])).tolist())
 
+        # The following line can be added to change the precision of the complex number. complex64 is faster be can be 
+        # slightly different at the 10-10 contrast level.
+        # model_config['complex_precision'] = 'complex128'
+
         # Create all optical elements of the THD
         entrance_pupil = Pupil(model_config,
                                PupType=model_config["filename_instr_pup"],

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -40,7 +40,7 @@ class THD2(Testbed):
         model_config['mandatory_wls'] = sorted(
             np.unique(np.array(model_config['mandatory_wls'] + config["Estimationconfig"]["estimation_wls"])).tolist())
 
-        # The following line can be added to change the precision of the complex number. complex64 is faster be can be
+        # The following line can be added to change the precision of the complex number. complex64 is faster but can be
         # slightly different at the 10-10 contrast level.
         # model_config['complex_precision'] = 'complex128'
 

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -42,7 +42,7 @@ class THD2(Testbed):
 
         # The following line can be added to change the precision of the complex number. complex64 is faster but can be
         # slightly different at the 10-10 contrast level.
-        # model_config['complex_precision'] = 'complex128'
+        # model_config['complex_precision'] = 'complex64'
 
         # Create all optical elements of the THD
         entrance_pupil = Pupil(model_config,

--- a/Asterix/optics/coronagraph.py
+++ b/Asterix/optics/coronagraph.py
@@ -1048,7 +1048,7 @@ def prop_fpm_regional_sampling(pup,
         if False, the normal propagation image is returned
         if True, return AAs_direct, AAs_inverse, BBs_direct, BBs_inverse, norm0s_direct, norm0s_inverse, butterworths
         that can be used for all the propagation when only_mat_mult is True.
-    dtype_complex: string, default 'complex128'
+    dtype_complex : string, default 'complex128'
             bit number for the complex arrays in the MFT matrices.
             Can be 'complex128' or 'complex64'. The latter increases the speed of the mft but at the
             cost of lower precision.

--- a/Asterix/optics/coronagraph.py
+++ b/Asterix/optics/coronagraph.py
@@ -190,7 +190,8 @@ class Coronagraph(optsy.OpticalSystem):
                                    nbres=dim_science_here / fpm_sampling_here / lambda_ratio,
                                    inverse=False,
                                    norm='ortho',
-                                   returnAABB=True)
+                                   returnAABB=True,
+                                   dtype_complex=self.dtype_complex)
                 self.AA_direct.append(a)
                 self.BB_direct.append(b)
                 self.norm0_direct.append(c)
@@ -201,7 +202,8 @@ class Coronagraph(optsy.OpticalSystem):
                                    nbres=dim_science_here / fpm_sampling_here / lambda_ratio,
                                    inverse=True,
                                    norm='ortho',
-                                   returnAABB=True)
+                                   returnAABB=True,
+                                   dtype_complex=self.dtype_complex)
 
                 self.AA_inverse.append(a)
                 self.BB_inverse.append(b)
@@ -217,7 +219,8 @@ class Coronagraph(optsy.OpticalSystem):
                 returnAAsBBs=True,
                 shift=(0, 0),
                 filter_order=15,
-                alpha=1.5)
+                alpha=1.5,
+                dtype_complex=self.dtype_complex)
 
         if "bool_overwrite_perfect_coro" in coroconfig:
             if coroconfig["bool_overwrite_perfect_coro"]:
@@ -322,7 +325,8 @@ class Coronagraph(optsy.OpticalSystem):
             corono_focal_plane = prop.fft_choosecenter(input_wavefront_after_apod_pad,
                                                        inverse=False,
                                                        center_pos='bb',
-                                                       norm='ortho')
+                                                       norm='ortho',
+                                                       dtype_complex=self.dtype_complex)
 
             if dir_save_all_planes is not None:
                 name_plane = 'EF_FP_before_FPM' + f'_wl{int(wavelength * 1e9)}'
@@ -347,7 +351,8 @@ class Coronagraph(optsy.OpticalSystem):
             lyotplane_before_lyot = prop.fft_choosecenter(corono_focal_plane * FPmsk,
                                                           inverse=True,
                                                           center_pos='bb',
-                                                          norm='ortho')
+                                                          norm='ortho',
+                                                          dtype_complex=self.dtype_complex)
 
         elif self.prop_apod2lyot == "mft-babinet":
             # Apod plane to focal plane
@@ -356,7 +361,8 @@ class Coronagraph(optsy.OpticalSystem):
                                               AA=self.AA_direct[self.wav_vec.tolist().index(wavelength)],
                                               BB=self.BB_direct[self.wav_vec.tolist().index(wavelength)],
                                               norm0=self.norm0_direct[self.wav_vec.tolist().index(wavelength)],
-                                              only_mat_mult=True)
+                                              only_mat_mult=True,
+                                              dtype_complex=self.dtype_complex)
             else:
                 lambda_ratio = wavelength / self.wavelength_0
                 dim_science_here = self.dim_fpm
@@ -366,7 +372,8 @@ class Coronagraph(optsy.OpticalSystem):
                                               dim_output=dim_science_here,
                                               nbres=dim_science_here / fpm_sampling_here / lambda_ratio,
                                               inverse=False,
-                                              norm='ortho')
+                                              norm='ortho',
+                                              dtype_complex=self.dtype_complex)
 
             if dir_save_all_planes is not None:
                 name_plane = 'EF_FP_before_FPM' + f'_wl{int(wavelength * 1e9)}'
@@ -395,7 +402,8 @@ class Coronagraph(optsy.OpticalSystem):
                              AA=self.AA_inverse[self.wav_vec.tolist().index(wavelength)],
                              BB=self.BB_inverse[self.wav_vec.tolist().index(wavelength)],
                              norm0=self.norm0_inverse[self.wav_vec.tolist().index(wavelength)],
-                             only_mat_mult=True), self.dim_overpad_pupil)
+                             only_mat_mult=True,
+                             dtype_complex=self.dtype_complex), self.dim_overpad_pupil)
             else:
                 lyotplane_before_lyot_central_part = crop_or_pad_image(
                     prop.mft(corono_focal_plane * (1 - FPmsk),
@@ -403,7 +411,8 @@ class Coronagraph(optsy.OpticalSystem):
                              dim_output=int(2 * self.prad),
                              nbres=dim_science_here / fpm_sampling_here / lambda_ratio,
                              inverse=True,
-                             norm='ortho'), self.dim_overpad_pupil)
+                             norm='ortho',
+                             dtype_complex=self.dtype_complex), self.dim_overpad_pupil)
 
             lyotplane_before_lyot = input_wavefront_after_apod - lyotplane_before_lyot_central_part
 
@@ -414,7 +423,8 @@ class Coronagraph(optsy.OpticalSystem):
                                               AA=self.AA_direct[self.wav_vec.tolist().index(wavelength)],
                                               BB=self.BB_direct[self.wav_vec.tolist().index(wavelength)],
                                               norm0=self.norm0_direct[self.wav_vec.tolist().index(wavelength)],
-                                              only_mat_mult=True)
+                                              only_mat_mult=True,
+                                              dtype_complex=self.dtype_complex)
             else:
                 dim_science_here = self.dimScience
                 fpm_sampling_here = self.Science_sampling
@@ -425,7 +435,8 @@ class Coronagraph(optsy.OpticalSystem):
                                               dim_output=dim_science_here,
                                               nbres=dim_science_here / fpm_sampling_here / lambda_ratio,
                                               inverse=False,
-                                              norm='ortho')
+                                              norm='ortho',
+                                              dtype_complex=self.dtype_complex)
 
             if dir_save_all_planes is not None:
                 name_plane = 'EF_FP_before_FPM' + f'_wl{int(wavelength * 1e9)}'
@@ -450,7 +461,8 @@ class Coronagraph(optsy.OpticalSystem):
                              AA=self.AA_inverse[self.wav_vec.tolist().index(wavelength)],
                              BB=self.BB_inverse[self.wav_vec.tolist().index(wavelength)],
                              norm0=self.norm0_inverse[self.wav_vec.tolist().index(wavelength)],
-                             only_mat_mult=True), self.dim_overpad_pupil)
+                             only_mat_mult=True,
+                             dtype_complex=self.dtype_complex), self.dim_overpad_pupil)
             else:
                 lyotplane_before_lyot = crop_or_pad_image(
                     prop.mft(corono_focal_plane * FPmsk,
@@ -458,7 +470,8 @@ class Coronagraph(optsy.OpticalSystem):
                              dim_output=int(2 * self.prad),
                              nbres=dim_science_here / fpm_sampling_here / lambda_ratio,
                              inverse=True,
-                             norm='ortho'), self.dim_overpad_pupil)
+                             norm='ortho',
+                             dtype_complex=self.dtype_complex), self.dim_overpad_pupil)
 
         elif self.prop_apod2lyot == "regional-sampling":
             # Apod plane to Lyot plane
@@ -476,7 +489,8 @@ class Coronagraph(optsy.OpticalSystem):
                                                                    BBs_inverse=self.BBs_inverse,
                                                                    norm0s_direct=self.norm0s_direct,
                                                                    norm0s_inverse=self.norm0s_inverse,
-                                                                   butterworths=self.butterworths)
+                                                                   butterworths=self.butterworths,
+                                                                   dtype_complex=self.dtype_complex)
             else:
                 lyotplane_before_lyot = prop_fpm_regional_sampling(input_wavefront_after_apod,
                                                                    FPmsk,
@@ -484,7 +498,8 @@ class Coronagraph(optsy.OpticalSystem):
                                                                    real_dim_input=int(2 * self.prad),
                                                                    shift=(0, 0),
                                                                    filter_order=15,
-                                                                   alpha=1.5)
+                                                                   alpha=1.5,
+                                                                   dtype_complex=self.dtype_complex)
 
         else:
             raise ValueError(f"{self.prop_apod2lyot} is not a known `prop_apod2lyot` propagation method")
@@ -545,7 +560,7 @@ class Coronagraph(optsy.OpticalSystem):
             if self.achrom_phase_coro:
                 # If we want to do an achromatic fqpm, we do not include a variation
                 # of the phase with the wl.
-                fqpm.append(np.exp(1j * phase4q))
+                fqpm.append(np.exp(1j * phase4q, dtype=self.dtype_complex))
             else:
                 # In the general case, we use the EF_from_phase_and_ampl which handle the phase chromaticity.
                 fqpm.append(self.EF_from_phase_and_ampl(phase_abb=phase4q, wavelengths=wav))
@@ -595,7 +610,7 @@ class Coronagraph(optsy.OpticalSystem):
             if self.achrom_phase_coro:
                 # If we want to do an achromatic vortex, we do not include a variation
                 # of the phase with the wl.
-                vortex.append(np.exp(1j * phasevortex_cut))
+                vortex.append(np.exp(1j * phasevortex_cut, dtype=self.dtype_complex))
             else:
                 # In the general case, we use the EF_from_phase_and_ampl which handle the phase chromaticity.
                 vortex.append(self.EF_from_phase_and_ampl(phase_abb=phasevortex_cut, wavelengths=wav))
@@ -655,7 +670,7 @@ class Coronagraph(optsy.OpticalSystem):
             if self.achrom_phase_coro:
                 # If we want to do an achromatic vortex, we do not include a variation
                 # of the phase with the wl.
-                wrapped_vortex.append(np.exp(1j * phasevortex_cut))
+                wrapped_vortex.append(np.exp(1j * phasevortex_cut, dtype=self.dtype_complex))
             else:
                 # In the general case, we use the EF_from_phase_and_ampl which handle the phase chromaticity.
                 wrapped_vortex.append(self.EF_from_phase_and_ampl(phase_abb=phasevortex_cut, wavelengths=wav))
@@ -750,7 +765,7 @@ class Coronagraph(optsy.OpticalSystem):
             if self.achrom_phase_coro:
                 # If we want to do an achromatic hlc, we do not include a variation
                 # of the phase with the wl.
-                hlc_all_wl.append((1 + ampl_hlc) * np.exp(1j * phase_hlc))
+                hlc_all_wl.append((1 + ampl_hlc) * np.exp(1j * phase_hlc, dtype=self.dtype_complex))
             else:
                 # In the general case, we use the EF_from_phase_and_ampl which handle the phase chromaticity.
                 hlc_all_wl.append(self.EF_from_phase_and_ampl(ampl_abb=ampl_hlc, phase_abb=phase_hlc, wavelengths=wav))
@@ -951,6 +966,7 @@ def prop_fpm_regional_sampling(pup,
                                norm0s_inverse=None,
                                butterworths=None,
                                returnAAsBBs=False,
+                               dtype_complex="complex128",
                                dir_save_all_planes=None):
     """
     Calculate the coronagraphic electric field in the Lyot plane by using varying sampling in different parts of the FPM.
@@ -1032,6 +1048,10 @@ def prop_fpm_regional_sampling(pup,
         if False, the normal propagation image is returned
         if True, return AAs_direct, AAs_inverse, BBs_direct, BBs_inverse, norm0s_direct, norm0s_inverse, butterworths
         that can be used for all the propagation when only_mat_mult is True.
+    dtype_complex: string, default 'complex128'
+            bit number for the complex arrays in the MFT matrices.
+            Can be 'complex128' or 'complex64'. The latter increases the speed of the mft but at the
+            cost of lower precision.
     dir_save_all_planes : string or None, default None
         If not None, absolute directory to save all planes in fits for debugging purposes.
         This can generate a lot of fits especially if in a loop, use with caution.
@@ -1127,7 +1147,8 @@ def prop_fpm_regional_sampling(pup,
                                      dim_output=dim_fpm,
                                      nbres=nbres[k],
                                      norm='ortho',
-                                     returnAABB=True)
+                                     returnAABB=True,
+                                     dtype_complex=dtype_complex)
             AAs_direct.append(AA)
             BBs_direct.append(BB)
             norm0s_direct.append(norm0)
@@ -1138,7 +1159,8 @@ def prop_fpm_regional_sampling(pup,
                                      nbres=nbres[k],
                                      inverse=True,
                                      norm='ortho',
-                                     returnAABB=True)
+                                     returnAABB=True,
+                                     dtype_complex=dtype_complex)
             AAs_inverse.append(AA)
             BBs_inverse.append(BB)
             norm0s_inverse.append(norm0)
@@ -1149,12 +1171,14 @@ def prop_fpm_regional_sampling(pup,
                                         only_mat_mult=True,
                                         AA=AAs_direct[k],
                                         BB=BBs_direct[k],
-                                        norm0=norm0s_direct[k])
+                                        norm0=norm0s_direct[k],
+                                        dtype_complex=dtype_complex)
             ef_pp_before_ls_reg = prop.mft(ef_fp_before_fpm * fpm * but_here,
                                            only_mat_mult=True,
                                            AA=AAs_inverse[k],
                                            BB=BBs_inverse[k],
-                                           norm0=norm0s_inverse[k])
+                                           norm0=norm0s_inverse[k],
+                                           dtype_complex=dtype_complex)
 
             if dir_save_all_planes is not None:
                 name_plane = f'FPbeforeFPM_number{k}'
@@ -1170,7 +1194,8 @@ def prop_fpm_regional_sampling(pup,
                                         nbres=nbres[k],
                                         norm='ortho',
                                         X_offset_output=shift[0] * samplings[k],
-                                        Y_offset_output=shift[1] * samplings[k])
+                                        Y_offset_output=shift[1] * samplings[k],
+                                        dtype_complex=dtype_complex)
             ef_pp_before_ls_reg = prop.mft(ef_fp_before_fpm * fpm * but_here,
                                            real_dim_input=dim_fpm,
                                            dim_output=real_dim_input,
@@ -1178,7 +1203,8 @@ def prop_fpm_regional_sampling(pup,
                                            inverse=True,
                                            norm='ortho',
                                            X_offset_input=shift[0] * samplings[k],
-                                           Y_offset_input=shift[1] * samplings[k])
+                                           Y_offset_input=shift[1] * samplings[k],
+                                           dtype_complex=dtype_complex)
 
             if dir_save_all_planes is not None:
                 name_plane = f'FPbeforeFPM_nbr{int(nbres[k])}_sampling{int(samplings[k])}'

--- a/Asterix/optics/deformable_mirror.py
+++ b/Asterix/optics/deformable_mirror.py
@@ -369,8 +369,12 @@ class DeformableMirror(optsy.OpticalSystem):
         if self.z_position != 0:
 
             Pup_inDMplane = crop_or_pad_image(
-                prop.prop_angular_spectrum(self.clearpup.pup, self.wavelength_0, self.z_position, self.diam_pup_in_m / 2,
-                                           self.prad), self.dim_overpad_pupil)
+                prop.prop_angular_spectrum(self.clearpup.pup,
+                                           self.wavelength_0,
+                                           self.z_position,
+                                           self.diam_pup_in_m / 2,
+                                           self.prad,
+                                           dtype_complex=self.dtype_complex), self.dim_overpad_pupil)
         else:
             Pup_inDMplane = self.clearpup.pup
 
@@ -423,8 +427,12 @@ class DeformableMirror(optsy.OpticalSystem):
         """
 
         EF_inDMplane = crop_or_pad_image(
-            prop.prop_angular_spectrum(entrance_EF, wavelength, self.z_position, self.diam_pup_in_m / 2., self.prad),
-            self.dim_overpad_pupil)
+            prop.prop_angular_spectrum(entrance_EF,
+                                       wavelength,
+                                       self.z_position,
+                                       self.diam_pup_in_m / 2.,
+                                       self.prad,
+                                       dtype_complex=self.dtype_complex), self.dim_overpad_pupil)
 
         if dir_save_all_planes is not None:
             name_plane = 'EF_before_DM_in_' + self.Name_DM + f'plane_wl{int(wavelength * 1e9)}'
@@ -440,8 +448,12 @@ class DeformableMirror(optsy.OpticalSystem):
         # and propagate to next pupil plane
 
         EF_back_in_pup_plane = crop_or_pad_image(
-            prop.prop_angular_spectrum(EF_inDMplane_after_DM, wavelength, -self.z_position, self.diam_pup_in_m / 2.,
-                                       self.prad), self.dim_overpad_pupil)
+            prop.prop_angular_spectrum(EF_inDMplane_after_DM,
+                                       wavelength,
+                                       -self.z_position,
+                                       self.diam_pup_in_m / 2.,
+                                       self.prad,
+                                       dtype_complex=self.dtype_complex), self.dim_overpad_pupil)
 
         return EF_back_in_pup_plane
 

--- a/Asterix/optics/optical_systems.py
+++ b/Asterix/optics/optical_systems.py
@@ -713,7 +713,7 @@ class OpticalSystem:
         else:
             return 0.
 
-    def EF_from_phase_and_ampl(self, phase_abb=0., ampl_abb=0., wavelengths=-1.):
+    def EF_from_phase_and_ampl(self, phase_abb=0., ampl_abb=0., wavelengths=-1., dtype_complex='complex128'):
         """Create an electrical field from an phase and amplitude aberrations
         as follows:
 
@@ -732,6 +732,10 @@ class OpticalSystem:
         wavelengths : float or list of floats
             Default is all the wl of the testbed self.wav_vec
             wavelengths in m.
+        dtype_complex: string, default 'complex128'
+            bit number for the complex arrays in the exponential.
+            Can be 'complex128' or 'complex64'. The latter increases the speed of the exp but at the
+            cost of lower precision.
 
         Returns
         --------
@@ -760,7 +764,9 @@ class OpticalSystem:
 
         entrance_EF = []
         for wavelength in wavelength_vec:
-            entrance_EF.append((1 + ampl_abb) * np.exp(1j * phase_abb * self.wavelength_0 / wavelength))
+            entrance_EF.append((1 + np.asarray(ampl_abb).astype(dtype_complex)) *
+                                np.exp(1j * phase_abb * self.wavelength_0 / wavelength, dtype=dtype_complex))
+
         entrance_EF = np.array(entrance_EF)
 
         if len(wavelength_vec) == 1:

--- a/Asterix/optics/optical_systems.py
+++ b/Asterix/optics/optical_systems.py
@@ -36,7 +36,7 @@ class OpticalSystem:
         if modelconfig["diam_pup_in_pix"] % 2 == 1:
             raise ValueError("Please set [modelconfig]['diam_pup_in_pix'] parameter to an even number.")
 
-        if "complex_precision" in modelconfig.keys():
+        if "complex_precision" in modelconfig:
             if modelconfig["complex_precision"] not in ['complex64', 'complex128']:
                 raise ValueError("[modelconfig]['complex_precision parameter'] must be 'complex64' or 'complex128'")
             self.dtype_complex = modelconfig["complex_precision"]

--- a/Asterix/optics/optical_systems.py
+++ b/Asterix/optics/optical_systems.py
@@ -196,7 +196,10 @@ class OpticalSystem:
             print(entrance_EF)
             raise TypeError("entrance_EF should be a float of a numpy array of floats")
 
-        exit_EF = entrance_EF
+        if isinstance(entrance_EF, (np.ndarray)):
+            exit_EF = entrance_EF.astype(self.dtype_complex)
+        else:
+            exit_EF = entrance_EF
         return exit_EF
 
     def todetector(self,

--- a/Asterix/optics/propagation_functions.py
+++ b/Asterix/optics/propagation_functions.py
@@ -436,7 +436,7 @@ def prop_angular_spectrum(pup, lam, z, rad, prad, gamma=2, dtype_complex='comple
     return np.fft.ifft2(angular * four, norm='ortho').astype(dtype_complex)
 
 
-def fft_choosecenter(image, inverse=False, center_pos='bb', norm='backward', dtype_complex="comple128"):
+def fft_choosecenter(image, inverse=False, center_pos='bb', norm='backward', dtype_complex="complx128"):
     """FFT Computation. IDL "FFT" routine uses coordinates origin at pixel.
 
     This function uses a coordinate origin at any pixel [k,l],

--- a/Asterix/optics/propagation_functions.py
+++ b/Asterix/optics/propagation_functions.py
@@ -481,6 +481,11 @@ def fft_choosecenter(image, inverse=False, center_pos='bb', norm='backward', dty
         if 'ortho' 1/sqrt(N) normalisation is done in both directions.
         Note that norm = 'ortho' allows you to conserve energy between a focal plane and pupil plane
         The default is 'backward' to be consistent with numpy.fft.fft2 and numpy.fft.ifft2
+    dtype_complex: string, default 'complex128'
+        bit number for the complex arrays in the exponential.
+        Can be 'complex128' or 'complex64'. The latter increases the speed of the exp but at the
+        cost of lower precision. Because numpy fft does not have a dtype parameter, the difference in speed
+        is probably minimum for this function.
 
     Returns
     --------

--- a/Asterix/optics/propagation_functions.py
+++ b/Asterix/optics/propagation_functions.py
@@ -436,7 +436,7 @@ def prop_angular_spectrum(pup, lam, z, rad, prad, gamma=2, dtype_complex='comple
     return np.fft.ifft2(angular * four, norm='ortho').astype(dtype_complex)
 
 
-def fft_choosecenter(image, inverse=False, center_pos='bb', norm='backward', dtype_complex="complx128"):
+def fft_choosecenter(image, inverse=False, center_pos='bb', norm='backward', dtype_complex="complex128"):
     """FFT Computation. IDL "FFT" routine uses coordinates origin at pixel.
 
     This function uses a coordinate origin at any pixel [k,l],

--- a/Asterix/optics/propagation_functions.py
+++ b/Asterix/optics/propagation_functions.py
@@ -427,7 +427,7 @@ def prop_angular_spectrum(pup, lam, z, rad, prad, gamma=2, dtype_complex='comple
     Nfourier = int(gamma * diam_pup_in_pix)
     cycles = diam_pup_in_pix
 
-    four = np.fft.fft2(crop_or_pad_image(pup, Nfourier), norm='ortho')
+    four = np.fft.fft2(crop_or_pad_image(pup, Nfourier), norm='ortho').astype(dtype_complex)
     u, v = np.meshgrid(np.arange(Nfourier) - Nfourier / 2, np.arange(Nfourier) - Nfourier / 2)
 
     rho2D = np.fft.fftshift(np.hypot(v, u)) * (cycles / diam_pup_in_m) / Nfourier
@@ -436,7 +436,7 @@ def prop_angular_spectrum(pup, lam, z, rad, prad, gamma=2, dtype_complex='comple
     return np.fft.ifft2(angular * four, norm='ortho').astype(dtype_complex)
 
 
-def fft_choosecenter(image, inverse=False, center_pos='bb', norm='backward'):
+def fft_choosecenter(image, inverse=False, center_pos='bb', norm='backward', dtype_complex="comple128"):
     """FFT Computation. IDL "FFT" routine uses coordinates origin at pixel.
 
     This function uses a coordinate origin at any pixel [k,l],
@@ -512,16 +512,18 @@ def fft_choosecenter(image, inverse=False, center_pos='bb', norm='backward'):
 
     # shift in Fourier space, i.e. multiplication in direct space, and computation of FFT
     if not inverse:
-        farray = np.fft.fft2(image * np.exp((-sens) * 2. * np.pi * 1j * (fourier[0] * X / Nx + fourier[1] * Y / Ny)),
-                             norm=norm)
+        farray = np.fft.fft2(image * np.exp(
+            (-sens) * 2. * np.pi * 1j * (fourier[0] * X / Nx + fourier[1] * Y / Ny), dtype=dtype_complex),
+                             norm=norm).astype(dtype_complex)
     else:
-        farray = np.fft.ifft2(image * np.exp((-sens) * 2. * np.pi * 1j * (fourier[0] * X / Nx + fourier[1] * Y / Ny)),
-                              norm=norm)
+        farray = np.fft.ifft2(image * np.exp(
+            (-sens) * 2. * np.pi * 1j * (fourier[0] * X / Nx + fourier[1] * Y / Ny), dtype=dtype_complex),
+                              norm=norm).astype(dtype_complex)
 
     # shift in direct space, i.e. multiplication in fourier space, and computation of FFT
-    farray *= np.exp((-sens) * 2. * np.pi * 1j * (direct[0] * X / Nx + direct[1] * Y / Ny))
+    farray *= np.exp((-sens) * 2. * np.pi * 1j * (direct[0] * X / Nx + direct[1] * Y / Ny), dtype=dtype_complex)
 
     # normalisation
-    farray *= np.exp(sens * (2. * 1j * np.pi / np.sqrt(Nx * Ny)) * np.sum(direct * fourier))
+    farray *= np.exp(sens * (2. * 1j * np.pi / np.sqrt(Nx * Ny)) * np.sum(direct * fourier), dtype=dtype_complex)
 
     return farray

--- a/Asterix/optics/propagation_functions.py
+++ b/Asterix/optics/propagation_functions.py
@@ -123,7 +123,7 @@ def mft(image,
         returnAABB: boolean, default False
             if False, the normal MFT(image is returned)
             if True, we return AA, BB, norm0 used to do norm0 * ((AA @ image) @ BB).
-        dtype_complex: string, default 'complex128'
+        dtype_complex : string, default 'complex128'
             bit number for the complex arrays in the MFT matrices.
             Can be 'complex128' or 'complex64'. The latter increases the speed of the mft but at the
             cost of lower precision.
@@ -303,7 +303,7 @@ def prop_fresnel(pup, lam, z, rad, prad, retscale=0, dtype_complex='complex128')
         of the input and output arrays
         if 0, the function returns the output
         electric field (see Returns)
-    dtype_complex: string, default 'complex128'
+    dtype_complex : string, default 'complex128'
         bit number for the complex arrays in the exponential.
         Can be 'complex128' or 'complex64'. The latter increases the speed of the exp but at the
         cost of lower precision.
@@ -409,7 +409,7 @@ def prop_angular_spectrum(pup, lam, z, rad, prad, gamma=2, dtype_complex='comple
         factor of oversizing in the fourier plane in diameter of the pupil
         (gamma*2*prad is the output dim)
         optional: default = 2
-    dtype_complex: string, default 'complex128'
+    dtype_complex : string, default 'complex128'
         bit number for the complex arrays in the exponential.
         Can be 'complex128' or 'complex64'. The latter increases the speed of the exp but at the
         cost of lower precision.
@@ -481,7 +481,7 @@ def fft_choosecenter(image, inverse=False, center_pos='bb', norm='backward', dty
         if 'ortho' 1/sqrt(N) normalisation is done in both directions.
         Note that norm = 'ortho' allows you to conserve energy between a focal plane and pupil plane
         The default is 'backward' to be consistent with numpy.fft.fft2 and numpy.fft.ifft2
-    dtype_complex: string, default 'complex128'
+    dtype_complex : string, default 'complex128'
         bit number for the complex arrays in the exponential.
         Can be 'complex128' or 'complex64'. The latter increases the speed of the exp but at the
         cost of lower precision. Because numpy fft does not have a dtype parameter, the difference in speed

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -231,7 +231,7 @@ class Corrector:
                 pixel_in_mask = int(np.sum(self.MaskEstim))
                 number_wl_matrix = self.Gmatrix.shape[0] // (2 * pixel_in_mask)
 
-                self.G = np.zeros((number_wl_matrix * pixel_in_mask, self.Gmatrix.shape[1]), dtype=complex)
+                self.G = np.zeros((number_wl_matrix * pixel_in_mask, self.Gmatrix.shape[1]), dtype=testbed.dtype_complex)
 
                 for i in range(number_wl_matrix):
                     self.G[i * pixel_in_mask:(i + 1) * pixel_in_mask, :] = (

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -263,7 +263,7 @@ class Estimator:
             estimation of the Electrical field
         """
 
-        if 'wavelength' in kwargs.keys():
+        if 'wavelength' in kwargs:
             raise ValueError(("estimate() function is polychromatic, "
                               "do not use wavelength keyword. "
                               "Use 'wavelengths' keyword even for monochromatic intensity"))

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -340,7 +340,7 @@ class Estimator:
                                                             wavelengths=wavei,
                                                             **kwargs)
 
-                    result_estim.append(wfs.calculate_pw_estimate(Difference, self.PWMatrix[i]))
+                    result_estim.append(wfs.calculate_pw_estimate(Difference, self.PWMatrix[i],dtype_complex=testbed.dtype_complex))
 
                     if 'dir_save_all_planes' in kwargs.keys():
                         if kwargs['dir_save_all_planes'] is not None:
@@ -358,7 +358,7 @@ class Estimator:
                                                         wavelengths=self.wav_vec_estim[0],
                                                         **kwargs)
 
-                result_estim.append(wfs.calculate_pw_estimate(Difference, self.PWMatrix[0]))
+                result_estim.append(wfs.calculate_pw_estimate(Difference, self.PWMatrix[0],dtype_complex=testbed.dtype_complex))
                 if 'dir_save_all_planes' in kwargs.keys():
                     if kwargs['dir_save_all_planes'] is not None:
                         name_plane = 'PW_estimate_singlewl' + f'_wl{int(self.wav_vec_estim[0] * 1e9)}'
@@ -374,7 +374,7 @@ class Estimator:
                                                         wavelengths=testbed.wav_vec,
                                                         **kwargs)
 
-                result_estim.append(wfs.calculate_pw_estimate(Difference, self.PWMatrix[0]))
+                result_estim.append(wfs.calculate_pw_estimate(Difference, self.PWMatrix[0],dtype_complex=testbed.dtype_complex))
                 if 'dir_save_all_planes' in kwargs.keys():
                     if kwargs['dir_save_all_planes'] is not None:
                         name_plane = 'PW_estimate_broadband_pwprobes' + f'_wl{int(testbed.wavelength_0 * 1e9)}_bw{testbed.Delta_wav * 1e9}'

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -340,7 +340,8 @@ class Estimator:
                                                             wavelengths=wavei,
                                                             **kwargs)
 
-                    result_estim.append(wfs.calculate_pw_estimate(Difference, self.PWMatrix[i],dtype_complex=testbed.dtype_complex))
+                    result_estim.append(
+                        wfs.calculate_pw_estimate(Difference, self.PWMatrix[i], dtype_complex=testbed.dtype_complex))
 
                     if 'dir_save_all_planes' in kwargs.keys():
                         if kwargs['dir_save_all_planes'] is not None:
@@ -358,7 +359,8 @@ class Estimator:
                                                         wavelengths=self.wav_vec_estim[0],
                                                         **kwargs)
 
-                result_estim.append(wfs.calculate_pw_estimate(Difference, self.PWMatrix[0],dtype_complex=testbed.dtype_complex))
+                result_estim.append(
+                    wfs.calculate_pw_estimate(Difference, self.PWMatrix[0], dtype_complex=testbed.dtype_complex))
                 if 'dir_save_all_planes' in kwargs.keys():
                     if kwargs['dir_save_all_planes'] is not None:
                         name_plane = 'PW_estimate_singlewl' + f'_wl{int(self.wav_vec_estim[0] * 1e9)}'
@@ -374,7 +376,8 @@ class Estimator:
                                                         wavelengths=testbed.wav_vec,
                                                         **kwargs)
 
-                result_estim.append(wfs.calculate_pw_estimate(Difference, self.PWMatrix[0],dtype_complex=testbed.dtype_complex))
+                result_estim.append(
+                    wfs.calculate_pw_estimate(Difference, self.PWMatrix[0], dtype_complex=testbed.dtype_complex))
                 if 'dir_save_all_planes' in kwargs.keys():
                     if kwargs['dir_save_all_planes'] is not None:
                         name_plane = 'PW_estimate_broadband_pwprobes' + f'_wl{int(testbed.wavelength_0 * 1e9)}_bw{testbed.Delta_wav * 1e9}'

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -263,7 +263,7 @@ class Estimator:
             estimation of the Electrical field
         """
 
-        if 'wavelength' in kwargs:
+        if 'wavelength' in kwargs.keys():
             raise ValueError(("estimate() function is polychromatic, "
                               "do not use wavelength keyword. "
                               "Use 'wavelengths' keyword even for monochromatic intensity"))

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -457,8 +457,12 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
             if DM.z_position != 0:
 
                 wavefrontupstreaminDM = crop_or_pad_image(
-                    prop.prop_angular_spectrum(wavefrontupstream, wavelength, DM.z_position, DM.diam_pup_in_m / 2,
-                                               DM.prad), DM.dim_overpad_pupil)
+                    prop.prop_angular_spectrum(wavefrontupstream,
+                                               wavelength,
+                                               DM.z_position,
+                                               DM.diam_pup_in_m / 2,
+                                               DM.prad,
+                                               dtype_complex=testbed.dtype_complex), DM.dim_overpad_pupil)
 
             if visu:
                 plt.ion()
@@ -488,11 +492,14 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
                     else:
 
                         wavefront = crop_or_pad_image(
-                            prop.prop_angular_spectrum(
-                                wavefrontupstreaminDM * DM.EF_from_phase_and_ampl(
-                                    phase_abb=phase_in_basis + DM_phase_init[testbed.name_of_DMs.index(DM_name)],
-                                    wavelengths=wavelength), wavelength, -DM.z_position, DM.diam_pup_in_m / 2, DM.prad),
-                            DM.dim_overpad_pupil)
+                            prop.prop_angular_spectrum(wavefrontupstreaminDM * DM.EF_from_phase_and_ampl(
+                                phase_abb=phase_in_basis + DM_phase_init[testbed.name_of_DMs.index(DM_name)],
+                                wavelengths=wavelength),
+                                                       wavelength,
+                                                       -DM.z_position,
+                                                       DM.diam_pup_in_m / 2,
+                                                       DM.prad,
+                                                       dtype_complex=testbed.dtype_complex), DM.dim_overpad_pupil)
 
                 if MatrixType == 'smallphase':
                     # TODO we added a 1+ which was initially in Axel's code and that was
@@ -506,7 +513,11 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
                             prop.prop_angular_spectrum(
                                 wavefrontupstreaminDM * (1 + 1j * phase_in_basis) * DM.EF_from_phase_and_ampl(
                                     phase_abb=DM_phase_init[testbed.name_of_DMs.index(DM_name)], wavelengths=wavelength),
-                                wavelength, -DM.z_position, DM.diam_pup_in_m / 2, DM.prad), DM.dim_overpad_pupil)
+                                wavelength,
+                                -DM.z_position,
+                                DM.diam_pup_in_m / 2,
+                                DM.prad,
+                                dtype_complex=testbed.dtype_complex), DM.dim_overpad_pupil)
 
                 if dir_save_all_planes is not None:
                     name_plane = 'EF_PP_after_' + DM_name + f'_wl{int(wavelength * 1e9)}'

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -766,7 +766,7 @@ def calc_strokemin_solution(mask,
     pixel_in_mask = np.sum(mask)
 
     # With notations from Potier PhD eq 4.74 p78:
-    Eab = np.zeros(int(np.sum(mask)) * len(Result_Estimate), dtype=complex)
+    Eab = np.zeros(int(np.sum(mask)) * len(Result_Estimate), dtype=testbed.dtype_complex)
     for i_wave, estimate_at_this_wave in enumerate(Result_Estimate):
         Eab[i_wave * int(np.sum(mask)):(i_wave + 1) * int(np.sum(mask))] = estimate_at_this_wave[np.where(mask == 1)]
 

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -490,11 +490,11 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
                                                DM_phase_init[testbed.name_of_DMs.index(DM_name)])
 
                     else:
-
+                        efDMplane = wavefrontupstreaminDM * DM.EF_from_phase_and_ampl(
+                            phase_abb=phase_in_basis + DM_phase_init[testbed.name_of_DMs.index(DM_name)],
+                            wavelengths=wavelength)
                         wavefront = crop_or_pad_image(
-                            prop.prop_angular_spectrum(wavefrontupstreaminDM * DM.EF_from_phase_and_ampl(
-                                phase_abb=phase_in_basis + DM_phase_init[testbed.name_of_DMs.index(DM_name)],
-                                wavelengths=wavelength),
+                            prop.prop_angular_spectrum(efDMplane,
                                                        wavelength,
                                                        -DM.z_position,
                                                        DM.diam_pup_in_m / 2,
@@ -508,16 +508,15 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
                         wavefront = (1 + 1j * phase_in_basis) * wavefrontupstream * DM.EF_from_phase_and_ampl(
                             phase_abb=DM_phase_init[testbed.name_of_DMs.index(DM_name)], wavelengths=wavelength)
                     else:
-
+                        efDMplane = wavefrontupstreaminDM * (1 + 1j * phase_in_basis) * DM.EF_from_phase_and_ampl(
+                            phase_abb=DM_phase_init[testbed.name_of_DMs.index(DM_name)], wavelengths=wavelength)
                         wavefront = crop_or_pad_image(
-                            prop.prop_angular_spectrum(
-                                wavefrontupstreaminDM * (1 + 1j * phase_in_basis) * DM.EF_from_phase_and_ampl(
-                                    phase_abb=DM_phase_init[testbed.name_of_DMs.index(DM_name)], wavelengths=wavelength),
-                                wavelength,
-                                -DM.z_position,
-                                DM.diam_pup_in_m / 2,
-                                DM.prad,
-                                dtype_complex=testbed.dtype_complex), DM.dim_overpad_pupil)
+                            prop.prop_angular_spectrum(efDMplane,
+                                                       wavelength,
+                                                       -DM.z_position,
+                                                       DM.diam_pup_in_m / 2,
+                                                       DM.prad,
+                                                       dtype_complex=testbed.dtype_complex), DM.dim_overpad_pupil)
 
                 if dir_save_all_planes is not None:
                     name_plane = 'EF_PP_after_' + DM_name + f'_wl{int(wavelength * 1e9)}'

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -164,7 +164,7 @@ def create_singlewl_pw_matrix(testbed: Testbed,
         print("Start PW matrix" + ' at ' + str(int(wavelength * 1e9)) + "nm (wait a few seconds)")
 
     numprobe = len(posprobes)
-    deltapsik = np.zeros((numprobe, dimEstim, dimEstim), dtype=complex)
+    deltapsik = np.zeros((numprobe, dimEstim, dimEstim), dtype=testbed.dtype_complex)
     probephase = np.zeros((numprobe, testbed.dim_overpad_pupil, testbed.dim_overpad_pupil))
     matrix = np.zeros((numprobe, 2))
     PWMatrix = np.zeros((dimEstim**2, 2, numprobe))
@@ -218,7 +218,7 @@ def create_singlewl_pw_matrix(testbed: Testbed,
     return PWMatrix
 
 
-def calculate_pw_estimate(Difference, Vectorprobes, dir_save_all_planes=None):
+def calculate_pw_estimate(Difference, Vectorprobes, dir_save_all_planes=None, dtype_complex='complex128'):
     """Calculate the focal plane electric field from the probe image
     differences and the modeled probe matrix.
 
@@ -233,6 +233,10 @@ def calculate_pw_estimate(Difference, Vectorprobes, dir_save_all_planes=None):
     dir_save_all_planes : string or None, default None
         If not None, absolute directory to save all planes in fits for debugging purposes.
         This can generate a lot of fits especially if in a loop, use with caution.
+    dtype_complex : string, default 'complex128'
+        bit number for the complex arrays in the PW matrices.
+        Can be 'complex128' or 'complex64'. The latter increases the speed of the mft but at the
+        cost of lower precision.
 
     Returns
     --------
@@ -244,7 +248,7 @@ def calculate_pw_estimate(Difference, Vectorprobes, dir_save_all_planes=None):
     dimimages = len(Difference[0])
     numprobe = len(Vectorprobes[0, 0])
     Differenceij = np.zeros((numprobe))
-    Resultat = np.zeros((dimimages, dimimages), dtype=complex)
+    Resultat = np.zeros((dimimages, dimimages), dtype=dtype_complex)
     l_ind = 0
     for i in np.arange(dimimages):
         for j in np.arange(dimimages):


### PR DESCRIPTION
Option to switch the complex precision "complex128", to "complex64".

This is mostly important for the MFT and the complex exponential. The FFT in numpy does not allow the dtype keyword so I suspect that in that case the change is pretty useless. (the FFT in numpy is used for the angular spectrum propagation that is used for the out of plane DMs). The default stay complex128. 

The option is a 'secret' parameter (not accessible from parameter file to not over fill it). You can access by defining
`model_config['complex_precision'] = 'complex128'`

before the definition of the optical elements of the sytem. For example :
```
config = read_parameter_file(parameter_file_path)
model_config = config["modelconfig"]
model_config['complex_precision'] = 'complex64'
entrance_pupil = Pupil(model_config)
```
This will ensure that all MFTs and phase exponential are fasters. For example: 
```
wf = entrance_pupil.EF_from_phase_and_ampl(phase_abb=myphase)
```
and
```
psf = entrance_pupil.todetector_intensity()
```
Will be measured 'complex64' and should be faster.