### PR TITLE
Add Bordé et Traub mode for estimation 

### DIFF
--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -222,7 +222,7 @@ onbench=True
 
 [Estimationconfig]
 
-    estimation='Perfect' # FP WF sensing : "Perfect", "pwp" or "btp+"
+    estimation='Perfect' # FP WF sensing : "Perfect", "pwp" or "btp"
 
     # Integer. We bin the estimation images used for PW / perfect estim by this factor 
     # this way dimEstim = dimScience / Estim_bin_factor

--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -222,7 +222,7 @@ onbench=True
 
 [Estimationconfig]
 
-    estimation='Perfect' # FP WF sensing : "Perfect", "pw" or "btp+"
+    estimation='Perfect' # FP WF sensing : "Perfect", "pwp" or "btp+"
 
     # Integer. We bin the estimation images used for PW / perfect estim by this factor 
     # this way dimEstim = dimScience / Estim_bin_factor

--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -377,3 +377,5 @@ onbench=True
 
     #photon noise
     nb_photons = 0 #1e10 #If 0, no photon noise.
+
+    

--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -222,7 +222,7 @@ onbench=True
 
 [Estimationconfig]
 
-    estimation='Perfect' # FP WF sensing : 'Perfect', 'pw' or 'btp+'
+    estimation='Perfect' # FP WF sensing : "Perfect", "pw" or "btp+"
 
     # Integer. We bin the estimation images used for PW / perfect estim by this factor 
     # this way dimEstim = dimScience / Estim_bin_factor

--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -378,4 +378,4 @@ onbench=True
     #photon noise
     nb_photons = 0 #1e10 #If 0, no photon noise.
 
-    
+

--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -222,7 +222,7 @@ onbench=True
 
 [Estimationconfig]
 
-    estimation='Perfect' # FP WF sensing : 'Perfect' or 'pw'
+    estimation='Perfect' # FP WF sensing : 'Perfect', 'pw' or 'btp+'
 
     # Integer. We bin the estimation images used for PW / perfect estim by this factor 
     # this way dimEstim = dimScience / Estim_bin_factor
@@ -377,5 +377,3 @@ onbench=True
 
     #photon noise
     nb_photons = 0 #1e10 #If 0, no photon noise.
-
-

--- a/Asterix/example_run_asterix.py
+++ b/Asterix/example_run_asterix.py
@@ -8,65 +8,65 @@ your_parameter_file_name = 'Example_param_file.ini'
 
 parameter_file_path = os.path.join(your_directory, your_parameter_file_name)
 
-start_time = time.time()
-main_THD.runthd2(parameter_file_path,
-                 NewDMconfig={'DM1_active': False},
-                 NewEstimationconfig={'estimation': 'pwp'},
-                 NewCorrectionconfig={
-                     'DH_side': "Right",
-                     'correction_algorithm': "efc",
-                     'Nbmodes_OnTestbed': 330
-                 },
-                 NewLoopconfig={
-                     'Nbiter_corr': [5, 10],
-                     "Nbmode_corr": [330, 340]
-                 },
-                 NewSIMUconfig={'Name_Experiment': "My_first_experiment"},
-                 dir_save_all_planes=None)
+# start_time = time.time()
+# main_THD.runthd2(parameter_file_path,
+#                  NewDMconfig={'DM1_active': False},
+#                  NewEstimationconfig={'estimation': 'pwp'},
+#                  NewCorrectionconfig={
+#                      'DH_side': "Right",
+#                      'correction_algorithm': "efc",
+#                      'Nbmodes_OnTestbed': 330
+#                  },
+#                  NewLoopconfig={
+#                      'Nbiter_corr': [5, 10],
+#                      "Nbmode_corr": [330, 340]
+#                  },
+#                  NewSIMUconfig={'Name_Experiment': "My_first_experiment"},
+#                  dir_save_all_planes=None)
 
-print('time correction 1DM perfect estim efc', time.time() - start_time)
-print("")
-print("")
-print("")
+# print('time correction 1DM perfect estim efc', time.time() - start_time)
+# print("")
+# print("")
+# print("")
 
-start_time = time.time()
-main_THD.runthd2(parameter_file_path,
-                 NewDMconfig={'DM1_active': False},
-                 NewEstimationconfig={'estimation': 'perfect'},
-                 NewCorrectionconfig={
-                     'DH_side': "Right",
-                     'correction_algorithm': "efc",
-                     'Nbmodes_OnTestbed': 330
-                 },
-                 NewLoopconfig={
-                     'Nbiter_corr': [5, 10],
-                     "Nbmode_corr": [330, 340]
-                 },
-                 NewSIMUconfig={'Name_Experiment': "My_second_experiment"})
-print('time correction 1DM perfect estim efc', time.time() - start_time)
-print("")
-print("")
-print("")
+# start_time = time.time()
+# main_THD.runthd2(parameter_file_path,
+#                  NewDMconfig={'DM1_active': False},
+#                  NewEstimationconfig={'estimation': 'perfect'},
+#                  NewCorrectionconfig={
+#                      'DH_side': "Right",
+#                      'correction_algorithm': "efc",
+#                      'Nbmodes_OnTestbed': 330
+#                  },
+#                  NewLoopconfig={
+#                      'Nbiter_corr': [5, 10],
+#                      "Nbmode_corr": [330, 340]
+#                  },
+#                  NewSIMUconfig={'Name_Experiment': "My_second_experiment"})
+# print('time correction 1DM perfect estim efc', time.time() - start_time)
+# print("")
+# print("")
+# print("")
+
+# start_time = time.time()
+# main_THD.runthd2(parameter_file_path,
+#                  NewDMconfig={'DM1_active': True},
+#                  NewEstimationconfig={'estimation': 'perfect'},
+#                  NewCorrectionconfig={
+#                      'DH_side': "Full",
+#                      'correction_algorithm': "sm",
+#                  },
+#                  NewLoopconfig={'Nbiter_corr': [20]},
+#                  NewSIMUconfig={'Name_Experiment': "My_third_experiment"})
+# print('time correction 2DM perfect estim sm', time.time() - start_time)
+# print("")
+# print("")
+# print("")
 
 start_time = time.time()
 main_THD.runthd2(parameter_file_path,
                  NewDMconfig={'DM1_active': True},
-                 NewEstimationconfig={'estimation': 'perfect'},
-                 NewCorrectionconfig={
-                     'DH_side': "Full",
-                     'correction_algorithm': "sm",
-                 },
-                 NewLoopconfig={'Nbiter_corr': [20]},
-                 NewSIMUconfig={'Name_Experiment': "My_third_experiment"})
-print('time correction 2DM perfect estim sm', time.time() - start_time)
-print("")
-print("")
-print("")
-
-start_time = time.time()
-main_THD.runthd2(parameter_file_path,
-                 NewDMconfig={'DM1_active': True},
-                 NewEstimationconfig={'estimation': 'pwp'},
+                 NewEstimationconfig={'estimation': 'btp'},
                  NewCorrectionconfig={
                      'DH_side': "Full",
                      'correction_algorithm': "efc",

--- a/Asterix/example_run_asterix.py
+++ b/Asterix/example_run_asterix.py
@@ -11,7 +11,7 @@ parameter_file_path = os.path.join(your_directory, your_parameter_file_name)
 start_time = time.time()
 main_THD.runthd2(parameter_file_path,
                  NewDMconfig={'DM1_active': False},
-                 NewEstimationconfig={'estimation': 'pw'},
+                 NewEstimationconfig={'estimation': 'pwp'},
                  NewCorrectionconfig={
                      'DH_side': "Right",
                      'correction_algorithm': "efc",
@@ -66,7 +66,7 @@ print("")
 start_time = time.time()
 main_THD.runthd2(parameter_file_path,
                  NewDMconfig={'DM1_active': True},
-                 NewEstimationconfig={'estimation': 'pw'},
+                 NewEstimationconfig={'estimation': 'pwp'},
                  NewCorrectionconfig={
                      'DH_side': "Full",
                      'correction_algorithm': "efc",

--- a/Asterix/example_run_asterix.py
+++ b/Asterix/example_run_asterix.py
@@ -8,65 +8,65 @@ your_parameter_file_name = 'Example_param_file.ini'
 
 parameter_file_path = os.path.join(your_directory, your_parameter_file_name)
 
-# start_time = time.time()
-# main_THD.runthd2(parameter_file_path,
-#                  NewDMconfig={'DM1_active': False},
-#                  NewEstimationconfig={'estimation': 'pwp'},
-#                  NewCorrectionconfig={
-#                      'DH_side': "Right",
-#                      'correction_algorithm': "efc",
-#                      'Nbmodes_OnTestbed': 330
-#                  },
-#                  NewLoopconfig={
-#                      'Nbiter_corr': [5, 10],
-#                      "Nbmode_corr": [330, 340]
-#                  },
-#                  NewSIMUconfig={'Name_Experiment': "My_first_experiment"},
-#                  dir_save_all_planes=None)
+start_time = time.time()
+main_THD.runthd2(parameter_file_path,
+                 NewDMconfig={'DM1_active': False},
+                 NewEstimationconfig={'estimation': 'pwp'},
+                 NewCorrectionconfig={
+                     'DH_side': "Right",
+                     'correction_algorithm': "efc",
+                     'Nbmodes_OnTestbed': 330
+                 },
+                 NewLoopconfig={
+                     'Nbiter_corr': [5, 10],
+                     "Nbmode_corr": [330, 340]
+                 },
+                 NewSIMUconfig={'Name_Experiment': "My_first_experiment"},
+                 dir_save_all_planes=None)
 
-# print('time correction 1DM perfect estim efc', time.time() - start_time)
-# print("")
-# print("")
-# print("")
+print('time correction 1DM perfect estim efc', time.time() - start_time)
+print("")
+print("")
+print("")
 
-# start_time = time.time()
-# main_THD.runthd2(parameter_file_path,
-#                  NewDMconfig={'DM1_active': False},
-#                  NewEstimationconfig={'estimation': 'perfect'},
-#                  NewCorrectionconfig={
-#                      'DH_side': "Right",
-#                      'correction_algorithm': "efc",
-#                      'Nbmodes_OnTestbed': 330
-#                  },
-#                  NewLoopconfig={
-#                      'Nbiter_corr': [5, 10],
-#                      "Nbmode_corr": [330, 340]
-#                  },
-#                  NewSIMUconfig={'Name_Experiment': "My_second_experiment"})
-# print('time correction 1DM perfect estim efc', time.time() - start_time)
-# print("")
-# print("")
-# print("")
-
-# start_time = time.time()
-# main_THD.runthd2(parameter_file_path,
-#                  NewDMconfig={'DM1_active': True},
-#                  NewEstimationconfig={'estimation': 'perfect'},
-#                  NewCorrectionconfig={
-#                      'DH_side': "Full",
-#                      'correction_algorithm': "sm",
-#                  },
-#                  NewLoopconfig={'Nbiter_corr': [20]},
-#                  NewSIMUconfig={'Name_Experiment': "My_third_experiment"})
-# print('time correction 2DM perfect estim sm', time.time() - start_time)
-# print("")
-# print("")
-# print("")
+start_time = time.time()
+main_THD.runthd2(parameter_file_path,
+                 NewDMconfig={'DM1_active': False},
+                 NewEstimationconfig={'estimation': 'perfect'},
+                 NewCorrectionconfig={
+                     'DH_side': "Right",
+                     'correction_algorithm': "efc",
+                     'Nbmodes_OnTestbed': 330
+                 },
+                 NewLoopconfig={
+                     'Nbiter_corr': [5, 10],
+                     "Nbmode_corr": [330, 340]
+                 },
+                 NewSIMUconfig={'Name_Experiment': "My_second_experiment"})
+print('time correction 1DM perfect estim efc', time.time() - start_time)
+print("")
+print("")
+print("")
 
 start_time = time.time()
 main_THD.runthd2(parameter_file_path,
                  NewDMconfig={'DM1_active': True},
-                 NewEstimationconfig={'estimation': 'btp'},
+                 NewEstimationconfig={'estimation': 'perfect'},
+                 NewCorrectionconfig={
+                     'DH_side': "Full",
+                     'correction_algorithm': "sm",
+                 },
+                 NewLoopconfig={'Nbiter_corr': [20]},
+                 NewSIMUconfig={'Name_Experiment': "My_third_experiment"})
+print('time correction 2DM perfect estim sm', time.time() - start_time)
+print("")
+print("")
+print("")
+
+start_time = time.time()
+main_THD.runthd2(parameter_file_path,
+                 NewDMconfig={'DM1_active': True},
+                 NewEstimationconfig={'estimation': 'pwp'},
                  NewCorrectionconfig={
                      'DH_side': "Full",
                      'correction_algorithm': "efc",

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -132,8 +132,8 @@ def runthd2(parameter_file_path,
     # Concatenate into the full testbed optical system
     thd2 = THD2(config, model_local_dir, silence=silence)
 
-    # The following line can be used to change the DM which applies PW probes.
-    # This can be used to use the DM out of the pupil plane as the PW DM.
+    # The following line can be used to change the DM which applies PWP probes.
+    # This can be used to use the DM out of the pupil plane as the PWP DM.
     # This is an unusual option so not in the param file and not well documented.
     # thd2.name_DM_to_probe_in_PW = "DM1"
 

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -170,7 +170,7 @@ class Estimator:
             if self.polychrom == 'broadband_pwprobes':
                 raise ValueError("Cannot use [Estimationconfig]['polychromatic']='broadband_pwprobes' in perfect mode.")
 
-        elif self.technique in ["pairwise", "pw", "pwp", "btp+"]:
+        elif self.technique in ["pairwise", "pw", "pwp", "btp"]:
             self.is_focal_plane = True
             self.is_complex = True
 
@@ -322,7 +322,7 @@ class Estimator:
                 raise ValueError(self.polychrom +
                                  "is not a valid value for [Estimationconfig]['polychromatic'] parameter.")
 
-        elif self.technique in ["pairwise", "pw", "pwp", "btp+"]:
+        elif self.technique in ["pairwise", "pw", "pwp", "btp"]:
 
             # nb_photons parameter is normally for the whole bandwidth (testbed.Delta_wav). For this
             # case, we reduce it to self.delta_wav_estim_individual bandwidth

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -12,7 +12,7 @@ class Estimator:
     """Estimator Class allows you to define a WF estimator.
 
         It must contains 2 functions at least:
-            - an initialization (e.g. PW matrix) Estimator.__init__(), with parameters:
+            - an initialization (e.g. PWP matrix) Estimator.__init__(), with parameters:
                     - the testbed structure
                     - the estimation parameters
                     - saving directories
@@ -170,7 +170,7 @@ class Estimator:
             if self.polychrom == 'broadband_pwprobes':
                 raise ValueError("Cannot use [Estimationconfig]['polychromatic']='broadband_pwprobes' in perfect mode.")
 
-        elif self.technique in ["pairwise", "pw", "btp+"]:
+        elif self.technique in ["pairwise", "pw", "pwp", "btp+"]:
             self.is_focal_plane = True
             self.is_complex = True
 
@@ -190,7 +190,7 @@ class Estimator:
                                                  self.wav_vec_estim,
                                                  silence=silence)
 
-            # Saving PW matrix in Labview directory
+            # Saving PWP matrix in Labview directory
             if save_for_bench:
 
                 if not os.path.exists(realtestbed_dir):
@@ -216,7 +216,7 @@ class Estimator:
                                  self.dimEstim] = self.PWMatrix[k][:, 1, i].flatten()
 
                     # Because the exact laser WLs can change a bit quite often and labview reads a given
-                    # fits name, we name the PW matrix laser1, 2, 3 for a range of WL.
+                    # fits name, we name the PWP matrix laser1, 2, 3 for a range of WL.
 
                     string_laser = ''
                     if 625 < wave_k * 1e9 < 645:
@@ -322,7 +322,7 @@ class Estimator:
                 raise ValueError(self.polychrom +
                                  "is not a valid value for [Estimationconfig]['polychromatic'] parameter.")
 
-        elif self.technique in ["pairwise", "pw", "btp+"]:
+        elif self.technique in ["pairwise", "pw", "pwp", "btp+"]:
 
             # nb_photons parameter is normally for the whole bandwidth (testbed.Delta_wav). For this
             # case, we reduce it to self.delta_wav_estim_individual bandwidth
@@ -441,7 +441,7 @@ class Estimator:
 
 
 def find_DM_to_probe(testbed: Testbed):
-    """Find which DM to use for the PW probes.
+    """Find which DM to use for the PWP/BTP probes.
 
     AUTHOR : Johan Mazoyer
 
@@ -453,14 +453,14 @@ def find_DM_to_probe(testbed: Testbed):
     Returns
     ------------
     name_DM_to_probe_in_PW : string
-        name of the DM to probe in PW
+        name of the DM to probe in PWP or BTP
     """
 
     # we chose it already. We only check its existence
     if hasattr(testbed, 'name_DM_to_probe_in_PW'):
         if testbed.name_DM_to_probe_in_PW not in testbed.name_of_DMs:
             raise ValueError(f"Testbed has no DM '{testbed.name_DM_to_probe_in_PW}', choose another DM name "
-                             "for PW, using using 'testbed.name_DM_to_probe_in_PW'.")
+                             "for PWP, using using 'testbed.name_DM_to_probe_in_PW'.")
         return testbed.name_DM_to_probe_in_PW
 
     # If name_DM_to_probe_in_PW is not already set,
@@ -483,9 +483,9 @@ def find_DM_to_probe(testbed: Testbed):
         # If there are several DMs in PP, error, you need to set name_DM_to_probe_in_PW
         if number_DMs_in_PP > 1:
             raise ValueError("You have several DM in PP, choose manually one for "
-                             "the PW probes using 'testbed.name_DM_to_probe_in_PW'.")
+                             "the PWP probes using 'testbed.name_DM_to_probe_in_PW'.")
         # Several DMS, none in PP, error, you need to set name_DM_to_probe_in_PW
         if number_DMs_in_PP == 0:
             raise ValueError("You have several DMs, none in PP, choose manually one for "
-                             "the PW probes using 'testbed.name_DM_to_probe_in_PW'.")
+                             "the PWP probes using 'testbed.name_DM_to_probe_in_PW'.")
     return name_DM_to_probe_in_PW

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -170,7 +170,7 @@ class Estimator:
             if self.polychrom == 'broadband_pwprobes':
                 raise ValueError("Cannot use [Estimationconfig]['polychromatic']='broadband_pwprobes' in perfect mode.")
 
-        elif self.technique in ["pairwise", "pw"]:
+        elif self.technique in ["pairwise", "pw", "btp+"]:
             self.is_focal_plane = True
             self.is_complex = True
 
@@ -322,7 +322,7 @@ class Estimator:
                 raise ValueError(self.polychrom +
                                  "is not a valid value for [Estimationconfig]['polychromatic'] parameter.")
 
-        elif self.technique in ["pairwise", "pw"]:
+        elif self.technique in ["pairwise", "pw", "btp+"]:
 
             # nb_photons parameter is normally for the whole bandwidth (testbed.Delta_wav). For this
             # case, we reduce it to self.delta_wav_estim_individual bandwidth
@@ -338,6 +338,7 @@ class Estimator:
                                                             self.amplitudePW,
                                                             voltage_vector=voltage_vector,
                                                             wavelengths=wavei,
+                                                            pwp_or_btp=self.technique,
                                                             **kwargs)
                     probed_fp_images.append(Difference)
 
@@ -349,6 +350,7 @@ class Estimator:
                                                         self.amplitudePW,
                                                         voltage_vector=voltage_vector,
                                                         wavelengths=self.wav_vec_estim[0],
+                                                        pwp_or_btp=self.technique,
                                                         **kwargs)
                 probed_fp_images.append(Difference)
 
@@ -359,6 +361,7 @@ class Estimator:
                                                         self.amplitudePW,
                                                         voltage_vector=voltage_vector,
                                                         wavelengths=testbed.wav_vec,
+                                                        pwp_or_btp=self.technique,
                                                         **kwargs)
                 probed_fp_images.append(Difference)
 

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -399,7 +399,7 @@ class Estimator:
         if (self.technique == "perfect") or (perfect_estimation):
             return probed_images
 
-        elif self.technique in ["pairwise", "pw"]:
+        elif self.technique in ["pairwise", "pw", "pwp", "btp"]:
 
             result_estim = []
 

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -60,7 +60,7 @@ def create_interaction_matrix(testbed: Testbed,
     polychrom : string
         For polychromatic estimation and correction:
         - 'singlewl': only a single wavelength is used for estimation / correction. 1 Interation Matrix
-        - 'broadband_pwprobes': probes images PW are broadband but Matrices are at central wavelength: 1 PW Matrix and 1 Interation Matrix
+        - 'broadband_pwprobes': probes images PWP are broadband but Matrices are at central wavelength: 1 PWP Matrix and 1 Interation Matrix
         - 'multiwl': nb_wav images are used for estimation and there are nb_wav matrices of estimation and nb_wav matrices for correction
     initial_DM_voltage : 1D-array real
         initial DM voltage for all DMs

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -222,7 +222,7 @@ def calculate_pw_estimate(Difference,
                           Vectorprobes,
                           dimimages,
                           dir_save_all_planes=None,
-                          pwp_or_btp="pw",
+                          pwp_or_btp="pwp",
                           dtype_complex='complex128'):
     """Calculate the focal plane electric field from the probe image
     differences and the modeled probe matrix.
@@ -290,7 +290,7 @@ def simulate_pw_difference(input_wavefront,
                            amplitudePW,
                            voltage_vector=0.,
                            wavelengths=None,
-                           pwp_or_btp="pw",
+                           pwp_or_btp="pwp",
                            **kwargs):
     """Simulate the acquisition of probe images using Pair-wise.
 

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -243,7 +243,7 @@ def calculate_pw_estimate(Difference,
     pwp_or_btp : string, default 'pwp'
         type of algorithm used, can be
             'pw' Pair Wise Probing
-            'btp+' Borde Traub Probing where the probe is pushed positevely
+            'btp' Borde Traub Probing where the probe is pushed positevely
     dtype_complex : string, default 'complex128'
         bit number for the complex arrays in the PWP matrices.
         Can be 'complex128' or 'complex64'. The latter increases the speed of the mft but at the
@@ -277,11 +277,11 @@ def calculate_pw_estimate(Difference,
 
     if pwp_or_btp in ['pw', "pwp", 'pairwise']:
         return Resultat / 4.
-    elif pwp_or_btp in ['btp+']:
+    elif pwp_or_btp in ['btp']:
         return Resultat / 2.
     else:
         raise ValueError("pwp_or_btp parameter can only take 2 values 'pwp' for Pair Wise Probing "
-                         "or 'btp+' for Borde Traub Probing")
+                         "or 'btp' for Borde Traub Probing")
 
 
 def simulate_pw_difference(input_wavefront,
@@ -295,7 +295,7 @@ def simulate_pw_difference(input_wavefront,
     """Simulate the acquisition of probe images using Pair-wise.
 
     and calculate the difference of images [I(+probe) - I(-probe)] (if pwp_or_btp = 'pw')
-    or [I(+probe) - I(0)] (if pwp_or_btp = 'btp+').
+    or [I(+probe) - I(0)] (if pwp_or_btp = 'btp').
     We use testbed.name_DM_to_probe_in_PW to do the probes.
 
     Parameters
@@ -315,7 +315,7 @@ def simulate_pw_difference(input_wavefront,
     pwp_or_btp : string, default 'pwp'
         type of algorithm used, can be
             'pw' Pair Wise Probing
-            'btp+' Borde Traub Probing where the probe is pushed positevely
+            'btp' Borde Traub Probing where the probe is pushed positevely
 
     Returns
     --------
@@ -325,7 +325,7 @@ def simulate_pw_difference(input_wavefront,
 
     Difference = np.zeros((len(posprobes), testbed.dimScience, testbed.dimScience))
 
-    if pwp_or_btp == 'btp+':
+    if pwp_or_btp == 'btp':
         # If we are in a polychromatic mode but we need monochromatic instensity
         # we have to be careful with the normalization, because
         # todetector_intensity is normalizing to polychromatic PSF by default
@@ -381,12 +381,13 @@ def simulate_pw_difference(input_wavefront,
                                                        wavelengths=wavelengths,
                                                        **kwargs)
 
-            elif pwp_or_btp in ['btp+']:
+            elif pwp_or_btp in ['btp']:
                 Int_fp_probe = testbed.todetector_intensity(entrance_EF=1 + 1j * probephase,
                                                             wavelengths=wavelengths,
                                                             **kwargs)
-            raise ValueError("pwp_or_btp parameter can only take 2 values 'pwp', 'pairwise' for"
-                             "Pair Wise Probing or 'btp+' for Borde Traub Probing")
+            else:
+                raise ValueError("pwp_or_btp parameter can only take 2 values 'pwp', 'pairwise' for"
+                             "Pair Wise Probing or 'btp' for Borde Traub Probing")
 
         elif isinstance(wavelengths, (float, int)) and wavelengths in testbed.wav_vec:
             # hard case : we are monochromatic for the probes, but polychromatic for the rest of images
@@ -406,13 +407,14 @@ def simulate_pw_difference(input_wavefront,
                     in_contrast=False,
                     **kwargs) / testbed.norm_monochrom[testbed.wav_vec.tolist().index(wavelengths)]
 
-            elif pwp_or_btp in ['btp+']:
+            elif pwp_or_btp in ['btp']:
                 Int_fp_probe = testbed.todetector_intensity(
                     entrance_EF=1 + 1j * probephase, wavelengths=wavelengths, in_contrast=False, **
                     kwargs) / testbed.norm_monochrom[testbed.wav_vec.tolist().index(wavelengths)]
 
-            raise ValueError("pwp_or_btp parameter can only take 2 values 'pwp', 'pairwise' for"
-                             "Pair Wise Probing or 'btp+' for Borde Traub Probing")
+            else:
+                raise ValueError("pwp_or_btp parameter can only take 2 values 'pwp', 'pairwise' for"
+                             "Pair Wise Probing or 'btp' for Borde Traub Probing")
 
         else:
             raise ValueError(("You are trying to do a pw_difference with wavelength parameters I don't understand. "
@@ -420,7 +422,7 @@ def simulate_pw_difference(input_wavefront,
 
         if pwp_or_btp in ['pw', "pwp", 'pairwise']:
             Difference[count] = Ikplus - Ikmoins
-        elif pwp_or_btp in ['btp+']:
+        elif pwp_or_btp in ['btp']:
             Difference[count] = Ikplus - Ik0 - Int_fp_probe
 
     return Difference

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -387,7 +387,7 @@ def simulate_pw_difference(input_wavefront,
                                                             **kwargs)
             else:
                 raise ValueError("pwp_or_btp parameter can only take 2 values 'pwp', 'pairwise' for"
-                             "Pair Wise Probing or 'btp' for Borde Traub Probing")
+                                 "Pair Wise Probing or 'btp' for Borde Traub Probing")
 
         elif isinstance(wavelengths, (float, int)) and wavelengths in testbed.wav_vec:
             # hard case : we are monochromatic for the probes, but polychromatic for the rest of images
@@ -414,7 +414,7 @@ def simulate_pw_difference(input_wavefront,
 
             else:
                 raise ValueError("pwp_or_btp parameter can only take 2 values 'pwp', 'pairwise' for"
-                             "Pair Wise Probing or 'btp' for Borde Traub Probing")
+                                 "Pair Wise Probing or 'btp' for Borde Traub Probing")
 
         else:
             raise ValueError(("You are trying to do a pw_difference with wavelength parameters I don't understand. "

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -41,7 +41,7 @@ def create_pw_matrix(testbed: Testbed,
     polychrom : string
         For polychromatic estimation and correction:
         - 'singlewl': only a single wavelength is used for estimation / correction. 1 Interation Matrix
-        - 'broadband_pwprobes': probes images PW are broadband but Matrices are at central wavelength: 1 PW Matrix and 1 Interation Matrix
+        - 'broadband_pwprobes': probes images PWP are broadband but Matrices are at central wavelength: 1 PWP Matrix and 1 Interation Matrix
         - 'multiwl': nb_wav images are used for estimation and there are nb_wav matrices of estimation and nb_wav matrices for correction
     wav_vec_estim : list of float, default None
         list of wavelengths to do the estimation, used in the case of polychrom == 'multiwl'
@@ -149,7 +149,7 @@ def create_singlewl_pw_matrix(testbed: Testbed,
                 round(testbed.Science_sampling / testbed.wavelength_0 * wavelength, 2)) + '_wl' + str(
                     int(wavelength * 1e9))
 
-    # Calculating and Saving PW matrix
+    # Calculating and Saving PWP matrix
 
     filePW = "MatPW_" + string_dims_PWMatrix
     if os.path.exists(os.path.join(matrix_dir, filePW + ".fits")):
@@ -161,7 +161,7 @@ def create_singlewl_pw_matrix(testbed: Testbed,
     start_time = time.time()
     if not silence:
         print("The PWmatrix " + filePW + " does not exists")
-        print("Start PW matrix" + ' at ' + str(int(wavelength * 1e9)) + "nm (wait a few seconds)")
+        print("Start PWP matrix" + ' at ' + str(int(wavelength * 1e9)) + "nm (wait a few seconds)")
 
     numprobe = len(posprobes)
     deltapsik = np.zeros((numprobe, dimEstim, dimEstim), dtype=testbed.dtype_complex)
@@ -182,7 +182,7 @@ def create_singlewl_pw_matrix(testbed: Testbed,
         Voltage_probe[i] = amplitude
         probephase[k] = DM_probe.voltage_to_phase(Voltage_probe)
 
-        # for PW the probes are not sent in the DM but at the entrance of the testbed.
+        # for PWP the probes are not sent in the DM but at the entrance of the testbed.
         # with an hypothesis of small phase.
         # I tried to remove "1+"". It breaks the code
         # (coronagraph does not "remove the 1 exactly")
@@ -213,7 +213,7 @@ def create_singlewl_pw_matrix(testbed: Testbed,
     visuPWMap = "EigenPW_" + string_dims_PWMatrix
     fits.writeto(os.path.join(matrix_dir, visuPWMap + ".fits"), np.array(SVD[1]))
     if not silence:
-        print("Time for PW Matrix (s): ", np.round(time.time() - start_time))
+        print("Time for PWP Matrix (s): ", np.round(time.time() - start_time))
 
     return PWMatrix
 
@@ -244,7 +244,7 @@ def calculate_pw_estimate(Difference,
             'pw' Pair Wise Probing
             'btp+' Borde Traub Probing where the probe is pushed positevely
     dtype_complex : string, default 'complex128'
-        bit number for the complex arrays in the PW matrices.
+        bit number for the complex arrays in the PWP matrices.
         Can be 'complex128' or 'complex64'. The latter increases the speed of the mft but at the
         cost of lower precision.
 
@@ -274,7 +274,7 @@ def calculate_pw_estimate(Difference,
         name_plane = 'PW_Estimate'
         save_plane_in_fits(dir_save_all_planes, name_plane, Resultat / 4.)
 
-    if pwp_or_btp in ['pw', 'pairwise']:
+    if pwp_or_btp in ['pw', "pwp", 'pairwise']:
         return Resultat / 4.
     elif pwp_or_btp in ['btp+']:
         return Resultat / 2.
@@ -306,7 +306,7 @@ def simulate_pw_difference(input_wavefront,
     posprobes : 1D-array
         Index of the actuators to push and pull for pair-wise probing.
     amplitudePW : float
-        PW probes amplitude in nm.
+        PWP probes amplitude in nm.
     voltage_vector : 1D float array or float, default 0
         Vector of voltages vectors for each DMs arounf which we do the difference.
     wavelengths : float, default None
@@ -340,7 +340,7 @@ def simulate_pw_difference(input_wavefront,
 
             indice_acum_number_act += DM.number_act
 
-        if pwp_or_btp in ['pw', 'pairwise']:
+        if pwp_or_btp in ['pw', "pwp", 'pairwise']:
             Voltage_probe_value1 = +Voltage_probe
             Voltage_probe_value2 = -Voltage_probe
         elif pwp_or_btp == 'btp+':
@@ -399,7 +399,7 @@ def simulate_pw_difference(input_wavefront,
             raise ValueError(("You are trying to do a pw_difference with wavelength parameters I don't understand. "
                               "Code it yourself in simulate_pw_difference and be careful with the normalization"))
 
-        if pwp_or_btp in ['pw', 'pairwise']:
+        if pwp_or_btp in ['pw', "pwp", 'pairwise']:
             Difference[count] = resizing(Ikprobevalue1 - Ikprobevalue2, dimimages)
         elif pwp_or_btp in ['btp+']:
             Difference[count] = resizing(Ikprobevalue1 - Ikprobevalue2 - Int_fp_probe, dimimages)

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -271,14 +271,20 @@ def calculate_pw_estimate(Difference,
 
             l_ind = l_ind + 1
 
-    if dir_save_all_planes is not None:
-        name_plane = 'PW_Estimate'
-        save_plane_in_fits(dir_save_all_planes, name_plane, Resultat / 4.)
-
     if pwp_or_btp in ['pw', "pwp", 'pairwise']:
+        if dir_save_all_planes is not None:
+            name_plane = 'PWP_Estimate'
+            save_plane_in_fits(dir_save_all_planes, name_plane, Resultat / 4.)
+
         return Resultat / 4.
+
     elif pwp_or_btp in ['btp']:
+        if dir_save_all_planes is not None:
+            name_plane = 'BTP_Estimate'
+            save_plane_in_fits(dir_save_all_planes, name_plane, Resultat / 2.)
+
         return Resultat / 2.
+
     else:
         raise ValueError("pwp_or_btp parameter can only take 2 values 'pwp' for Pair Wise Probing "
                          "or 'btp' for Borde Traub Probing")

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -389,7 +389,6 @@ def simulate_pw_difference(input_wavefront,
             raise ValueError("pwp_or_btp parameter can only take 2 values 'pwp', 'pairwise' for"
                              "Pair Wise Probing or 'btp+' for Borde Traub Probing")
 
-
         elif isinstance(wavelengths, (float, int)) and wavelengths in testbed.wav_vec:
             # hard case : we are monochromatic for the probes, but polychromatic for the rest of images
             # case polychromatic = 'singlewl' or polychromatic = 'multiwl'
@@ -412,7 +411,7 @@ def simulate_pw_difference(input_wavefront,
                 Int_fp_probe = testbed.todetector_intensity(
                     entrance_EF=1 + 1j * probephase, wavelengths=wavelengths, in_contrast=False, **
                     kwargs) / testbed.norm_monochrom[testbed.wav_vec.tolist().index(wavelengths)]
-            
+
             raise ValueError("pwp_or_btp parameter can only take 2 values 'pwp', 'pairwise' for"
                              "Pair Wise Probing or 'btp+' for Borde Traub Probing")
 

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -220,6 +220,7 @@ def create_singlewl_pw_matrix(testbed: Testbed,
 
 def calculate_pw_estimate(Difference,
                           Vectorprobes,
+                          dimimages,
                           dir_save_all_planes=None,
                           pwp_or_btp="pw",
                           dtype_complex='complex128'):
@@ -400,8 +401,8 @@ def simulate_pw_difference(input_wavefront,
                               "Code it yourself in simulate_pw_difference and be careful with the normalization"))
 
         if pwp_or_btp in ['pw', "pwp", 'pairwise']:
-            Difference[count] = resizing(Ikprobevalue1 - Ikprobevalue2, dimimages)
+            Difference[count] = Ikprobevalue1 - Ikprobevalue2
         elif pwp_or_btp in ['btp+']:
-            Difference[count] = resizing(Ikprobevalue1 - Ikprobevalue2 - Int_fp_probe, dimimages)
+            Difference[count] = Ikprobevalue1 - Ikprobevalue2 - Int_fp_probe
 
     return Difference

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -370,7 +370,6 @@ def simulate_pw_difference(input_wavefront,
             # easy case: we are monochromatic or polychromatic both for images and probes
             # It's either a monochromatic correction, or a polychromatic correction with
             # case polychromatic = 'broadband_pwprobes'
-
             Ikplus = testbed.todetector_intensity(entrance_EF=input_wavefront,
                                                   voltage_vector=voltage_vector + Voltage_probe,
                                                   wavelengths=wavelengths,

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -363,16 +363,6 @@ def simulate_pw_difference(input_wavefront,
 
             indice_acum_number_act += DM.number_act
 
-        if pwp_or_btp in ['pw', "pwp", 'pairwise']:
-            Voltage_probe_value1 = +Voltage_probe
-            Voltage_probe_value2 = -Voltage_probe
-        elif pwp_or_btp == 'btp+':
-            Voltage_probe_value1 = +Voltage_probe
-            Voltage_probe_value2 = 0
-        else:
-            raise ValueError("pwp_or_btp parameter can only take 2 values 'pwp' for Pair Wise Probing "
-                             "or 'btp+' for Borde Traub Probing")
-
         # If we are in a polychromatic mode but we need monochromatic instensity
         # we have to be careful with the normalization, because
         # todetector_intensity is normalizing to polychromatic PSF by default
@@ -392,10 +382,13 @@ def simulate_pw_difference(input_wavefront,
                                                        wavelengths=wavelengths,
                                                        **kwargs)
 
-            if pwp_or_btp in ['btp+']:
+            elif pwp_or_btp in ['btp+']:
                 Int_fp_probe = testbed.todetector_intensity(entrance_EF=1 + 1j * probephase,
                                                             wavelengths=wavelengths,
                                                             **kwargs)
+            raise ValueError("pwp_or_btp parameter can only take 2 values 'pwp', 'pairwise' for"
+                             "Pair Wise Probing or 'btp+' for Borde Traub Probing")
+
 
         elif isinstance(wavelengths, (float, int)) and wavelengths in testbed.wav_vec:
             # hard case : we are monochromatic for the probes, but polychromatic for the rest of images
@@ -415,10 +408,13 @@ def simulate_pw_difference(input_wavefront,
                     in_contrast=False,
                     **kwargs) / testbed.norm_monochrom[testbed.wav_vec.tolist().index(wavelengths)]
 
-            if pwp_or_btp in ['btp+']:
+            elif pwp_or_btp in ['btp+']:
                 Int_fp_probe = testbed.todetector_intensity(
                     entrance_EF=1 + 1j * probephase, wavelengths=wavelengths, in_contrast=False, **
                     kwargs) / testbed.norm_monochrom[testbed.wav_vec.tolist().index(wavelengths)]
+            
+            raise ValueError("pwp_or_btp parameter can only take 2 values 'pwp', 'pairwise' for"
+                             "Pair Wise Probing or 'btp+' for Borde Traub Probing")
 
         else:
             raise ValueError(("You are trying to do a pw_difference with wavelength parameters I don't understand. "

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -240,7 +240,7 @@ def calculate_pw_estimate(Difference,
         If not None, absolute directory to save all planes in fits for debugging purposes.
         This can generate a lot of fits especially if in a loop, use with caution.
     pwp_or_btp : string, default 'pwp'
-        type of algorithm used, can be 
+        type of algorithm used, can be
             'pw' Pair Wise Probing
             'btp+' Borde Traub Probing where the probe is pushed positevely
     dtype_complex : string, default 'complex128'
@@ -312,7 +312,7 @@ def simulate_pw_difference(input_wavefront,
     wavelengths : float, default None
         Wavelength of the estimation in m.
     pwp_or_btp : string, default 'pwp'
-        type of algorithm used, can be 
+        type of algorithm used, can be
             'pw' Pair Wise Probing
             'btp+' Borde Traub Probing where the probe is pushed positevely
 

--- a/docs/estimation.rst
+++ b/docs/estimation.rst
@@ -102,15 +102,23 @@ resized by the ``Estim_bin_factor``:
 All estimators are done this way (first obtains images in the focal plane at the ``Science_sampling`` and 
 then resizing) to ensure that the behavior is equivalent to what would be done on a real testbed
 
-Pair Wise Estimation
+Pair Wise Probing Estimation
 +++++++++++++++++++++++++
 
-The Pair wise estimation version we used is defined in 
+The Pair wise probing estimation version we used is defined in 
 `Potier et al. (2020) <http://adsabs.harvard.edu/abs/2020A%26A...635A.192P>`_ 
 The probe used are actuators, which can be chosen using ``posprobes`` parameter. If you choose 
 2 random actuators, it can be useful to check the .fits file starting in *EigenValPW* in 
 Interaction_Matrices directory. This is the map of the inverse singular values for each 
 pixels and it shows if all of the part of the DH are covered by the estimation (see Fig. 4 in Potier et al. 2020).
+
+Bordé & Traub Probing Estimation
++++++++++++++++++++++++++
+
+The Pair wise probing estimation version we used is defined in 
+`Bordé & Traub (2024) <http://iopscience.iop.org/0004-637X/638/1/488>`_ 
+The difference with Pair Wise Probing is that we do not do a difference between the positive and negative probes but only
+a difference between positive probe and the unprobed image. 
 
 ..  _polychromaticestim-label:
 Polychromatic Estimation

--- a/docs/estimation.rst
+++ b/docs/estimation.rst
@@ -8,7 +8,7 @@ are possible in Asterix. Additional details can be found directly in :ref:`the c
 
 It contains 2 functions at least:
 
-- an initialization ``Estimator.__init__()`` The initialization will require previous initialization of the testbed (see previous section) and the [Estimationconfig] part of the parameter file.  It set up everything you need for the estimation (e.g. the PW matrix). 
+- an initialization ``Estimator.__init__()`` The initialization will require previous initialization of the testbed (see previous section) and the [Estimationconfig] part of the parameter file.  It set up everything you need for the estimation (e.g. the PWP matrix). 
 
 - an probe function ``Estimator.probe()``, with parameters:
         - the entrance EF
@@ -102,7 +102,7 @@ resized by the ``Estim_bin_factor``:
 All estimators are done this way (first obtains images in the focal plane at the ``Science_sampling`` and 
 then resizing) to ensure that the behavior is equivalent to what would be done on a real testbed
 
-Pair Wise Probing Estimation
+Pair Wise Probing (PWP) Estimation
 +++++++++++++++++++++++++
 
 The Pair wise probing estimation version we used is defined in 
@@ -112,13 +112,13 @@ The probe used are actuators, which can be chosen using ``posprobes`` parameter.
 Interaction_Matrices directory. This is the map of the inverse singular values for each 
 pixels and it shows if all of the part of the DH are covered by the estimation (see Fig. 4 in Potier et al. 2020).
 
-Bordé & Traub Probing Estimation
+Bordé & Traub Probing (BTP) Estimation
 +++++++++++++++++++++++++
 
-The Pair wise probing estimation version we used is defined in 
-`Bordé & Traub (2024) <http://iopscience.iop.org/0004-637X/638/1/488>`_ 
+The Pair wise probing estimation version we used is defined in
+`Bordé & Traub (2024) <http://iopscience.iop.org/0004-637X/638/1/488>`_
 The difference with Pair Wise Probing is that we do not do a difference between the positive and negative probes but only
-a difference between positive probe and the unprobed image. 
+a difference between positive probe (BTP+) and the unprobed image.
 
 ..  _polychromaticestim-label:
 Polychromatic Estimation
@@ -129,8 +129,8 @@ If ``mandatory_wls`` is an empty list (``mandatory_wls = ,``), these simulation 
 Polychromatic estimation and correction are linked so they are 
 both driven by the parameter  the ``[Estimationconfig]`` section, ``polychromatic``:
 
-- ``'singlewl'``: only one wavelength is used for estimation / correction. Probes and PW / EFC matrices are measured at this wavelength. This parameter allows you to test the results of a monochromatic correction, applied to polychromatic light. 
-- ``'broadband_pwprobes'``: This is mostly like the previous case, but probes images used for PW are broadband (of bandwidth ``Delta_wav``). Matrices are at central wavelength. This is what is currently done in `Potier et al. (2022) <https://ui.adsabs.harvard.edu/abs/2022A%26A...665A.136P/abstract>`_ on SPHERE on sky for example. This mode is only relevant for PW estimation and will raise an error if use with perfect estimation.
+- ``'singlewl'``: only one wavelength is used for estimation / correction. Probes and PWP / EFC matrices are measured at this wavelength. This parameter allows you to test the results of a monochromatic correction, applied to polychromatic light. 
+- ``'broadband_pwprobes'``: This is mostly like the previous case, but probes images used for PWP are broadband (of bandwidth ``Delta_wav``). Matrices are at central wavelength. This is what is currently done in `Potier et al. (2022) <https://ui.adsabs.harvard.edu/abs/2022A%26A...665A.136P/abstract>`_ on SPHERE on sky for example. This mode is only relevant for PWP/BTP estimation and will raise an error if use with perfect estimation.
 - ``'multiwl'``: several images at different wls are used for estimation and there are several matrices of estimation. This parameter is only for the estimation / correction. The bandwidth of the images are still parametrized in [modelconfig](nb_wav, Delta_wav)
 
 We have 2 ways of defining the estimation / correction wavelengths. If ``polychromatic = 'broadband_pwprobes'``, the central wavelength and bandwidth are always used. For other case, you can use 2 different methods :

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -8,7 +8,7 @@ If you know all about conda virtual environments and you only want to install as
 
 .. code-block:: bash
 
-    $pip install git+https://github.com/johanmazoyer/Asterix.git
+    $ pip install git+https://github.com/johanmazoyer/Asterix.git
 
 
 Conda envs

--- a/docs/run_asterix.rst
+++ b/docs/run_asterix.rst
@@ -213,7 +213,7 @@ The [Estimationconfig] section contains the estimator parameters. An estimator i
     - ``estimation`` : string, FP WF sensing : 'perfect' or 'pwp'.
     - ``Estim_bin_factor`` : int, We bin the estimation images used for PWP / perfect estim by this factor. this way dimEstim = dimScience / Estim_bin_factor and  Estim_sampling = Science_sampling / Estim_bin_factor. Be careful, this raise an error if Estim_sampling < 3.
 
-If ``estimation`` = 'pwp' or 'btp+':
+If ``estimation`` = 'pwp' or 'btp':
 
     - ``amplitudePW`` : float, Amplitude of PWP probes or BTP (in nm).
     - ``posprobes`` : list of int, Actuators used for PWP or BTP (DM in pupil plane).

--- a/docs/run_asterix.rst
+++ b/docs/run_asterix.rst
@@ -71,14 +71,14 @@ Use with caution, as this can generate a lot of fits especially if in a loop. To
 What is saved if you activate this option in runthd2() was carefully thougth about, to avoid sending thousands of .fits files:
 
 * Dark Hole Mask
-* PW Estimate at each iteration.
+* PWP Estimate at each iteration.
 * 1 full run through testbed (~17 fits file for 1 DM testbed -one before and after each planes more or less-) at each iteration.
 
 What is not saved by default, but can be easily done by setting up the keyword ``dir_save_all_planes`` to an existing path directory, individually for these functions:
 
-* PW Matrix (nb_probes*17 fits for 1 DM testbed)
+* PWP Matrix (nb_probes*17 fits for 1 DM testbed)
 * EFC Matrix (nb_actuator*17 fits for 1 DM testbed)
-* PW difference (nb_probes x17 fits for 1 DM testbed), at each iteration
+* PWP difference (nb_probes x17 fits for 1 DM testbed), at each iteration
 
 
 Description of the parameter file
@@ -210,13 +210,13 @@ If phase coronagraph:
 ~~~~~~~~~~~~~~~~~~~~~~
 The [Estimationconfig] section contains the estimator parameters. An estimator is the thing that measure something you want to correct. 
 
-    - ``estimation`` : string, FP WF sensing : 'perfect' or 'pw'.
-    - ``Estim_bin_factor`` : int, We bin the estimation images used for PW / perfect estim by this factor. this way dimEstim = dimScience / Estim_bin_factor and  Estim_sampling = Science_sampling / Estim_bin_factor. Be careful, this raise an error if Estim_sampling < 3.
+    - ``estimation`` : string, FP WF sensing : 'perfect' or 'pwp'.
+    - ``Estim_bin_factor`` : int, We bin the estimation images used for PWP / perfect estim by this factor. this way dimEstim = dimScience / Estim_bin_factor and  Estim_sampling = Science_sampling / Estim_bin_factor. Be careful, this raise an error if Estim_sampling < 3.
 
-If ``estimation`` = 'PW':
+If ``estimation`` = 'pwp' or 'btp+':
 
-    - ``amplitudePW`` : float, Amplitude of PW probes (in nm).
-    - ``posprobes`` : list of int, Actuators used for PW (DM in pupil plane).
+    - ``amplitudePW`` : float, Amplitude of PWP probes or BTP (in nm).
+    - ``posprobes`` : list of int, Actuators used for PWP or BTP (DM in pupil plane).
     - ``cut`` : float, Threshold to remove pixels with bad estimation of the electric field.
 
 


### PR DESCRIPTION
Added a mode to do Bordé and Traub Probing (see Potier et al 2024 paper for details). Update also the docs

Used this opportunity to rename pw by pwp while keeping the backward compatibility with former parameter file 

Quick comparison with 2 corrections (1 and 2 DM) show it seems to work 
﻿
![Screenshot 2024-07-12 at 15 27 12](https://github.com/user-attachments/assets/22053e1c-b353-4b9f-8558-8bda87050afe)

![Screenshot 2024-07-12 at 15 27 17](https://github.com/user-attachments/assets/069b5670-6005-4f0a-9bed-c3e4df9a45ec)
