### PR TITLE
Votge vectors now inlcude the inactive DMs actuators

### DIFF
--- a/Asterix/optics/deformable_mirror.py
+++ b/Asterix/optics/deformable_mirror.py
@@ -482,6 +482,8 @@ class DeformableMirror(optsy.OpticalSystem):
         """
 
         where_non_zero_voltage = np.where(actu_vect != 0)
+        if len(where_non_zero_voltage[0]) == 0:
+            return np.zeros((self.dim_overpad_pupil, self.dim_overpad_pupil))
 
         # opd is in nanometer
         # DM_pushact is in opd nanometer

--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -453,6 +453,8 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
                      header,
                      overwrite=True)
 
+    print("Final contrast in DH: ", meancontrast[-1])
+
     fits.writeto(os.path.join(result_dir, "Mean_Contrast_DH.fits"), np.array(meancontrast), header, overwrite=True)
 
     fits.writeto(os.path.join(result_dir, "estimationFP_RE.fits"), np.real(np.array(EF_estim)), header, overwrite=True)

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -81,10 +81,11 @@ class Corrector:
 
         for DM_name in testbed.name_of_DMs:
             DM: DeformableMirror = vars(testbed)[DM_name]
-            DM.basis = DM.create_DM_basis(basis_type=basis_type, silence=silence)
-            DM.basis_size = DM.basis.shape[0]
-            self.total_number_modes += DM.basis_size
-            DM.basis_type = basis_type
+            if DM.active:
+                DM.basis = DM.create_DM_basis(basis_type=basis_type, silence=silence)
+                DM.basis_size = DM.basis.shape[0]
+                self.total_number_modes += DM.basis_size
+                DM.basis_type = basis_type
 
         self.correction_algorithm = Correctionconfig["correction_algorithm"].lower()
         self.MatrixType = Correctionconfig["MatrixType"].lower()

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -466,26 +466,38 @@ def find_DM_to_probe(testbed: Testbed):
     # If name_DM_to_probe_in_PW is not already set,
     # automatically check which DM to use to probe in this case
     # this is only done once.
-    if len(testbed.name_of_DMs) == 0:
+
+    # If several DMs we check if there is at least one active
+    number_DMs_activated = 0
+    for DM_name in testbed.name_of_DMs:
+        DM: DeformableMirror = vars(testbed)[DM_name]
+        if DM.active:
+            number_DMs_activated += 1
+
+    if number_DMs_activated == 0:
         raise ValueError("You need at least one activated DM to do PW.")
+
     # If only one DM, we use this one, independenlty of its position
-    elif len(testbed.name_of_DMs) == 1:
-        name_DM_to_probe_in_PW = testbed.name_of_DMs[0]
-    else:
-        # If several DMs we check if there is at least one in PP
-        number_DMs_in_PP = 0
+    elif number_DMs_activated == 1:
         for DM_name in testbed.name_of_DMs:
             DM: DeformableMirror = vars(testbed)[DM_name]
-            if DM.z_position == 0.:
-                number_DMs_in_PP += 1
+            if DM.active:
+                name_DM_to_probe_in_PW = DM_name
+    else:
+        # If several active DMs, we check if there is at least one in PP
+        number_active_DMs_in_PP = 0
+        for DM_name in testbed.name_of_DMs:
+            DM: DeformableMirror = vars(testbed)[DM_name]
+            if DM.z_position == 0. and DM.active:
+                number_active_DMs_in_PP += 1
                 name_DM_to_probe_in_PW = DM_name
 
         # If there are several DMs in PP, error, you need to set name_DM_to_probe_in_PW
-        if number_DMs_in_PP > 1:
-            raise ValueError("You have several DM in PP, choose manually one for "
+        if number_active_DMs_in_PP > 1:
+            raise ValueError("You have several active DMs in PP, choose manually one for "
                              "the PWP probes using 'testbed.name_DM_to_probe_in_PW'.")
         # Several DMS, none in PP, error, you need to set name_DM_to_probe_in_PW
-        if number_DMs_in_PP == 0:
-            raise ValueError("You have several DMs, none in PP, choose manually one for "
+        if number_active_DMs_in_PP == 0:
+            raise ValueError("You have several active DMs, none in PP, choose manually one for "
                              "the PWP probes using 'testbed.name_DM_to_probe_in_PW'.")
     return name_DM_to_probe_in_PW

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -268,8 +268,6 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
         fileDirectMatrix = headfile + basis_str + '_binEstim' + str(int(np.round(
             testbed.dimScience / dimEstim))) + string_testbed_without_DMS + "_resFP" + str(
                 round(DM.Science_sampling / DM.wavelength_0 * wavelength, 2)) + '_wl' + str(int(wavelength * 1e9))
-        print(fileDirectMatrix)
-        asd
 
         # We only save the 'first' matrix meaning the one with no initial DM voltages
         # Matrix is saved/loaded for each DM independetly which allow quick switch

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -231,26 +231,10 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
     for i, DM_name in enumerate(testbed.name_of_DMs):
 
         DM: DeformableMirror = vars(testbed)[DM_name]
-        total_number_basis_modes += DM.basis_size
-        DM_small_str = "_" + "_".join(DM.string_os.split("_")[3:])
-        string_testbed_without_DMS = string_testbed_without_DMS.replace(DM_small_str, '')
-
-    # Some string manips to name the matrix if we save it
-    if MatrixType == 'perfect':
-        headfile = "DirectMatPerf"
-    elif MatrixType == 'smallphase':
-        headfile = "DirectMatSP"
-    else:
-        raise ValueError("This Matrix type does not exist ([Correctionconfig]['MatrixType'] parameter).")
-
-    if DM.basis_type == 'fourier':
-        basis_type_str = 'Four'
-        pass
-    elif DM.basis_type == 'actuator':
-        basis_type_str = 'Actu'
-        headfile += "_EFCampl" + str(amplitudeEFC)
-    else:
-        raise ValueError("This basis type does not exist ([Correctionconfig]['DM_basis'] parameter).")
+        if DM.active:
+            total_number_basis_modes += DM.basis_size
+            DM_small_str = "_" + "_".join(DM.string_os.split("_")[3:])
+            string_testbed_without_DMS = string_testbed_without_DMS.replace(DM_small_str, '')
 
     InterMat = np.zeros((2 * int(dimEstim**2), total_number_basis_modes))
     pos_in_matrix = 0
@@ -258,6 +242,26 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
     for DM_name in testbed.name_of_DMs:
 
         DM: DeformableMirror = vars(testbed)[DM_name]
+        if not DM.active:
+            continue
+
+        # Some string manips to name the matrix if we save it
+        if MatrixType == 'perfect':
+            headfile = "DirectMatPerf"
+        elif MatrixType == 'smallphase':
+            headfile = "DirectMatSP"
+        else:
+            raise ValueError("This Matrix type does not exist ([Correctionconfig]['MatrixType'] parameter).")
+
+        if DM.basis_type == 'fourier':
+            basis_type_str = 'Four'
+            pass
+        elif DM.basis_type == 'actuator':
+            basis_type_str = 'Actu'
+            headfile += "_EFCampl" + str(amplitudeEFC)
+        else:
+            raise ValueError("This basis type does not exist ([Correctionconfig]['DM_basis'] parameter).")
+
         DM_small_str = "_" + "_".join(DM.string_os.split("_")[3:])
 
         basis_str = DM_small_str + "_" + basis_type_str + "Basis" + str(DM.basis_size)
@@ -275,7 +279,6 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
         list_str.pop(2)
         name_basis_fits = "Basis" + '_'.join(list_str) + ".fits"
         fits.writeto(os.path.join(matrix_dir, name_basis_fits), DM.basis, overwrite=True)
-
 
         if os.path.exists(os.path.join(matrix_dir, fileDirectMatrix + ".fits")) and (initial_DM_voltage == 0.).all():
             if not silence:

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -233,8 +233,8 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
         DM: DeformableMirror = vars(testbed)[DM_name]
         if DM.active:
             total_number_basis_modes += DM.basis_size
-            DM_small_str = "_" + "_".join(DM.string_os.split("_")[3:])
-            string_testbed_without_DMS = string_testbed_without_DMS.replace(DM_small_str, '')
+        DM_small_str = "_" + "_".join(DM.string_os.split("_")[3:])
+        string_testbed_without_DMS = string_testbed_without_DMS.replace(DM_small_str, '')
 
     InterMat = np.zeros((2 * int(dimEstim**2), total_number_basis_modes))
     pos_in_matrix = 0
@@ -268,6 +268,8 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
         fileDirectMatrix = headfile + basis_str + '_binEstim' + str(int(np.round(
             testbed.dimScience / dimEstim))) + string_testbed_without_DMS + "_resFP" + str(
                 round(DM.Science_sampling / DM.wavelength_0 * wavelength, 2)) + '_wl' + str(int(wavelength * 1e9))
+        print(fileDirectMatrix)
+        asd
 
         # We only save the 'first' matrix meaning the one with no initial DM voltages
         # Matrix is saved/loaded for each DM independetly which allow quick switch


### PR DESCRIPTION
DMs that are declared on the Testbed during initialization but marked as inactive (``DMXX_active = False`` in parameter file) are still accounted in the vector of voltages sent to the DMs. (DMvotage = [DM1 voltage, DM3 Voltage])

Before this PR, inactive DM names were declared (DM objects were created) to the DMs but could not be talked to as the vector of voltages sent to the DMs was only using the other DM voltages

With this PR, the inactive DM names are still declared but during EFC / PW they are not sent command (command always zero). This is a more consistent testbed model in both cases (with 1 or 2 DMs).

If you really want a one DM testbed, you can still remove the other one from initialization 

