### PR TITLE
Remove estimator from corrector

### DIFF
--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -150,17 +150,23 @@ def runthd2(parameter_file_path,
 
     # Initialize the DH masks
     mask_dh = MaskDH(Correctionconfig)
+
+    # mask for the estimation used in correction loop
+    estim_mask_dh = mask_dh.creatingMaskDH(estimator.dimEstim, estimator.Estim_sampling)
+
+    # Mask in science detector size for contrast estimation at each iteration.
+    # if we used a fits file to do the dh mask, the fits must be of dimEstim size and
+    # we do not use a science dark-hole mask.
     if mask_dh.DH_shape.lower().endswith('.fits'):
         science_mask_dh = np.ones((thd2.dimScience, thd2.dimScience))
     else:
         science_mask_dh = mask_dh.creatingMaskDH(thd2.dimScience, thd2.Science_sampling, **kwargs)
 
-    maskEstim = mask_dh.creatingMaskDH(estimator.dimEstim, estimator.Estim_sampling)
     # Initialize the corrector
     corrector = Corrector(Correctionconfig,
                           thd2,
                           estimator.dimEstim,
-                          maskEstim=maskEstim,
+                          maskEstim=estim_mask_dh,
                           wav_vec_estim=estimator.wav_vec_estim,
                           matrix_dir=matrix_dir,
                           save_for_bench=onbench,

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -155,11 +155,13 @@ def runthd2(parameter_file_path,
     else:
         science_mask_dh = mask_dh.creatingMaskDH(thd2.dimScience, thd2.Science_sampling, **kwargs)
 
+    maskEstim = mask_dh.creatingMaskDH(estimator.dimEstim, estimator.Estim_sampling)
     # Initialize the corrector
     corrector = Corrector(Correctionconfig,
                           thd2,
-                          mask_dh,
-                          estimator,
+                          estimator.dimEstim,
+                          maskEstim=maskEstim,
+                          wav_vec_estim=estimator.wav_vec_estim,
                           matrix_dir=matrix_dir,
                           save_for_bench=onbench,
                           realtestbed_dir=labview_dir,

--- a/Asterix/tests/test_wfsc.py
+++ b/Asterix/tests/test_wfsc.py
@@ -30,10 +30,17 @@ def quick_run_no_save(config, data_dir):
 
     # Initialize the DH masks
     mask_dh = MaskDH(Correctionconfig)
+    maskEstim = mask_dh.creatingMaskDH(estimator.dimEstim, estimator.Estim_sampling)
     science_mask_dh = mask_dh.creatingMaskDH(thd2.dimScience, thd2.Science_sampling)
 
     # Initialize the corrector
-    corrector = Corrector(Correctionconfig, thd2, mask_dh, estimator, matrix_dir=matrix_dir, silence=silence)
+    corrector = Corrector(Correctionconfig,
+                          thd2,
+                          estimator.dimEstim,
+                          maskEstim=maskEstim,
+                          wav_vec_estim=estimator.wav_vec_estim,
+                          matrix_dir=matrix_dir,
+                          silence=silence)
 
     ### Set initial phase and amplitude
     # Phase upstream of the coronagraph (entrance pup)

--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -12,13 +12,12 @@ from Asterix.optics import DeformableMirror, Testbed
 
 import Asterix.wfsc.corrector as corrector_mod
 import Asterix.wfsc.estimator as estimator_mod
-import Asterix.wfsc.maskDH as maskDH
 
 
 def correction_loop(testbed: Testbed,
                     estimator: estimator_mod.Estimator,
                     corrector: corrector_mod.Corrector,
-                    mask_dh: maskDH.MaskDH,
+                    mask_dh,
                     Loopconfig,
                     SIMUconfig,
                     input_wavefront=1.,
@@ -113,8 +112,7 @@ def correction_loop(testbed: Testbed,
     for i in range(Number_matrix):
 
         if i > 0:
-            # the first matrix is done during initialization
-            corrector.update_matrices(testbed, estimator, initial_DM_voltage=initial_DM_voltage, silence=silence)
+            corrector.update_matrices(testbed, initial_DM_voltage=initial_DM_voltage, silence=silence)
 
         Resultats_correction_loop = correction_loop_1matrix(testbed,
                                                             estimator,
@@ -147,7 +145,7 @@ def correction_loop(testbed: Testbed,
 def correction_loop_1matrix(testbed: Testbed,
                             estimator: estimator_mod.Estimator,
                             corrector: corrector_mod.Corrector,
-                            mask_dh: maskDH.MaskDH,
+                            mask_dh,
                             Nbiter_corr,
                             CorrectionLoopResult,
                             gain=0.1,

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -5,7 +5,6 @@ from astropy.io import fits
 from Asterix.utils import invert_svd
 from Asterix.optics import OpticalSystem, DeformableMirror, Testbed
 
-import Asterix.wfsc.estimator as estimator_mod
 import Asterix.wfsc.thd_quick_invert as thd_quick_invert
 import Asterix.wfsc.wf_control_functions as wfc
 

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -80,17 +80,6 @@ class Estimator:
         self.technique = Estimationconfig["estimation"].lower()
         self.polychrom = Estimationconfig["polychromatic"].lower()
 
-        # For now estimation central wl and simu central wl are the same
-        # wavelength_0_estim = testbed.wavelength_0
-
-        if self.polychrom == "centralwl":
-            print("")
-            print(("DEPRECATED PARAMETER VALUE: use 'singlelw' instead of 'centralwl' "
-                   "in [Estimationconfig]['polychromatic'] parameter."
-                   "'centralwl' value for this parameter will not ne supported in the near future"))
-            print("")
-            self.polychrom = "singlewl"
-
         if len(testbed.wav_vec) == 1:
             # monochromatic simulation, polychromatic correction keywords are ignored
             self.polychrom = "singlewl"

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -21,7 +21,6 @@ def create_interaction_matrix(testbed: Testbed,
                               initial_DM_voltage=0.,
                               input_wavefront=1.,
                               MatrixType='',
-                              polychrom='singlewl',
                               wav_vec_estim=None,
                               dir_save_all_planes=None,
                               silence=False,
@@ -58,11 +57,8 @@ def create_interaction_matrix(testbed: Testbed,
         or 'perfect' (we keep exp(i phi)).
         in both case, if the DMs are not initially flat (non zero initial_DM_voltage),
         we do not make the small phase assumption for initial DM phase
-    polychrom : string
-        For polychromatic estimation and correction:
-        - 'singlewl': only a single wavelength is used for estimation / correction. 1 Interation Matrix
-        - 'broadband_pwprobes': probes images PWP are broadband but Matrices are at central wavelength: 1 PWP Matrix and 1 Interation Matrix
-        - 'multiwl': nb_wav images are used for estimation and there are nb_wav matrices of estimation and nb_wav matrices for correction
+    wav_vec_estim : list of wavelengths, default: [testbed.wavelength_0]
+            vector of wavelengths for polychromatic correction
     initial_DM_voltage : 1D-array real
         initial DM voltage for all DMs
     input_wavefront : complex scalar or 2d complex array or 3d complex array. Default is 1 (flat WF)
@@ -96,44 +92,11 @@ def create_interaction_matrix(testbed: Testbed,
                          "(nb_wav, dim_overpad_pupil, dim_overpad_pupil)"))
 
     if wav_vec_estim is None:
-        wav_vec_estim = testbed.wav_vec
+        wav_vec_estim = np.array([testbed.wavelength_0])
 
     return_matrix = []
 
-    if polychrom == 'singlewl':
-
-        return_matrix.append(
-            create_singlewl_interaction_matrix(testbed,
-                                               dimEstim,
-                                               amplitudeEFC,
-                                               wav_vec_estim[0],
-                                               matrix_dir,
-                                               initial_DM_voltage=initial_DM_voltage,
-                                               input_wavefront=input_wavefront[testbed.wav_vec.tolist().index(
-                                                   wav_vec_estim[0])],
-                                               MatrixType=MatrixType,
-                                               dir_save_all_planes=dir_save_all_planes,
-                                               silence=silence,
-                                               visu=visu))
-    elif polychrom == 'broadband_pwprobes':
-
-        return_matrix.append(
-            create_singlewl_interaction_matrix(testbed,
-                                               dimEstim,
-                                               amplitudeEFC,
-                                               testbed.wavelength_0,
-                                               matrix_dir,
-                                               initial_DM_voltage=initial_DM_voltage,
-                                               input_wavefront=input_wavefront[testbed.wav_vec.tolist().index(
-                                                   testbed.wavelength_0)],
-                                               MatrixType=MatrixType,
-                                               dir_save_all_planes=dir_save_all_planes,
-                                               silence=silence,
-                                               visu=visu))
-
-    elif polychrom == 'multiwl':
-
-        for i, wave_i in enumerate(wav_vec_estim):
+    for wave_i in wav_vec_estim:
             return_matrix.append(
                 create_singlewl_interaction_matrix(testbed,
                                                    dimEstim,
@@ -141,14 +104,11 @@ def create_interaction_matrix(testbed: Testbed,
                                                    wave_i,
                                                    matrix_dir,
                                                    initial_DM_voltage=initial_DM_voltage,
-                                                   input_wavefront=input_wavefront[i],
+                                                   input_wavefront=input_wavefront[testbed.wav_vec.tolist().index(wave_i)],
                                                    MatrixType=MatrixType,
                                                    dir_save_all_planes=dir_save_all_planes,
                                                    silence=silence,
                                                    visu=visu))
-    else:
-        raise ValueError(polychrom + "is not a valid value for [Estimationconfig]['polychromatic'] parameter.")
-
     return return_matrix
 
 

--- a/docs/correction.rst
+++ b/docs/correction.rst
@@ -7,7 +7,7 @@ This section describes how to correct the electrical field in the focal plane in
 are possible in Asterix:
 
 - an initialization (e.g. Jacobian matrix) ``Corrector.__init__`` : The initialization requires previous initialization of the testbed and of the estimator.
-- a matrix update function ``Corrector.update_matrices`` This function is called once during initialization and then each time we need to recompute the Jacobian in the middle of the correction using different DM voltages as the starting point.
+- a matrix update function ``Corrector.update_matrices`` This function is called once during initialization and then each time we need to recompute the Jacobian in the middle of the correction using different DM voltages as the starting point. It can also be used to update the dark-hole mask.
 - a correction function ``Corrector.toDM_voltage`` which takes the results of an estimation and returns the DM voltages.
 
 Dark Hole Mask Definition
@@ -96,12 +96,10 @@ Once you have initialized, you can update the matrix during the correction wihto
 .. code-block:: python
     
     corrector.update_matrices(testbed,
-                              estimator.dimEstim,
-                              estimator.wav_vec_estim,
                               initial_DM_voltage=some_DM_voltage,
                               input_wavefront=some_input_wavefront)
 
-This can be useful to recalculate the jacobian around a non zero DM voltage or if you want to crop the matrix with another dark hole:
+This can be useful to recalculate the jacobian around a non zero DM voltage or if you want to crop the matrix with another dark-hole:
 
 .. code-block:: python
 
@@ -109,8 +107,7 @@ This can be useful to recalculate the jacobian around a non zero DM voltage or i
     maskEstim2 = mask_dh2.creatingMaskDH(estimator.dimEstim, estimator.Estim_sampling)
     
     corrector.update_matrices(testbed,
-                              estimator.dimEstim,
-                              estimator.wav_vec_estim)
+                              maskEstim=maskEstim2)
 
 
 Correction mode

--- a/docs/correction.rst
+++ b/docs/correction.rst
@@ -82,12 +82,13 @@ The Matrix calculation is done during initialization:
     Correctionconfig = config["Correctionconfig"]
 
     mask_dh = MaskDH(Correctionconfig)
-
-    #initalize the corrector
-    correc = Corrector(Correctionconfig,
-                       testbed,
-                       mask_dh,
-                       estimator)
+    maskEstim = mask_dh.creatingMaskDH(estimator.dimEstim, estimator.Estim_sampling)
+    
+    # Initialize the corrector
+    corrector = Corrector(Correctionconfig,
+                          thd2,
+                          estimator.dimEstim,
+                          maskEstim=maskEstim)
 
 
 Once you have initialized, you can update the matrix during the correction wihtout re-initializing using : 
@@ -95,12 +96,21 @@ Once you have initialized, you can update the matrix during the correction wihto
 .. code-block:: python
     
     corrector.update_matrices(testbed,
-                              estimator,
-                              initial_DM_voltage=initial_DM_voltage,
-                              input_wavefront=1.)
+                              estimator.dimEstim,
+                              estimator.wav_vec_estim,
+                              initial_DM_voltage=some_DM_voltage,
+                              input_wavefront=some_input_wavefront)
 
+This can be useful to recalculate the jacobian around a non zero DM voltage or if you want to crop the matrix with another dark hole:
 
-This can be useful if the strokes are too high and makes the algorithm not as efficient. 
+.. code-block:: python
+
+    mask_dh2 = MaskDH(Correctionconfig)
+    maskEstim2 = mask_dh2.creatingMaskDH(estimator.dimEstim, estimator.Estim_sampling)
+    
+    corrector.update_matrices(testbed,
+                              estimator.dimEstim,
+                              estimator.wav_vec_estim)
 
 
 Correction mode


### PR DESCRIPTION
The goal is to make Corrector estimation much more independent of the estimator. The full estimator class needed to be called when defining a corrector, but in practice we only used 2 values (the dimension of the estimation and the wavelengths of the estimation). I only pass those 2 parameters. 

I also make it easier to update the mask in update_matrices() function. 