### PR TITLE
update header matrices + saved thd-control version

### DIFF
--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -132,6 +132,9 @@ def runthd2(parameter_file_path,
     # Concatenate into the full testbed optical system
     thd2 = THD2(config, model_local_dir, silence=silence)
 
+    config["modelconfig"]["MODELSIM"] = 'asterix'
+    thd2.config_file = config
+
     # The following line can be used to change the DM which applies PWP probes.
     # This can be used to use the DM out of the pupil plane as the PWP DM.
     # This is an unusual option so not in the param file and not well documented.

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -66,7 +66,7 @@ def runthd2(parameter_file_path,
             NewCorrectionconfig={},
             NewLoopconfig={},
             NewSIMUconfig={},
-            silence=False,
+            silence=True,
             **kwargs):
     """
     Run a simulation of a correction loop for the THD2 testbed.

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -66,7 +66,7 @@ def runthd2(parameter_file_path,
             NewCorrectionconfig={},
             NewLoopconfig={},
             NewSIMUconfig={},
-            silence=True,
+            silence=False,
             **kwargs):
     """
     Run a simulation of a correction loop for the THD2 testbed.

--- a/Asterix/optics/testbed.py
+++ b/Asterix/optics/testbed.py
@@ -204,15 +204,15 @@ class Testbed(optsy.OpticalSystem):
             # we access each DM object individually
             DM: deformable_mirror.DeformableMirror = vars(self)[DM_name]
             if DM.active:
-                # we extract the voltages for this one
+                # we extract the voltages for this DM
                 # this voltages are in the DM basis
                 vector_basis_voltage_for_DM = vector_basis_voltage[indice_acum_basis_size:indice_acum_basis_size +
                                                                    DM.basis_size]
 
-                # we change to actuator basis
+                # we change to the actuator basis
                 vector_actu_voltage_for_DM = np.dot(np.transpose(DM.basis), vector_basis_voltage_for_DM)
 
-                # we recreate a voltages vector, but for each actuator
+                # we concatenate DM voltages to obtain a single vector of voltages, but for the testbed
                 vector_actuator_voltage[indice_acum_number_act:indice_acum_number_act +
                                         DM.number_act] = vector_actu_voltage_for_DM
 

--- a/Asterix/optics/testbed.py
+++ b/Asterix/optics/testbed.py
@@ -11,7 +11,7 @@ class Testbed(optsy.OpticalSystem):
     subclass of Optical System, because we do not know what is inside It can
     only be initialized by giving a list of Optical Systems and it will create
     a "testbed" with contains all the Optical Systems and associated EF_through
-    functions and correct normlaization.
+    functions and correct normalization.
 
     AUTHOR : Johan Mazoyer
     """

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -197,13 +197,13 @@ def from_param_to_header(config, header=fits.Header()):
     if isinstance(config, ConfigObj):
         for sect in config.sections:
             for scalar in config[str(sect)].scalars:
-                header.set(str(scalar), str(config[str(sect)][str(scalar)]), str(scalar))
+                header.set(str(scalar), str(config[str(sect)][str(scalar)]))
     elif isinstance(config, Section):
         for scalar in config.scalars:
-            header.set(str(scalar), str(config[str(scalar)]), str(scalar))
+            header.set(str(scalar), str(config[str(scalar)]))
     elif isinstance(config, dict):
         for key in config.keys():
-            header.set(str(key), str(config[str(key)]), str(key))
+            header.set(str(key), str(config[str(key)]))
     else:
         raise TypeError("Input must be a ConfigObj object, a Section object or a dict")
 

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -193,7 +193,7 @@ def from_param_to_header(config):
     for sect in config.sections:
         # print(config[str(sect)])
         for scalar in config[str(sect)].scalars:
-            header[str(scalar)[:8]] = str(config[str(sect)][str(scalar)])
+            header.set(str(scalar)[:8], str(config[str(sect)][str(scalar)]), str(scalar))
     return header
 
 

--- a/Asterix/utils/save_and_read.py
+++ b/Asterix/utils/save_and_read.py
@@ -9,7 +9,8 @@ import datetime
 import numpy as np
 
 from astropy.io import fits
-from configobj import ConfigObj
+from astropy.io.fits.verify import VerifyWarning
+from configobj import ConfigObj, Section
 from validate import Validator
 
 from Asterix import Asterix_root
@@ -42,7 +43,7 @@ def save_plane_in_fits(dir_save_fits, name_plane, image):
         return
 
     if np.iscomplexobj(image):
-        tofits_array = np.zeros((2, ) + image.shape)
+        tofits_array = np.zeros((2,) + image.shape)
         tofits_array[0] = np.real(image)
         tofits_array[1] = np.imag(image)
         fits.writeto(os.path.join(dir_save_fits, name_fits + '_RE_and_IM.fits'), tofits_array, overwrite=True)
@@ -173,7 +174,7 @@ def read_parameter_file(parameter_file,
     return config
 
 
-def from_param_to_header(config):
+def from_param_to_header(config, header=fits.Header()):
     """
     Convert ConfigObj parameters to fits header type list
     AUTHOR: Axel Potier
@@ -182,18 +183,30 @@ def from_param_to_header(config):
     ----------
     config : dict
         Config object.
+    header : fits.Header() object, optional, default empty header
+        fits header object to which the parameters will be added.
 
     Returns
     --------
-    header : dict
-        List of parameters.
+    header : fits.Header() object
+        header with list of parameters.
 
     """
-    header = fits.Header()
-    for sect in config.sections:
-        # print(config[str(sect)])
-        for scalar in config[str(sect)].scalars:
-            header.set(str(scalar)[:8], str(config[str(sect)][str(scalar)]), str(scalar))
+    warnings.simplefilter('ignore', category=VerifyWarning)
+
+    if isinstance(config, ConfigObj):
+        for sect in config.sections:
+            for scalar in config[str(sect)].scalars:
+                header.set(str(scalar), str(config[str(sect)][str(scalar)]), str(scalar))
+    elif isinstance(config, Section):
+        for scalar in config.scalars:
+            header.set(str(scalar), str(config[str(scalar)]), str(scalar))
+    elif isinstance(config, dict):
+        for key in config.keys():
+            header.set(str(key), str(config[str(key)]), str(key))
+    else:
+        raise TypeError("Input must be a ConfigObj object, a Section object or a dict")
+
     return header
 
 

--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -456,6 +456,7 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
     print("Final contrast in DH: ", meancontrast[-1])
 
     fits.writeto(os.path.join(result_dir, "Mean_Contrast_DH.fits"), np.array(meancontrast), header, overwrite=True)
+    print("Final contrast in DH: ", meancontrast[-1])
 
     fits.writeto(os.path.join(result_dir, "estimationFP_RE.fits"), np.real(np.array(EF_estim)), header, overwrite=True)
 

--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -456,7 +456,6 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
     print("Final contrast in DH: ", meancontrast[-1])
 
     fits.writeto(os.path.join(result_dir, "Mean_Contrast_DH.fits"), np.array(meancontrast), header, overwrite=True)
-    print("Final contrast in DH: ", meancontrast[-1])
 
     fits.writeto(os.path.join(result_dir, "estimationFP_RE.fits"), np.real(np.array(EF_estim)), header, overwrite=True)
 

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -1,9 +1,8 @@
 import os
-from datetime import datetime
 import numpy as np
 from astropy.io import fits
 
-from Asterix.utils import invert_svd, from_param_to_header
+from Asterix.utils import invert_svd
 from Asterix.optics import OpticalSystem, DeformableMirror, Testbed
 
 import Asterix.wfsc.estimator as estimator_mod

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -115,13 +115,16 @@ class Corrector:
             else:
                 number_wl_in_matrix = estimator.nb_wav_estim
 
-            name_int_matrixDM1 = testbed.DM1.fnameDirectMatrix
-            name_int_matrixDM3 = testbed.DM3.fnameDirectMatrix
 
-            headerdm1 = fits.getheader(name_int_matrixDM1)
-            headerdm3 = fits.getheader(name_int_matrixDM3)
-            headerdm1['DM_NAME'] = 'DM1+DM3'
             if testbed.DM1.active & testbed.DM3.active:
+
+                name_int_matrixDM1 = testbed.DM1.fnameDirectMatrix
+                name_int_matrixDM3 = testbed.DM3.fnameDirectMatrix
+
+                headerdm1 = fits.getheader(name_int_matrixDM1)
+                headerdm3 = fits.getheader(name_int_matrixDM3)
+                headerdm1['DM_NAME'] = 'DM1+DM3'
+
                 fits.writeto(os.path.join(realtestbed_dir, f"Direct_Matrix_2DM_{number_wl_in_matrix}wl.fits"),
                              self.Gmatrix,
                              headerdm1,

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 from astropy.io import fits
 
-from Asterix.utils import invert_svd
+from Asterix.utils import invert_svd, from_param_to_header
 from Asterix.optics import OpticalSystem, DeformableMirror, Testbed
 
 import Asterix.wfsc.estimator as estimator_mod
@@ -114,25 +114,30 @@ class Corrector:
             else:
                 number_wl_in_matrix = estimator.nb_wav_estim
 
+            header = from_param_to_header(testbed.config_file)
+
             if testbed.DM1.active & testbed.DM3.active:
                 fits.writeto(os.path.join(realtestbed_dir, f"Direct_Matrix_2DM_{number_wl_in_matrix}wl.fits"),
                              self.Gmatrix,
+                             header,
                              overwrite=True)
-                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM1.fits"), testbed.DM1.basis, overwrite=True)
-                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM3.fits"), testbed.DM3.basis, overwrite=True)
+                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM1.fits"), testbed.DM1.basis, header, overwrite=True)
+                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM3.fits"), testbed.DM3.basis, header, overwrite=True)
                 number_Active_testbeds = 13
 
             elif testbed.DM1.active:
                 fits.writeto(os.path.join(realtestbed_dir, f"Direct_Matrix_DM1only_{number_wl_in_matrix}wl.fits"),
                              self.Gmatrix,
+                             header,
                              overwrite=True)
-                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM1.fits"), testbed.DM1.basis, overwrite=True)
+                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM1.fits"), testbed.DM1.basis, header, overwrite=True)
                 number_Active_testbeds = 1
             elif testbed.DM3.active:
                 fits.writeto(os.path.join(realtestbed_dir, f"Direct_Matrix_DM3only_{number_wl_in_matrix}wl.fits"),
                              self.Gmatrix,
+                             header,
                              overwrite=True)
-                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM3.fits"), testbed.DM3.basis, overwrite=True)
+                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM3.fits"), testbed.DM3.basis, header, overwrite=True)
                 number_Active_testbeds = 3
             else:
                 raise ValueError("No active DMs")
@@ -155,11 +160,10 @@ class Corrector:
                                               number_wl_in_matrix=number_wl_in_matrix,
                                               silence=silence)
 
-            fits.writeto(os.path.join(realtestbed_dir, "DH_mask.fits"),
-                         self.MaskEstim.astype(np.float32),
-                         overwrite=True)
+            fits.writeto(os.path.join(realtestbed_dir, "DH_mask.fits"), self.MaskEstim.astype(np.float32), header, overwrite=True)
             fits.writeto(os.path.join(realtestbed_dir, "DH_mask_where_x_y.fits"),
                          np.array(np.where(self.MaskEstim == 1)).astype(np.float32),
+                         header,
                          overwrite=True)
 
         # Adding error on the DM model. Now that the matrix is measured, we can

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -137,16 +137,14 @@ class Corrector:
 
                 # thd_control_matrix
                 # careful, only work in monochromatic right now
-                name_int_matrixDM1 = testbed.DM1.fnameDirectMatrix[0]
-                name_int_matrixDM3 = testbed.DM3.fnameDirectMatrix[0]
+                name_int_matrixDM1 = testbed.DM1.fnameDirectMatrix
+                name_int_matrixDM3 = testbed.DM3.fnameDirectMatrix
 
-                fullmatrix_dm1 = fits.getdata(name_int_matrixDM1, extname='MATRIX')
-                basis_dm1 = fits.getdata(name_int_matrixDM1, extname='BASIS')
+                fullmatrix_dm1 = fits.getdata(name_int_matrixDM1)
 
-                fullmatrix_dm3 = fits.getdata(name_int_matrixDM3, extname='MATRIX')
-                basis_dm3 = fits.getdata(name_int_matrixDM3, extname='BASIS')
+                fullmatrix_dm3 = fits.getdata(name_int_matrixDM3)
 
-                int_matrix = np.concatenate((np.transpose(fullmatrix_dm1), np.transpose(fullmatrix_dm3)))
+                int_matrix = np.concatenate((np.transpose(testbed.DM1.basis), np.transpose(testbed.DM3.basis)))
 
                 header = fits.getheader(name_int_matrixDM1)
                 header['DM_NAME'] = 'DM1+DM3'
@@ -154,8 +152,8 @@ class Corrector:
 
                 hdu_list = fits.HDUList([fits.PrimaryHDU(header=header)])
                 hdu_list.append(fits.ImageHDU(data=int_matrix, name='BOSTON'))
-                hdu_list.append(fits.ImageHDU(data=basis_dm1, name='BASISDM1'))
-                hdu_list.append(fits.ImageHDU(data=basis_dm3, name='BASISDM3'))
+                hdu_list.append(fits.ImageHDU(data=testbed.DM1.basis, name='BASISDM1'))
+                hdu_list.append(fits.ImageHDU(data=testbed.DM3.basis, name='BASISDM3'))
 
                 hdu_list.writeto(os.path.join(realtestbed_dir, "thd-control-jacobians.fits"))
 
@@ -172,10 +170,9 @@ class Corrector:
 
                 # thd_control_matrix
                 # careful, only work in monochromatic right now
-                name_int_matrixDM1 = testbed.DM1.fnameDirectMatrix[0]
+                name_int_matrixDM1 = testbed.DM1.fnameDirectMatrix
 
-                fullmatrix_dm1 = fits.getdata(name_int_matrixDM1, extname='BOSTON')
-                basis_dm1 = fits.getdata(name_int_matrixDM1, extname='BASIS')
+                fullmatrix_dm1 = fits.getdata(name_int_matrixDM1)
 
                 int_matrix = np.transpose(fullmatrix_dm1)
 
@@ -184,7 +181,7 @@ class Corrector:
 
                 hdu_list = fits.HDUList([fits.PrimaryHDU(header=header)])
                 hdu_list.append(fits.ImageHDU(data=int_matrix, name='BOSTON'))
-                hdu_list.append(fits.ImageHDU(data=basis_dm1, name='BASISDM1'))
+                hdu_list.append(fits.ImageHDU(data=testbed.DM1.basis, name='BASISDM1'))
                 hdu_list.writeto(os.path.join(realtestbed_dir, "thd-control-jacobians.fits"))
 
             elif testbed.DM3.active:
@@ -200,10 +197,9 @@ class Corrector:
 
                 # hd_control_matrix
                 # careful, only work in monochromatic right now
-                name_int_matrixDM3 = testbed.DM3.fnameDirectMatrix[0]
+                name_int_matrixDM3 = testbed.DM3.fnameDirectMatrix
 
-                fullmatrix_dm3 = fits.getdata(name_int_matrixDM3, extname='MATRIX')
-                basis_dm3 = fits.getdata(name_int_matrixDM3, extname='BASIS')
+                fullmatrix_dm3 = fits.getdata(name_int_matrixDM3)
 
                 int_matrix = np.transpose(fullmatrix_dm3)
 
@@ -212,7 +208,7 @@ class Corrector:
 
                 hdu_list = fits.HDUList([fits.PrimaryHDU(header=header)])
                 hdu_list.append(fits.ImageHDU(data=int_matrix, name='BOSTON'))
-                hdu_list.append(fits.ImageHDU(data=basis_dm3, name='BASISDM3'))
+                hdu_list.append(fits.ImageHDU(data=testbed.DM3.basis, name='BASISDM3'))
                 hdu_list.writeto(os.path.join(realtestbed_dir, "thd-control-jacobians.fits"))
 
             else:

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -150,7 +150,7 @@ class Corrector:
 
                 header = fits.getheader(name_int_matrixDM1)
                 header['DM_NAME'] = 'DM1+DM3'
-                header['CREATION'] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+                header.insert(0, ('date_mat', datetime.now().strftime("%d/%m/%Y %H:%M:%S"), "matrix creation date"))
 
                 hdu_list = fits.HDUList([fits.PrimaryHDU(header=header)])
                 hdu_list.append(fits.ImageHDU(data=int_matrix, name='BOSTON'))
@@ -180,7 +180,7 @@ class Corrector:
                 int_matrix = np.transpose(fullmatrix_dm1)
 
                 header = fits.getheader(name_int_matrixDM1)
-                header['CREATION'] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+                header.insert(0, ('date_mat', datetime.now().strftime("%d/%m/%Y %H:%M:%S"), "matrix creation date"))
 
                 hdu_list = fits.HDUList([fits.PrimaryHDU(header=header)])
                 hdu_list.append(fits.ImageHDU(data=int_matrix, name='BOSTON'))
@@ -208,7 +208,7 @@ class Corrector:
                 int_matrix = np.transpose(fullmatrix_dm3)
 
                 header = fits.getheader(name_int_matrixDM3)
-                header['CREATION'] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+                header.insert(0, ('date_mat', datetime.now().strftime("%d/%m/%Y %H:%M:%S"), "matrix creation date"))
 
                 hdu_list = fits.HDUList([fits.PrimaryHDU(header=header)])
                 hdu_list.append(fits.ImageHDU(data=int_matrix, name='BOSTON'))

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -115,41 +115,35 @@ class Corrector:
             else:
                 number_wl_in_matrix = estimator.nb_wav_estim
 
-            if hasattr(testbed, 'config_file'):
-                header = from_param_to_header(testbed.config_file)
-            else:
-                header = fits.Header()
+            name_int_matrixDM1 = testbed.DM1.fnameDirectMatrix
+            name_int_matrixDM3 = testbed.DM3.fnameDirectMatrix
 
+            headerdm1 = fits.getheader(name_int_matrixDM1)
+            headerdm3 = fits.getheader(name_int_matrixDM3)
+            headerdm1['DM_NAME'] = 'DM1+DM3'
             if testbed.DM1.active & testbed.DM3.active:
                 fits.writeto(os.path.join(realtestbed_dir, f"Direct_Matrix_2DM_{number_wl_in_matrix}wl.fits"),
                              self.Gmatrix,
-                             header,
+                             headerdm1,
                              overwrite=True)
                 fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM1.fits"),
                              testbed.DM1.basis,
-                             header,
+                             headerdm1,
                              overwrite=True)
                 fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM3.fits"),
                              testbed.DM3.basis,
-                             header,
+                             headerdm3,
                              overwrite=True)
                 number_Active_testbeds = 13
 
                 # thd_control_matrix
                 # careful, only work in monochromatic right now
-                name_int_matrixDM1 = testbed.DM1.fnameDirectMatrix
-                name_int_matrixDM3 = testbed.DM3.fnameDirectMatrix
-
                 fullmatrix_dm1 = fits.getdata(name_int_matrixDM1)
 
                 fullmatrix_dm3 = fits.getdata(name_int_matrixDM3)
                 int_matrix = np.concatenate((np.transpose(fullmatrix_dm1), np.transpose(fullmatrix_dm3)))
 
-                header = fits.getheader(name_int_matrixDM1)
-                header['DM_NAME'] = 'DM1+DM3'
-                header.insert(0, ('date_mat', datetime.now().strftime("%d/%m/%Y %H:%M:%S"), "matrix creation date"))
-
-                hdu_list = fits.HDUList([fits.PrimaryHDU(header=header)])
+                hdu_list = fits.HDUList([fits.PrimaryHDU(header=headerdm1)])
                 hdu_list.append(fits.ImageHDU(data=int_matrix, name='BOSTON'))
                 hdu_list.append(fits.ImageHDU(data=testbed.DM1.basis, name='BASISDM1'))
                 hdu_list.append(fits.ImageHDU(data=testbed.DM3.basis, name='BASISDM3'))
@@ -157,13 +151,15 @@ class Corrector:
                 hdu_list.writeto(os.path.join(realtestbed_dir, "thd-control-jacobians.fits"))
 
             elif testbed.DM1.active:
+                name_int_matrixDM1 = testbed.DM1.fnameDirectMatrix
+                headerdm1 = fits.getheader(name_int_matrixDM1)
                 fits.writeto(os.path.join(realtestbed_dir, f"Direct_Matrix_DM1only_{number_wl_in_matrix}wl.fits"),
                              self.Gmatrix,
-                             header,
+                             headerdm1,
                              overwrite=True)
                 fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM1.fits"),
                              testbed.DM1.basis,
-                             header,
+                             headerdm1,
                              overwrite=True)
                 number_Active_testbeds = 1
 
@@ -175,22 +171,21 @@ class Corrector:
 
                 int_matrix = np.transpose(fullmatrix_dm1)
 
-                header = fits.getheader(name_int_matrixDM1)
-                header.insert(0, ('date_mat', datetime.now().strftime("%d/%m/%Y %H:%M:%S"), "matrix creation date"))
-
-                hdu_list = fits.HDUList([fits.PrimaryHDU(header=header)])
+                hdu_list = fits.HDUList([fits.PrimaryHDU(header=headerdm1)])
                 hdu_list.append(fits.ImageHDU(data=int_matrix, name='BOSTON'))
                 hdu_list.append(fits.ImageHDU(data=testbed.DM1.basis, name='BASISDM1'))
                 hdu_list.writeto(os.path.join(realtestbed_dir, "thd-control-jacobians.fits"))
 
             elif testbed.DM3.active:
+                name_int_matrixDM3 = testbed.DM3.fnameDirectMatrix
+                headerdm3 = fits.getheader(name_int_matrixDM3)
                 fits.writeto(os.path.join(realtestbed_dir, f"Direct_Matrix_DM3only_{number_wl_in_matrix}wl.fits"),
                              self.Gmatrix,
-                             header,
+                             headerdm3,
                              overwrite=True)
                 fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM3.fits"),
                              testbed.DM3.basis,
-                             header,
+                             headerdm3,
                              overwrite=True)
                 number_Active_testbeds = 3
 
@@ -202,10 +197,7 @@ class Corrector:
 
                 int_matrix = np.transpose(fullmatrix_dm3)
 
-                header = fits.getheader(name_int_matrixDM3)
-                header.insert(0, ('date_mat', datetime.now().strftime("%d/%m/%Y %H:%M:%S"), "matrix creation date"))
-
-                hdu_list = fits.HDUList([fits.PrimaryHDU(header=header)])
+                hdu_list = fits.HDUList([fits.PrimaryHDU(header=headerdm3)])
                 hdu_list.append(fits.ImageHDU(data=int_matrix, name='BOSTON'))
                 hdu_list.append(fits.ImageHDU(data=testbed.DM3.basis, name='BASISDM3'))
                 hdu_list.writeto(os.path.join(realtestbed_dir, "thd-control-jacobians.fits"))
@@ -233,11 +225,9 @@ class Corrector:
 
             fits.writeto(os.path.join(realtestbed_dir, "DH_mask.fits"),
                          self.MaskEstim.astype(np.float32),
-                         header,
                          overwrite=True)
             fits.writeto(os.path.join(realtestbed_dir, "DH_mask_where_x_y.fits"),
                          np.array(np.where(self.MaskEstim == 1)).astype(np.float32),
-                         header,
                          overwrite=True)
 
         # Adding error on the DM model. Now that the matrix is measured, we can

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -135,8 +135,8 @@ class Corrector:
                              overwrite=True)
                 number_Active_testbeds = 13
 
-                #thd_control_matrix
-                #careful, only work in monochromatic right now
+                # thd_control_matrix
+                # careful, only work in monochromatic right now
                 name_int_matrixDM1 = testbed.DM1.fnameDirectMatrix[0]
                 name_int_matrixDM3 = testbed.DM3.fnameDirectMatrix[0]
 
@@ -170,8 +170,8 @@ class Corrector:
                              overwrite=True)
                 number_Active_testbeds = 1
 
-                #thd_control_matrix
-                #careful, only work in monochromatic right now
+                # thd_control_matrix
+                # careful, only work in monochromatic right now
                 name_int_matrixDM1 = testbed.DM1.fnameDirectMatrix[0]
 
                 fullmatrix_dm1 = fits.getdata(name_int_matrixDM1, extname='BOSTON')
@@ -198,8 +198,8 @@ class Corrector:
                              overwrite=True)
                 number_Active_testbeds = 3
 
-                #thd_control_matrix
-                #careful, only work in monochromatic right now
+                # hd_control_matrix
+                # careful, only work in monochromatic right now
                 name_int_matrixDM3 = testbed.DM3.fnameDirectMatrix[0]
 
                 fullmatrix_dm3 = fits.getdata(name_int_matrixDM3, extname='MATRIX')

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -147,15 +147,16 @@ class Corrector:
                 basis_dm3 = fits.getdata(name_int_matrixDM3, extname='BASIS')
 
                 int_matrix = np.concatenate((np.transpose(fullmatrix_dm1), np.transpose(fullmatrix_dm3)))
-                basis_dms = np.concatenate(basis_dm1, basis_dm3)
 
                 header = fits.getheader(name_int_matrixDM1)
                 header['DM_NAME'] = 'DM1+DM3'
                 header['CREATION'] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
 
                 hdu_list = fits.HDUList([fits.PrimaryHDU(header=header)])
-                hdu_list.append(fits.ImageHDU(data=int_matrix, name='MATRIX'))
-                hdu_list.append(fits.ImageHDU(data=basis_dms, name='BASIS'))
+                hdu_list.append(fits.ImageHDU(data=int_matrix, name='BOSTON'))
+                hdu_list.append(fits.ImageHDU(data=basis_dm1, name='BASISDM1'))
+                hdu_list.append(fits.ImageHDU(data=basis_dm3, name='BASISDM3'))
+
                 hdu_list.writeto(os.path.join(realtestbed_dir, "thd-control-jacobians.fits"))
 
             elif testbed.DM1.active:
@@ -173,18 +174,17 @@ class Corrector:
                 #careful, only work in monochromatic right now
                 name_int_matrixDM1 = testbed.DM1.fnameDirectMatrix[0]
 
-                fullmatrix_dm1 = fits.getdata(name_int_matrixDM1, extname='MATRIX')
+                fullmatrix_dm1 = fits.getdata(name_int_matrixDM1, extname='BOSTON')
                 basis_dm1 = fits.getdata(name_int_matrixDM1, extname='BASIS')
 
                 int_matrix = np.transpose(fullmatrix_dm1)
-                basis_dms = basis_dm1
 
                 header = fits.getheader(name_int_matrixDM1)
                 header['CREATION'] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
 
                 hdu_list = fits.HDUList([fits.PrimaryHDU(header=header)])
-                hdu_list.append(fits.ImageHDU(data=int_matrix, name='MATRIX'))
-                hdu_list.append(fits.ImageHDU(data=basis_dms, name='BASIS'))
+                hdu_list.append(fits.ImageHDU(data=int_matrix, name='BOSTON'))
+                hdu_list.append(fits.ImageHDU(data=basis_dm1, name='BASISDM1'))
                 hdu_list.writeto(os.path.join(realtestbed_dir, "thd-control-jacobians.fits"))
 
             elif testbed.DM3.active:
@@ -206,14 +206,13 @@ class Corrector:
                 basis_dm3 = fits.getdata(name_int_matrixDM3, extname='BASIS')
 
                 int_matrix = np.transpose(fullmatrix_dm3)
-                basis_dms = basis_dm3
 
                 header = fits.getheader(name_int_matrixDM3)
                 header['CREATION'] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
 
                 hdu_list = fits.HDUList([fits.PrimaryHDU(header=header)])
-                hdu_list.append(fits.ImageHDU(data=int_matrix, name='MATRIX'))
-                hdu_list.append(fits.ImageHDU(data=basis_dms, name='BASIS'))
+                hdu_list.append(fits.ImageHDU(data=int_matrix, name='BOSTON'))
+                hdu_list.append(fits.ImageHDU(data=basis_dm3, name='BASISDM3'))
                 hdu_list.writeto(os.path.join(realtestbed_dir, "thd-control-jacobians.fits"))
 
             else:

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -143,8 +143,7 @@ class Corrector:
                 fullmatrix_dm1 = fits.getdata(name_int_matrixDM1)
 
                 fullmatrix_dm3 = fits.getdata(name_int_matrixDM3)
-
-                int_matrix = np.concatenate((np.transpose(testbed.DM1.basis), np.transpose(testbed.DM3.basis)))
+                int_matrix = np.concatenate((np.transpose(fullmatrix_dm1), np.transpose(fullmatrix_dm3)))
 
                 header = fits.getheader(name_int_matrixDM1)
                 header['DM_NAME'] = 'DM1+DM3'

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -114,15 +114,24 @@ class Corrector:
             else:
                 number_wl_in_matrix = estimator.nb_wav_estim
 
-            header = from_param_to_header(testbed.config_file)
+            if hasattr(testbed, 'config_file'):
+                header = from_param_to_header(testbed.config_file)
+            else:
+                header = fits.Header()
 
             if testbed.DM1.active & testbed.DM3.active:
                 fits.writeto(os.path.join(realtestbed_dir, f"Direct_Matrix_2DM_{number_wl_in_matrix}wl.fits"),
                              self.Gmatrix,
                              header,
                              overwrite=True)
-                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM1.fits"), testbed.DM1.basis, header, overwrite=True)
-                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM3.fits"), testbed.DM3.basis, header, overwrite=True)
+                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM1.fits"),
+                             testbed.DM1.basis,
+                             header,
+                             overwrite=True)
+                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM3.fits"),
+                             testbed.DM3.basis,
+                             header,
+                             overwrite=True)
                 number_Active_testbeds = 13
 
             elif testbed.DM1.active:
@@ -130,14 +139,20 @@ class Corrector:
                              self.Gmatrix,
                              header,
                              overwrite=True)
-                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM1.fits"), testbed.DM1.basis, header, overwrite=True)
+                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM1.fits"),
+                             testbed.DM1.basis,
+                             header,
+                             overwrite=True)
                 number_Active_testbeds = 1
             elif testbed.DM3.active:
                 fits.writeto(os.path.join(realtestbed_dir, f"Direct_Matrix_DM3only_{number_wl_in_matrix}wl.fits"),
                              self.Gmatrix,
                              header,
                              overwrite=True)
-                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM3.fits"), testbed.DM3.basis, header, overwrite=True)
+                fits.writeto(os.path.join(realtestbed_dir, "Base_Matrix_DM3.fits"),
+                             testbed.DM3.basis,
+                             header,
+                             overwrite=True)
                 number_Active_testbeds = 3
             else:
                 raise ValueError("No active DMs")
@@ -160,7 +175,10 @@ class Corrector:
                                               number_wl_in_matrix=number_wl_in_matrix,
                                               silence=silence)
 
-            fits.writeto(os.path.join(realtestbed_dir, "DH_mask.fits"), self.MaskEstim.astype(np.float32), header, overwrite=True)
+            fits.writeto(os.path.join(realtestbed_dir, "DH_mask.fits"),
+                         self.MaskEstim.astype(np.float32),
+                         header,
+                         overwrite=True)
             fits.writeto(os.path.join(realtestbed_dir, "DH_mask_where_x_y.fits"),
                          np.array(np.where(self.MaskEstim == 1)).astype(np.float32),
                          header,
@@ -236,7 +254,8 @@ class Corrector:
                 pixel_in_mask = int(np.sum(self.MaskEstim))
                 number_wl_matrix = self.Gmatrix.shape[0] // (2 * pixel_in_mask)
 
-                self.G = np.zeros((number_wl_matrix * pixel_in_mask, self.Gmatrix.shape[1]), dtype=testbed.dtype_complex)
+                self.G = np.zeros((number_wl_matrix * pixel_in_mask, self.Gmatrix.shape[1]),
+                                  dtype=testbed.dtype_complex)
 
                 for i in range(number_wl_matrix):
                     self.G[i * pixel_in_mask:(i + 1) * pixel_in_mask, :] = (

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -86,6 +86,7 @@ class Corrector:
                 DM.basis = DM.create_DM_basis(basis_type=basis_type, silence=silence)
                 DM.basis_size = DM.basis.shape[0]
                 self.total_number_modes += DM.basis_size
+                DM.basis_type = basis_type
             DM.fnameDirectMatrix = list()
 
         self.correction_algorithm = Correctionconfig["correction_algorithm"].lower()

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 from astropy.io import fits
 
-from Asterix.utils import resizing, save_plane_in_fits
+from Asterix.utils import resizing, save_plane_in_fits, from_param_to_header
 from Asterix.optics import OpticalSystem, DeformableMirror, Testbed
 
 import Asterix.wfsc.wf_sensing_functions as wfs
@@ -226,12 +226,16 @@ class Estimator:
                     if 775 < wave_k * 1e9 < 795:
                         string_laser = "_laser3"  # ~785nm laser source
 
+                    header = from_param_to_header(testbed.config_file)
+
                     namepwmatrix = '_PW_' + testbed.name_DM_to_probe_in_PW + string_laser
                     fits.writeto(os.path.join(realtestbed_dir, "Probes" + namepwmatrix + ".fits"),
                                  probes,
+                                 header,
                                  overwrite=True)
                     fits.writeto(os.path.join(realtestbed_dir, "Matr_mult_estim" + namepwmatrix + ".fits"),
                                  vectorPW,
+                                 header,
                                  overwrite=True)
 
         elif self.technique == 'coffee':

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -155,11 +155,7 @@ class Estimator:
 
         for wavei in self.wav_vec_estim:
             if self.Estim_sampling / testbed.wavelength_0 * wavei < 2.5:
-                raise ValueError(
-                    f"Estimator sampling must be >= 2.5 at all estimation wavelengths. "
-                    f"For [Estimationconfig]['Estim_bin_factor'] = {Estimationconfig['Estim_bin_factor']}, "
-                    f"the estimator sampling is {self.Estim_sampling} at wavelength {wavei*1e9} nm. "
-                    "Please decrease [Estimationconfig]['Estim_bin_factor'] parameter.")
+                raise ValueError(f"Estimator sampling must be >= 2.5 at all estimation wavelengths. "
                                  f"For [Estimationconfig]['Estim_bin_factor'] = {Estimationconfig['Estim_bin_factor']}, "
                                  f"the estimator sampling is {self.Estim_sampling} at wavelength {wavei * 1e9} nm. "
                                  "Please decrease [Estimationconfig]['Estim_bin_factor'] parameter.")
@@ -340,8 +336,7 @@ class Estimator:
             if self.polychrom == 'multiwl':
                 if 'nb_photons' in kwargs.keys():
                     if kwargs['nb_photons'] > 0:
-                        kwargs[
-                            'nb_photons'] = kwargs['nb_photons'] / testbed.Delta_wav * self.delta_wav_estim_individual
+                        kwargs['nb_photons'] = kwargs['nb_photons'] / testbed.Delta_wav * self.delta_wav_estim_individual
 
                 for i, wavei in enumerate(self.wav_vec_estim):
                     Difference = wfs.simulate_pw_difference(entrance_EF[testbed.wav_vec.tolist().index(wavei)],

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 import numpy as np
 from astropy.io import fits
 
@@ -226,10 +227,10 @@ class Estimator:
                     if 775 < wave_k * 1e9 < 795:
                         string_laser = "_laser3"  # ~785nm laser source
 
+                    header = fits.Header()
                     if hasattr(testbed, 'config_file'):
-                        header = from_param_to_header(testbed.config_file)
-                    else:
-                        header = fits.Header()
+                        header = from_param_to_header(testbed.config_file, header)
+                    header.insert(0, ('date_mat', datetime.now().strftime("%d/%m/%Y %H:%M:%S"), "matrix creation date"))
 
                     namepwmatrix = '_PW_' + testbed.name_DM_to_probe_in_PW + string_laser
                     fits.writeto(os.path.join(realtestbed_dir, "Probes" + namepwmatrix + ".fits"),

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -156,6 +156,9 @@ class Estimator:
         for wavei in self.wav_vec_estim:
             if self.Estim_sampling / testbed.wavelength_0 * wavei < 2.5:
                 raise ValueError(f"Estimator sampling must be >= 2.5 at all estimation wavelengths. "
+                    f"For [Estimationconfig]['Estim_bin_factor'] = {Estimationconfig['Estim_bin_factor']}, "
+                    f"the estimator sampling is {self.Estim_sampling} at wavelength {wavei*1e9} nm. "
+                    "Please decrease [Estimationconfig]['Estim_bin_factor'] parameter.")
                                  f"For [Estimationconfig]['Estim_bin_factor'] = {Estimationconfig['Estim_bin_factor']}, "
                                  f"the estimator sampling is {self.Estim_sampling} at wavelength {wavei * 1e9} nm. "
                                  "Please decrease [Estimationconfig]['Estim_bin_factor'] parameter.")
@@ -226,7 +229,10 @@ class Estimator:
                     if 775 < wave_k * 1e9 < 795:
                         string_laser = "_laser3"  # ~785nm laser source
 
-                    header = from_param_to_header(testbed.config_file)
+                    if hasattr(testbed, 'config_file'):
+                        header = from_param_to_header(testbed.config_file)
+                    else:
+                        header = fits.Header()
 
                     namepwmatrix = '_PW_' + testbed.name_DM_to_probe_in_PW + string_laser
                     fits.writeto(os.path.join(realtestbed_dir, "Probes" + namepwmatrix + ".fits"),

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -155,7 +155,8 @@ class Estimator:
 
         for wavei in self.wav_vec_estim:
             if self.Estim_sampling / testbed.wavelength_0 * wavei < 2.5:
-                raise ValueError(f"Estimator sampling must be >= 2.5 at all estimation wavelengths. "
+                raise ValueError(
+                    f"Estimator sampling must be >= 2.5 at all estimation wavelengths. "
                     f"For [Estimationconfig]['Estim_bin_factor'] = {Estimationconfig['Estim_bin_factor']}, "
                     f"the estimator sampling is {self.Estim_sampling} at wavelength {wavei*1e9} nm. "
                     "Please decrease [Estimationconfig]['Estim_bin_factor'] parameter.")
@@ -339,7 +340,8 @@ class Estimator:
             if self.polychrom == 'multiwl':
                 if 'nb_photons' in kwargs.keys():
                     if kwargs['nb_photons'] > 0:
-                        kwargs['nb_photons'] = kwargs['nb_photons'] / testbed.Delta_wav * self.delta_wav_estim_individual
+                        kwargs[
+                            'nb_photons'] = kwargs['nb_photons'] / testbed.Delta_wav * self.delta_wav_estim_individual
 
                 for i, wavei in enumerate(self.wav_vec_estim):
                     Difference = wfs.simulate_pw_difference(entrance_EF[testbed.wav_vec.tolist().index(wavei)],

--- a/Asterix/wfsc/thd_quick_invert.py
+++ b/Asterix/wfsc/thd_quick_invert.py
@@ -59,14 +59,18 @@ def THD_quick_invert(Nbmodes, name_active_DM, matrix_directory, regularization, 
         Gmatrix = fits.getdata(os.path.join(matrix_directory, f"Direct_Matrix_2DM_{number_wl_in_matrix}wl.fits"))
         DM1_basis = fits.getdata(os.path.join(matrix_directory, "Base_Matrix_DM1.fits"))
         DM3_basis = fits.getdata(os.path.join(matrix_directory, "Base_Matrix_DM3.fits"))
+        headerdm1 = fits.getheader(os.path.join(matrix_directory, "Base_Matrix_DM1.fits"))
+        headerdm3 = fits.getheader(os.path.join(matrix_directory, "Base_Matrix_DM3.fits"))
 
     elif name_active_DM == 1:
         Gmatrix = fits.getdata(os.path.join(matrix_directory, f"Direct_Matrix_DM1only_{number_wl_in_matrix}wl.fits"))
         DM1_basis = fits.getdata(os.path.join(matrix_directory, "Base_Matrix_DM1.fits"))
+        headerdm1 = fits.getheader(os.path.join(matrix_directory, "Base_Matrix_DM1.fits"))
 
     elif name_active_DM == 3:
         Gmatrix = fits.getdata(os.path.join(matrix_directory, f"Direct_Matrix_DM3only_{number_wl_in_matrix}wl.fits"))
         DM3_basis = fits.getdata(os.path.join(matrix_directory, "Base_Matrix_DM3.fits"))
+        headerdm3 = fits.getheader(os.path.join(matrix_directory, "Base_Matrix_DM3.fits"))
 
     else:
         raise ValueError("No active DMs")
@@ -85,24 +89,28 @@ def THD_quick_invert(Nbmodes, name_active_DM, matrix_directory, regularization, 
         EFCmatrix_DM1 = np.transpose(np.dot(np.transpose(DM1_basis), invertGDH_DM1))
         fits.writeto(os.path.join(matrix_directory, "Matrix_control_EFC_DM1.fits"),
                      EFCmatrix_DM1.astype(np.float32),
+                     headerdm1,
                      overwrite=True)
 
         invertGDH_DM3 = invertGDH[DM1_basis_size:]
         EFCmatrix_DM3 = np.transpose(np.dot(np.transpose(DM3_basis), invertGDH_DM3))
         fits.writeto(os.path.join(matrix_directory, "Matrix_control_EFC_DM3.fits"),
                      EFCmatrix_DM3.astype(np.float32),
+                     headerdm3,
                      overwrite=True)
     elif name_active_DM == 1:
         invertGDH_DM1 = invertGDH
         EFCmatrix_DM1 = np.transpose(np.dot(np.transpose(DM1_basis), invertGDH_DM1))
         fits.writeto(os.path.join(matrix_directory, "Matrix_control_EFC_DM1.fits"),
                      EFCmatrix_DM1.astype(np.float32),
+                     headerdm1,
                      overwrite=True)
     elif name_active_DM == 3:
         invertGDH_DM3 = invertGDH
         EFCmatrix_DM3 = np.transpose(np.dot(np.transpose(DM3_basis), invertGDH_DM3))
         fits.writeto(os.path.join(matrix_directory, "Matrix_control_EFC_DM3.fits"),
                      EFCmatrix_DM3.astype(np.float32),
+                     headerdm3,
                      overwrite=True)
     else:
         raise ValueError("No active DMs")

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -600,7 +600,7 @@ def name_header_efc_matrix(testbed: Testbed, DM: DeformableMirror, amplitudeEFC,
     """ Create the name of the file and header of the EFC matrix that will be used to
     identify precisely parameters used in the calcul of this matrix.
     We then load a potential matrix and compare the header to the one existing and return a false boolean
-    if theyneed to be recalculated. 
+    if they need to be recalculated.
 
     AUTHOR : Johan Mazoyer
 
@@ -681,7 +681,13 @@ def name_header_efc_matrix(testbed: Testbed, DM: DeformableMirror, amplitudeEFC,
         header = from_param_to_header(additional_model_param, header)
 
         header = from_param_to_header(testbed.config_file["modelconfig"], header)
-        header = from_param_to_header(testbed.config_file["DMconfig"], header)
+
+        necessary_dm_param = dict()
+        for paramdmkey in testbed.config_file["DMconfig"].scalars:
+            if DM.Name_DM in paramdmkey:
+                necessary_dm_param[paramdmkey] = testbed.config_file["DMconfig"][paramdmkey]
+        header = from_param_to_header(necessary_dm_param, header)
+
         header = from_param_to_header(testbed.config_file["Coronaconfig"], header)
 
         # Loading any existing matrix and comparing their headers to make sure they are created

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -1,5 +1,6 @@
 import os
 import time
+from datetime import datetime
 import numpy as np
 import matplotlib
 from IPython import get_ipython
@@ -275,6 +276,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
             testbed.dimScience / dimEstim))) + string_testbed_without_DMS + "_resFP" + str(
                 round(DM.Science_sampling / DM.wavelength_0 * wavelength, 2)) + '_wl' + str(int(wavelength * 1e9))
 
+        DM.fnameDirectMatrix.append(os.path.join(matrix_dir, fileDirectMatrix + ".fits"))
         # We only save the 'first' matrix meaning the one with no initial DM voltages
         # Matrix is saved/loaded for each DM independetly which allow quick switch
         # For 1DM test / 2DM test
@@ -605,6 +607,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
                 plt.ioff()
             # We save the interaction matrix:
             if (initial_DM_voltage == 0.).all():
+                header['CREATION'] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
                 hdu_list = fits.HDUList([fits.PrimaryHDU(header=header)])
                 hdu_list.append(
                     fits.ImageHDU(data=InterMat[:, pos_in_matrix:pos_in_matrix + DM.basis_size], name='MATRIX'))

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -607,7 +607,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
                 plt.ioff()
             # We save the interaction matrix:
             if (initial_DM_voltage == 0.).all():
-                header['CREATION'] = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+                header.insert(0, ('date_mat', datetime.now().strftime("%d/%m/%Y %H:%M:%S"), "matrix creation date"))
                 hdu_list = fits.HDUList([fits.PrimaryHDU(header=header)])
                 hdu_list.append(
                     fits.ImageHDU(data=InterMat[:, pos_in_matrix:pos_in_matrix + DM.basis_size], name='MATRIX'))

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -222,7 +222,10 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
     DM_phase_init = testbed.voltage_to_phases(initial_DM_voltage)
 
     # we load the configuration to save it in the fits
-    header = from_param_to_header(testbed.config_file)
+    if hasattr(testbed, 'config_file'):
+        header = from_param_to_header(testbed.config_file)
+    else:
+        header = fits.Header()
 
     # First run throught the DMs to :
     #   - string matrix to create a name for the matrix

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -276,7 +276,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
             testbed.dimScience / dimEstim))) + string_testbed_without_DMS + "_resFP" + str(
                 round(DM.Science_sampling / DM.wavelength_0 * wavelength, 2)) + '_wl' + str(int(wavelength * 1e9))
 
-        DM.fnameDirectMatrix.append(os.path.join(matrix_dir, fileDirectMatrix + ".fits"))
+        DM.fnameDirectMatrix = os.path.join(matrix_dir, fileDirectMatrix + ".fits")
         # We only save the 'first' matrix meaning the one with no initial DM voltages
         # Matrix is saved/loaded for each DM independetly which allow quick switch
         # For 1DM test / 2DM test
@@ -286,10 +286,8 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
             if not silence:
                 print("The matrix " + fileDirectMatrix + " already exists")
 
-            InterMat[:, pos_in_matrix:pos_in_matrix + DM.basis_size] = fits.getdata(os.path.join(
-                matrix_dir, fileDirectMatrix + ".fits"),
-                                                                                    extname='MATRIX')
-            DM.basis = fits.getdata(os.path.join(matrix_dir, fileDirectMatrix + ".fits"), extname='BASIS')
+            InterMat[:, pos_in_matrix:pos_in_matrix + DM.basis_size] = fits.getdata(
+                os.path.join(matrix_dir, fileDirectMatrix + ".fits"))
 
         else:
             start_time = time.time()
@@ -608,11 +606,9 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
             # We save the interaction matrix:
             if (initial_DM_voltage == 0.).all():
                 header.insert(0, ('date_mat', datetime.now().strftime("%d/%m/%Y %H:%M:%S"), "matrix creation date"))
-                hdu_list = fits.HDUList([fits.PrimaryHDU(header=header)])
-                hdu_list.append(
-                    fits.ImageHDU(data=InterMat[:, pos_in_matrix:pos_in_matrix + DM.basis_size], name='MATRIX'))
-                hdu_list.append(fits.ImageHDU(data=DM.basis, name='BASIS'))
-                hdu_list.writeto(os.path.join(matrix_dir, fileDirectMatrix + ".fits"))
+                fits.writeto(os.path.join(matrix_dir, fileDirectMatrix + ".fits"),
+                                 data=InterMat[:, pos_in_matrix:pos_in_matrix + DM.basis_size],
+                                 header=header)
 
             if not silence:
                 print("")

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -246,7 +246,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
     pos_in_matrix = 0
 
     for DM_name in testbed.name_of_DMs:
-
+        header['DM_NAME'] = DM_name
         DM: DeformableMirror = vars(testbed)[DM_name]
         if not DM.active:
             continue

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -690,23 +690,19 @@ def name_header_efc_matrix(testbed: Testbed, DM: DeformableMirror, amplitudeEFC,
 
         header = from_param_to_header(testbed.config_file["Coronaconfig"], header)
 
-        # Loading any existing matrix and comparing their headers to make sure they are created
-        # using the same set of parameters
-        if os.path.exists(os.path.join(matrix_dir, fileDirectMatrix + ".fits")):
-            header_existing = fits.getheader(os.path.join(matrix_dir, fileDirectMatrix + ".fits"))
-            # remove the basis kw created automatically  when saving the fits file
-            for keyw in ['SIMPLE', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2']:
-                header_existing.remove(keyw)
-            # we comapre the header (ignoring the date)
-            bool_already_existing_matrix = fits.HeaderDiff(header_existing, header,
-                                                           ignore_keywords=['DATE_MAT']).identical
-        else:
-            bool_already_existing_matrix = False
-
-        if bool_already_existing_matrix:
-            return fileDirectMatrix, header, bool_already_existing_matrix
-        else:
-            return fileDirectMatrix, header, bool_already_existing_matrix
+    # Loading any existing matrix and comparing their headers to make sure they are created
+    # using the same set of parameters
+    if os.path.exists(os.path.join(matrix_dir, fileDirectMatrix + ".fits")):
+        header_existing = fits.getheader(os.path.join(matrix_dir, fileDirectMatrix + ".fits"))
+        # remove the basis kw created automatically  when saving the fits file
+        for keyw in ['SIMPLE', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2']:
+            header_existing.remove(keyw)
+        # we comapre the header (ignoring the date)
+        bool_already_existing_matrix = fits.HeaderDiff(header_existing, header,
+                                                        ignore_keywords=['DATE_MAT']).identical
+    else:
+        bool_already_existing_matrix = False
+    return fileDirectMatrix, header, bool_already_existing_matrix
 
 
 def crop_interaction_matrix_to_dh(FullInteractionMatrix: np.ndarray, mask: np.ndarray):

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -607,8 +607,8 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
             if (initial_DM_voltage == 0.).all():
                 header.insert(0, ('date_mat', datetime.now().strftime("%d/%m/%Y %H:%M:%S"), "matrix creation date"))
                 fits.writeto(os.path.join(matrix_dir, fileDirectMatrix + ".fits"),
-                                 data=InterMat[:, pos_in_matrix:pos_in_matrix + DM.basis_size],
-                                 header=header)
+                             InterMat[:, pos_in_matrix:pos_in_matrix + DM.basis_size],
+                             header=header)
 
             if not silence:
                 print("")

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -237,67 +237,27 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
         DM_small_str = "_" + "_".join(DM.string_os.split("_")[3:])
         string_testbed_without_DMS = string_testbed_without_DMS.replace(DM_small_str, '')
 
+    testbed.string_testbed_without_DMS = string_testbed_without_DMS
+
     InterMat = np.zeros((2 * int(dimEstim**2), total_number_basis_modes))
     pos_in_matrix = 0
 
     for DM_name in testbed.name_of_DMs:
-
-        header = fits.Header()
-        header.insert(0, ('date_mat', datetime.now().strftime("%d/%m/%Y %H:%M:%S"), "matrix creation date"))
-        # we load the configuration to save it in the fits
-        if hasattr(testbed, 'config_file'):
-
-            necessary_correc_param = dict()
-            necessary_correc_param['DM4matrix'] = DM_name
-            necessary_correc_param['DM_basis'] = testbed.config_file["Correctionconfig"]["DM_basis"]
-            necessary_correc_param['MatrixType'] = testbed.config_file["Correctionconfig"]["MatrixType"]
-            header = from_param_to_header(necessary_correc_param, header)
-
-            necessary_estim_param = dict()
-            necessary_estim_param['Estim_bin_factor'] = testbed.config_file["Estimationconfig"]["Estim_bin_factor"]
-            necessary_estim_param['dimEstim'] = dimEstim
-            necessary_estim_param['Estim_wl'] = wavelength * 1e9
-            header = from_param_to_header(necessary_estim_param, header)
-
-            header = from_param_to_header(testbed.config_file["modelconfig"], header)
-            header = from_param_to_header(testbed.config_file["DMconfig"], header)
-            header = from_param_to_header(testbed.config_file["Coronaconfig"], header)
-
         DM: DeformableMirror = vars(testbed)[DM_name]
         if not DM.active:
             continue
 
-        # Some string manips to name the matrix if we save it
-        if MatrixType == 'perfect':
-            headfile = "DirectMatPerf"
-        elif MatrixType == 'smallphase':
-            headfile = "DirectMatSP"
-        else:
-            raise ValueError("This Matrix type does not exist ([Correctionconfig]['MatrixType'] parameter).")
-
-        if DM.basis_type == 'fourier':
-            basis_type_str = 'Four'
-            pass
-        elif DM.basis_type == 'actuator':
-            basis_type_str = 'Actu'
-            headfile += "_EFCampl" + str(amplitudeEFC)
-        else:
-            raise ValueError("This basis type does not exist ([Correctionconfig]['DM_basis'] parameter).")
-
-        DM_small_str = "_" + "_".join(DM.string_os.split("_")[3:])
-
-        basis_str = DM_small_str + "_" + basis_type_str + "Basis" + str(DM.basis_size)
-        fileDirectMatrix = headfile + basis_str + '_binEstim' + str(int(np.round(
-            testbed.dimScience / dimEstim))) + string_testbed_without_DMS + "_resFP" + str(
-                round(DM.Science_sampling / DM.wavelength_0 * wavelength, 2)) + '_wl' + str(int(wavelength * 1e9))
+        fileDirectMatrix, header_expected, bool_already_existing_matrix = name_header_efc_matrix(
+            testbed, DM, amplitudeEFC, MatrixType, dimEstim, wavelength, matrix_dir)
 
         DM.fnameDirectMatrix = os.path.join(matrix_dir, fileDirectMatrix + ".fits")
+
         # We only save the 'first' matrix meaning the one with no initial DM voltages
         # Matrix is saved/loaded for each DM independetly which allow quick switch
         # For 1DM test / 2DM test
         # Matrix is saved/loaded for all the FP and then crop at the good size later
 
-        if os.path.exists(os.path.join(matrix_dir, fileDirectMatrix + ".fits")) and (initial_DM_voltage == 0.).all():
+        if bool_already_existing_matrix and (initial_DM_voltage == 0.).all():
             if not silence:
                 print("The matrix " + fileDirectMatrix + " already exists")
 
@@ -622,7 +582,8 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
             if (initial_DM_voltage == 0.).all():
                 fits.writeto(os.path.join(matrix_dir, fileDirectMatrix + ".fits"),
                              InterMat[:, pos_in_matrix:pos_in_matrix + DM.basis_size],
-                             header=header)
+                             header=header_expected,
+                             overwrite=True)
 
             if not silence:
                 print("")
@@ -632,6 +593,114 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
         pos_in_matrix += DM.basis_size
 
     return InterMat
+
+
+def name_header_efc_matrix(testbed: Testbed, DM: DeformableMirror, amplitudeEFC, MatrixType, dimEstim, wavelength,
+                           matrix_dir):
+    """ Create the name of the file and header of the EFC matrix that will be used to
+    identify precisely parameters used in the calcul of this matrix.
+    We then load a potential matrix and compare the header to the one existing and return a false boolean
+    if theyneed to be recalculated. 
+
+    AUTHOR : Johan Mazoyer
+
+    Parameters
+    ----------
+    testbed : Testbed Optical_element
+        a testbed with one or more DM
+    DM : DM Optical_element
+        the DM used to create the matrix
+
+    amplitudeEFC: float
+        amplitude of the EFC probe on the DM
+    MatrixType: string
+        'smallphase' (when applying modes on the DMs we, do a small phase assumption : exp(i phi) = 1+ i.phi)
+        or 'perfect' (we keep exp(i phi)).
+        in both case, if the DMs are not initially flat (non zero initial_DM_voltage),
+        we do not make the small phase assumption for initial DM phase
+    dimEstim: int
+        size of the output image in teh estimator
+    wavelength : float
+        wavelength in m.
+    matrix_dir : string
+        path to directory to save all the matrices here
+
+    Returns
+    --------
+    filePW : string
+        file name of the efc matrix. If there is no identical matrix already measured in fits file, None.
+    header : fits.Header() Object
+        header of the efc matrix
+    bool_already_existing_matrix :bool
+        If there is no identical matrix already saved in fits file.
+    """
+
+    # Some string manips to name the matrix if we save it
+    if MatrixType == 'perfect':
+        headfile = "DirectMatPerf"
+    elif MatrixType == 'smallphase':
+        headfile = "DirectMatSP"
+    else:
+        raise ValueError("This Matrix type does not exist ([Correctionconfig]['MatrixType'] parameter).")
+
+    if DM.basis_type == 'fourier':
+        basis_type_str = 'Four'
+        pass
+    elif DM.basis_type == 'actuator':
+        basis_type_str = 'Actu'
+        headfile += "_EFCampl" + str(amplitudeEFC)
+    else:
+        raise ValueError("This basis type does not exist ([Correctionconfig]['DM_basis'] parameter).")
+
+    DM_small_str = "_" + "_".join(DM.string_os.split("_")[3:])
+    basis_str = DM_small_str + "_" + basis_type_str + "Basis" + str(DM.basis_size)
+    fileDirectMatrix = headfile + basis_str + '_binEstim' + str(int(np.round(
+        testbed.dimScience / dimEstim))) + testbed.string_testbed_without_DMS + "_resFP" + str(
+            round(DM.Science_sampling / DM.wavelength_0 * wavelength, 2)) + '_wl' + str(int(wavelength * 1e9))
+
+    header = fits.Header()
+    header.insert(0, ('date_mat', datetime.now().strftime("%d/%m/%Y %H:%M:%S"), "matrix creation date"))
+    # we load the configuration to save it in the fits
+    if hasattr(testbed, 'config_file'):
+
+        necessary_correc_param = dict()
+        necessary_correc_param['DM4matrix'] = DM.Name_DM
+        necessary_correc_param['DM_basis'] = DM.basis_type
+        necessary_correc_param['MatrixType'] = MatrixType
+        necessary_correc_param['amplitudeEFC'] = amplitudeEFC
+        header = from_param_to_header(necessary_correc_param, header)
+
+        necessary_estim_param = dict()
+        necessary_estim_param['Estim_bin_factor'] = testbed.config_file["Estimationconfig"]["Estim_bin_factor"]
+        necessary_estim_param['dimEstim'] = dimEstim
+        necessary_estim_param['Estim_wl'] = wavelength * 1e9
+        header = from_param_to_header(necessary_estim_param, header)
+
+        additional_model_param = dict()
+        additional_model_param['dtype_complex'] = testbed.dtype_complex
+        header = from_param_to_header(additional_model_param, header)
+
+        header = from_param_to_header(testbed.config_file["modelconfig"], header)
+        header = from_param_to_header(testbed.config_file["DMconfig"], header)
+        header = from_param_to_header(testbed.config_file["Coronaconfig"], header)
+
+        # Loading any existing matrix and comparing their headers to make sure they are created
+        # using the same set of parameters
+        if os.path.exists(os.path.join(matrix_dir, fileDirectMatrix + ".fits")):
+            header_existing = fits.getheader(os.path.join(matrix_dir, fileDirectMatrix + ".fits"))
+            # remove the basis kw created automatically  when saving the fits file
+            for keyw in ['SIMPLE', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2']:
+                header_existing.remove(keyw)
+            # we comapre the header (ignoring the date)
+            bool_already_existing_matrix = fits.HeaderDiff(header_existing, header,
+                                                           ignore_keywords=['DATE_MAT']).identical
+        else:
+            bool_already_existing_matrix = False
+
+        if bool_already_existing_matrix:
+            return fileDirectMatrix, header, bool_already_existing_matrix
+        else:
+            return fileDirectMatrix, header, bool_already_existing_matrix
 
 
 def crop_interaction_matrix_to_dh(FullInteractionMatrix: np.ndarray, mask: np.ndarray):

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -8,7 +8,7 @@ if get_ipython() is None:  # this matplotlib option is just in non-notebook case
 import matplotlib.pyplot as plt
 from astropy.io import fits
 
-from Asterix.utils import resizing, crop_or_pad_image, save_plane_in_fits, progress
+from Asterix.utils import resizing, crop_or_pad_image, save_plane_in_fits, progress, from_param_to_header
 import Asterix.optics.propagation_functions as prop
 from Asterix.optics import OpticalSystem, DeformableMirror, Testbed
 
@@ -221,6 +221,9 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
     # the initial phase for each DM
     DM_phase_init = testbed.voltage_to_phases(initial_DM_voltage)
 
+    # we load the configuration to save it in the fits
+    header = from_param_to_header(testbed.config_file)
+
     # First run throught the DMs to :
     #   - string matrix to create a name for the matrix
     #   - check total size of basis
@@ -278,7 +281,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
         list_str = basis_str.split('_')
         list_str.pop(2)
         name_basis_fits = "Basis" + '_'.join(list_str) + ".fits"
-        fits.writeto(os.path.join(matrix_dir, name_basis_fits), DM.basis, overwrite=True)
+        fits.writeto(os.path.join(matrix_dir, name_basis_fits), DM.basis, header, overwrite=True)
 
         if os.path.exists(os.path.join(matrix_dir, fileDirectMatrix + ".fits")) and (initial_DM_voltage == 0.).all():
             if not silence:
@@ -604,7 +607,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
             # We save the interaction matrix:
             if (initial_DM_voltage == 0.).all():
                 fits.writeto(os.path.join(matrix_dir, fileDirectMatrix + ".fits"),
-                             InterMat[:, pos_in_matrix:pos_in_matrix + DM.basis_size])
+                             InterMat[:, pos_in_matrix:pos_in_matrix + DM.basis_size], header)
 
             if not silence:
                 print("")

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -210,7 +210,10 @@ def create_singlewl_pw_matrix(testbed: Testbed,
                 PWMatrix[l_ind] = np.zeros((2, numprobe))
             l_ind = l_ind + 1
 
-    header = from_param_to_header(testbed.config_file)
+    if hasattr(testbed, 'config_file'):
+        header = from_param_to_header(testbed.config_file)
+    else:
+        header = fits.Header()
 
     fits.writeto(os.path.join(matrix_dir, filePW + ".fits"), np.array(PWMatrix), header)
     visuPWMap = "EigenPW_" + string_dims_PWMatrix

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -144,7 +144,7 @@ def create_singlewl_pw_matrix(testbed: Testbed,
         matrix in order to retrieve the focal plane electric field
     """
 
-    filePW, header_expected, bool_already_existing_matrix = name_header_pw_matrix(testbed, amplitude, posprobes,
+    filePW, header_expected, bool_already_existing_matrix = name_header_pwp_matrix(testbed, amplitude, posprobes,
                                                                                   dimEstim, cutsvd, wavelength,
                                                                                   matrix_dir)
 
@@ -218,7 +218,7 @@ def create_singlewl_pw_matrix(testbed: Testbed,
     return PWMatrix
 
 
-def name_header_pw_matrix(testbed: Testbed, amplitude, posprobes, dimEstim, cutsvd, wavelength, matrix_dir):
+def name_header_pwp_matrix(testbed: Testbed, amplitude, posprobes, dimEstim, cutsvd, wavelength, matrix_dir):
     """ Create the name of the file and header of the PW matrix that will be used to
     identify precisely parameter used in the calcul of this matrix and recalculate if need be.
     We then load a potential matrix and compare the header to the one existing.

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from astropy.io import fits
 
-from Asterix.utils import resizing, invert_svd, save_plane_in_fits
+from Asterix.utils import resizing, invert_svd, save_plane_in_fits, from_param_to_header
 from Asterix.optics import DeformableMirror, Testbed
 
 
@@ -209,9 +209,12 @@ def create_singlewl_pw_matrix(testbed: Testbed,
                 SVD[:, i, j] = np.zeros(2)
                 PWMatrix[l_ind] = np.zeros((2, numprobe))
             l_ind = l_ind + 1
-    fits.writeto(os.path.join(matrix_dir, filePW + ".fits"), np.array(PWMatrix))
+
+    header = from_param_to_header(testbed.config_file)
+
+    fits.writeto(os.path.join(matrix_dir, filePW + ".fits"), np.array(PWMatrix), header)
     visuPWMap = "EigenPW_" + string_dims_PWMatrix
-    fits.writeto(os.path.join(matrix_dir, visuPWMap + ".fits"), np.array(SVD[1]))
+    fits.writeto(os.path.join(matrix_dir, visuPWMap + ".fits"), np.array(SVD[1]), header)
     if not silence:
         print("Time for PWP Matrix (s): ", np.round(time.time() - start_time))
 

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -211,15 +211,23 @@ def create_singlewl_pw_matrix(testbed: Testbed,
                 PWMatrix[l_ind] = np.zeros((2, numprobe))
             l_ind = l_ind + 1
 
-    if hasattr(testbed, 'config_file'):
-        header = from_param_to_header(testbed.config_file)
-    else:
-        header = fits.Header()
-
+    header = fits.Header()
     header.insert(0, ('date_mat', datetime.now().strftime("%d/%m/%Y %H:%M:%S"), "matrix creation date"))
+    # we load the configuration to save it in the fits
+    if hasattr(testbed, 'config_file'):
+        necessary_estim_param = dict()
+        necessary_estim_param['dimEstim'] = dimEstim
+        necessary_estim_param['Estim_wl'] = wavelength * 1e9
+        header = from_param_to_header(necessary_estim_param, header)
+
+        header = from_param_to_header(testbed.config_file["Estimationconfig"], header)
+        header = from_param_to_header(testbed.config_file["modelconfig"], header)
+        header = from_param_to_header(testbed.config_file["DMconfig"], header)
+        header = from_param_to_header(testbed.config_file["Coronaconfig"], header)
+
     fits.writeto(os.path.join(matrix_dir, filePW + ".fits"), np.array(PWMatrix), header)
     visuPWMap = "EigenPW_" + string_dims_PWMatrix
-    fits.writeto(os.path.join(matrix_dir, visuPWMap + ".fits"), np.array(SVD[1]), header)
+    fits.writeto(os.path.join(matrix_dir, visuPWMap + ".fits"), np.array(SVD[1]), header, overwrite=True)
     if not silence:
         print("Time for PWP Matrix (s): ", np.round(time.time() - start_time))
 

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -1,5 +1,6 @@
 import os
 import time
+from datetime import datetime
 import numpy as np
 
 from astropy.io import fits
@@ -215,6 +216,7 @@ def create_singlewl_pw_matrix(testbed: Testbed,
     else:
         header = fits.Header()
 
+    header.insert(0, ('date_mat', datetime.now().strftime("%d/%m/%Y %H:%M:%S"), "matrix creation date"))
     fits.writeto(os.path.join(matrix_dir, filePW + ".fits"), np.array(PWMatrix), header)
     visuPWMap = "EigenPW_" + string_dims_PWMatrix
     fits.writeto(os.path.join(matrix_dir, visuPWMap + ".fits"), np.array(SVD[1]), header)

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -145,8 +145,8 @@ def create_singlewl_pw_matrix(testbed: Testbed,
     """
 
     filePW, header_expected, bool_already_existing_matrix = name_header_pwp_matrix(testbed, amplitude, posprobes,
-                                                                                  dimEstim, cutsvd, wavelength,
-                                                                                  matrix_dir)
+                                                                                   dimEstim, cutsvd, wavelength,
+                                                                                   matrix_dir)
 
     if bool_already_existing_matrix:
         # there is already a really identical matrix calculated, we just load the old matrix fits file.
@@ -290,23 +290,19 @@ def name_header_pwp_matrix(testbed: Testbed, amplitude, posprobes, dimEstim, cut
 
         header = from_param_to_header(testbed.config_file["Coronaconfig"], header)
 
-        # Loading any existing matrix and comparing their headers to make sure they are created
-        # using the same set of parameters
-        if os.path.exists(os.path.join(matrix_dir, filePW + ".fits")):
-            header_existing = fits.getheader(os.path.join(matrix_dir, filePW + ".fits"))
-            # remove the basis kw created automatically  when saving the fits file
-            for keyw in ['SIMPLE', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2', 'NAXIS3']:
-                header_existing.remove(keyw)
-            # we comapre the header (ignoring the date)
-            bool_already_existing_matrix = fits.HeaderDiff(header_existing, header,
-                                                           ignore_keywords=['DATE_MAT']).identical
-        else:
-            bool_already_existing_matrix = False
+    # Loading any existing matrix and comparing their headers to make sure they are created
+    # using the same set of parameters
+    if os.path.exists(os.path.join(matrix_dir, filePW + ".fits")):
+        header_existing = fits.getheader(os.path.join(matrix_dir, filePW + ".fits"))
+        # remove the basis kw created automatically  when saving the fits file
+        for keyw in ['SIMPLE', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2', 'NAXIS3']:
+            header_existing.remove(keyw)
+        # we comapre the header (ignoring the date)
+        bool_already_existing_matrix = fits.HeaderDiff(header_existing, header, ignore_keywords=['DATE_MAT']).identical
+    else:
+        bool_already_existing_matrix = False
 
-        if bool_already_existing_matrix:
-            return filePW, header, bool_already_existing_matrix
-        else:
-            return filePW, header, bool_already_existing_matrix
+    return filePW, header, bool_already_existing_matrix
 
 
 def calculate_pw_estimate(Difference,

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -281,7 +281,13 @@ def name_header_pw_matrix(testbed: Testbed, amplitude, posprobes, dimEstim, cuts
         header = from_param_to_header(additional_model_param, header)
 
         header = from_param_to_header(testbed.config_file["modelconfig"], header)
-        header = from_param_to_header(testbed.config_file["DMconfig"], header)
+
+        necessary_dm_param = dict()
+        for paramdmkey in testbed.config_file["DMconfig"].scalars:
+            if testbed.name_DM_to_probe_in_PW in paramdmkey:
+                necessary_dm_param[paramdmkey] = testbed.config_file["DMconfig"][paramdmkey]
+        header = from_param_to_header(necessary_dm_param, header)
+
         header = from_param_to_header(testbed.config_file["Coronaconfig"], header)
 
         # Loading any existing matrix and comparing their headers to make sure they are created

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,7 +4,7 @@
 Quick install
 --------------------------
 
-If you know all about conda virtual environments and you only want to install asterix's latest version, just copy:
+If you know all about conda virtual environments and you only want to install Asterix's latest version, just copy:
 
 .. code-block:: bash
 
@@ -24,7 +24,7 @@ switches between environments.
 
 By creating clean python environments for each of your projects (especially packages in continuous
 development by non developers like Asterix), you minimize the risk of of creating conflicts which
-will hinder the use of Asterx and/or on your other projects.
+will hinder the use of Asterix and/or of your other projects.
 
 First download and install miniconda3:
 https://docs.conda.io/en/latest/miniconda.html


### PR DESCRIPTION

1) Lot of header change in most fits saved : 

a / Added the config is all saved matrices. Created specific fonctions to identify `name_header_efc_matrix` and `name_header_pwp_matrix` to specifically identify kw important for each matrix. Based on these kw, the matrix are recalculated or not (this is more selective than the name of matrix that was used until now)/ 

b/ Date and hour of saving is also saved in header["date_mat"] 

c/ Finally Added a kw : header["MODELSIM"] = 'asterix' in all matrices
Referenced in this issue in thd-controls package
https://github.com/ivalaginja/thd-controls/issues/132

3) we also save the matrices in the thd-controls format, see 
https://github.com/ivalaginja/thd-controls/issues/129

