### PR TITLE
Separate probing and estimation for better integration on testbed

### DIFF
--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -311,11 +311,16 @@ def correction_loop_1matrix(testbed: Testbed,
             else:
                 print("Iteration number " + corrector.correction_algorithm + ": ", iteration + 1)
 
-        resultatestimation = estimator.estimate(testbed,
-                                                voltage_vector=thisloop_voltages_DMs[-1],
-                                                entrance_EF=input_wavefront,
+        probed_images = estimator.probe(testbed,
+                                        voltage_vector=thisloop_voltages_DMs[-1],
+                                        entrance_EF=input_wavefront,
+                                        perfect_estimation=Search_best_Mode,
+                                        nb_photons=nb_photons,
+                                        **kwargs)
+
+        resultatestimation = estimator.estimate(probed_images,
                                                 perfect_estimation=Search_best_Mode,
-                                                nb_photons=nb_photons,
+                                                dtype_complex=testbed.dtype_complex,
                                                 **kwargs)
 
         solution = corrector.toDM_voltage(testbed,

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -21,7 +21,7 @@ class Estimator:
             - an probe function Estimator.probe(), with parameters:
                     - the entrance EF
                     - DM voltages
-                    - the wavelength
+                    - the estimation wavelengths
                 It returns the probed images as a list (of length nb_wav_estim) of
                 3d arrays (nprobes,dimEstim,dimEstim).
 

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -335,7 +335,6 @@ class Estimator:
                     Difference = wfs.simulate_pw_difference(entrance_EF[testbed.wav_vec.tolist().index(wavei)],
                                                             testbed,
                                                             self.posprobes,
-                                                            self.dimEstim,
                                                             self.amplitudePW,
                                                             voltage_vector=voltage_vector,
                                                             wavelengths=wavei,
@@ -347,7 +346,6 @@ class Estimator:
                     self.wav_vec_estim[0])],
                                                         testbed,
                                                         self.posprobes,
-                                                        self.dimEstim,
                                                         self.amplitudePW,
                                                         voltage_vector=voltage_vector,
                                                         wavelengths=self.wav_vec_estim[0],
@@ -358,7 +356,6 @@ class Estimator:
                 Difference = wfs.simulate_pw_difference(entrance_EF,
                                                         testbed,
                                                         self.posprobes,
-                                                        self.dimEstim,
                                                         self.amplitudePW,
                                                         voltage_vector=voltage_vector,
                                                         wavelengths=testbed.wav_vec,
@@ -407,7 +404,10 @@ class Estimator:
 
                 for i, wavei in enumerate(self.wav_vec_estim):
                     result_estim.append(
-                        wfs.calculate_pw_estimate(probed_images[i], self.PWMatrix[i], dtype_complex=dtype_complex))
+                        wfs.calculate_pw_estimate(probed_images[i],
+                                                  self.PWMatrix[i],
+                                                  self.dimEstim,
+                                                  dtype_complex=dtype_complex))
 
                     if 'dir_save_all_planes' in kwargs.keys():
                         if kwargs['dir_save_all_planes'] is not None:
@@ -417,7 +417,10 @@ class Estimator:
             elif self.polychrom in ['singlewl', 'broadband_pwprobes']:
 
                 result_estim.append(
-                    wfs.calculate_pw_estimate(probed_images[0], self.PWMatrix[0], dtype_complex=dtype_complex))
+                    wfs.calculate_pw_estimate(probed_images[0],
+                                              self.PWMatrix[0],
+                                              self.dimEstim,
+                                              dtype_complex=dtype_complex))
 
                 if 'dir_save_all_planes' in kwargs.keys():
                     if kwargs['dir_save_all_planes'] is not None:

--- a/docs/estimation.rst
+++ b/docs/estimation.rst
@@ -10,13 +10,17 @@ It contains 2 functions at least:
 
 - an initialization ``Estimator.__init__()`` The initialization will require previous initialization of the testbed (see previous section) and the [Estimationconfig] part of the parameter file.  It set up everything you need for the estimation (e.g. the PW matrix). 
 
-- an estimation function itself with parameters:
-
+- an probe function ``Estimator.probe()``, with parameters:
         - the entrance EF
         - DM voltages
+        - the estimation wavelengths
+    It returns the probed images as a list (of length ``nb_wav_estim``) of 3d arrays (nprobes,dimEstim,dimEstim).
 
-It returns the estimation as a 2D complex array. The size in pixel of the output is 
-set by the ``Estim_bin_factor`` parameter and is ``dimScience`` / ``Estim_bin_factor``.
+- an estimation function ``Estimator.estimate()``, with parameters:
+    - the probed images
+    It returns the estimation as a list (of length ``nb_wav_estim``) of 2D arrays. The size
+    in pixel of the output is set by the ``Estim_bin_factor`` parameter and is 
+    ``dimScience`` / ``Estim_bin_factor``.
 
 .. code-block:: python
 
@@ -26,10 +30,12 @@ set by the ``Estim_bin_factor`` parameter and is ``dimScience`` / ``Estim_bin_fa
     Estimationconfig = config["Estimationconfig"]
 
     myestim = Estimator(Estimationconfig, testbed)
-    resultatestimation = myestim.estimate(testbed,
-                                          voltage_vector=init_voltage,
-                                          entrance_EF=input_wavefront)
 
+    probed_images = myestim.probe(testbed,
+                                    voltage_vector=init_voltage,
+                                    entrance_EF=input_wavefront,)
+
+    resultatestimation = myestim.estimate(probed_images)
 
 ``estimate`` function has been set up with a mode where each optical plane is saved to .fits file for debugging purposes.
 To use this option, set up the keyword ``dir_save_all_planes`` to an existing path directory.
@@ -37,8 +43,9 @@ To use this option, set up the keyword ``dir_save_all_planes`` to an existing pa
 Perfect Estimation
 +++++++++++++++++++++++
 
-This is a perfect estimation in focal plane of the electrical field in focal plane. You can use 
-this estimation by setting the parameter ``estimation='Perfect'`` before initialization. However, 
+This is a perfect estimation in focal plane of the electrical field in focal plane. In the case of
+a perfect estimation, both the probe and estimate function returns the electrical field in focal plane.
+You can use this estimation by setting the parameter ``estimation='Perfect'`` before initialization. However, 
 this estimation can be also done wihtout initialization or if another estimation have been initialized: 
 
 .. code-block:: python
@@ -51,20 +58,28 @@ this estimation can be also done wihtout initialization or if another estimation
     # we initialize in perfect mode
     Estimationconfig.update({'estimation': "Perfect"})
     myestim = Estimator(Estimationconfig, testbed)
-    resultatestimation = myestim.estimate(testbed,
-                                          voltage_vector=init_voltage,
-                                          entrance_EF=input_wavefront)
+    probed_images = myestim.probe(testbed,
+                                    voltage_vector=init_voltage,
+                                    entrance_EF=input_wavefront,)
+
+    resultatestimation = myestim.estimate(probed_images)
     # this is a perfect FP estimation
 
     # we re- initialize in pair-wise mode
     Estimationconfig.update({'estimation': "pw"})
     myestim = Estimator(Estimationconfig, testbed)
 
-    resultatestimation = myestim.estimate(testbed,
-                                          voltage_vector=init_voltage,
-                                          entrance_EF=input_wavefront)
+    probed_images = myestim.probe(testbed,
+                                    voltage_vector=init_voltage,
+                                    entrance_EF=input_wavefront)
+
+    resultatestimation = myestim.estimate(probed_images)
     # this is a pair-wise FP estimation
 
+    probed_images = myestim.probe(testbed,
+                                    voltage_vector=init_voltage,
+                                    entrance_EF=input_wavefront,
+                                    perfect_estimation=True)
     resultatestimation = myestim.estimate(testbed,
                                           voltage_vector=init_voltage,
                                           entrance_EF=input_wavefront,
@@ -85,7 +100,7 @@ resized by the ``Estim_bin_factor``:
 
 
 All estimators are done this way (first obtains images in the focal plane at the ``Science_sampling`` and 
-then resizing) to ensure that the behavior is equivalent to waht would be done on a real testbed
+then resizing) to ensure that the behavior is equivalent to what would be done on a real testbed
 
 Pair Wise Estimation
 +++++++++++++++++++++++++

--- a/docs/estimation.rst
+++ b/docs/estimation.rst
@@ -14,7 +14,7 @@ It contains 2 functions at least:
         - the entrance EF
         - DM voltages
         - the estimation wavelengths
-    It returns the probed images as a list (of length ``nb_wav_estim``) of 3d arrays (nprobes,dimEstim,dimEstim).
+    It returns the probed images as a list (of length ``nb_wav_estim``) of 3d arrays (nprobes,dimScience,dimScience).
 
 - an estimation function ``Estimator.estimate()``, with parameters:
     - the probed images


### PR DESCRIPTION
Separated estimates fonction in 2 parts :
- estimation.probes() which handle the probing part itself
- estimation.estimate() which does the PW matrix multiplication 
the goal is to make it easier to run on the testbed as only the probing function can be replaced. 

Checked that results were exactly identical to the current master branch. 