### PR TITLE
Add THD2 optical elements as class attributes

### DIFF
--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -46,10 +46,10 @@ class THD2(Testbed):
 
         # Create all optical elements of the THD
         self.entrance_pupil = Pupil(model_config,
-                               PupType=model_config["filename_instr_pup"],
-                               angle_rotation=model_config["entrance_pup_rotation"],
-                               Model_local_dir=model_local_dir,
-                               silence=silence)
+                                    PupType=model_config["filename_instr_pup"],
+                                    angle_rotation=model_config["entrance_pup_rotation"],
+                                    Model_local_dir=model_local_dir,
+                                    silence=silence)
         self.dm1 = DeformableMirror(model_config, dm_config, Name_DM="DM1", Model_local_dir=model_local_dir, silence=silence)
         self.dm2 = DeformableMirror(model_config, dm_config, Name_DM="DM2", Model_local_dir=model_local_dir, silence=silence)
         self.corono = Coronagraph(model_config, corona_config, Model_local_dir=model_local_dir, silence=silence)

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -45,19 +45,19 @@ class THD2(Testbed):
         # model_config['complex_precision'] = 'complex64'
 
         # Create all optical elements of the THD
-        entrance_pupil = Pupil(model_config,
+        self.entrance_pupil = Pupil(model_config,
                                PupType=model_config["filename_instr_pup"],
                                angle_rotation=model_config["entrance_pup_rotation"],
                                Model_local_dir=model_local_dir,
                                silence=silence)
-        dm1 = DeformableMirror(model_config, dm_config, Name_DM="DM1", Model_local_dir=model_local_dir, silence=silence)
-        dm2 = DeformableMirror(model_config, dm_config, Name_DM="DM2", Model_local_dir=model_local_dir, silence=silence)
-        corono = Coronagraph(model_config, corona_config, Model_local_dir=model_local_dir, silence=silence)
+        self.dm1 = DeformableMirror(model_config, dm_config, Name_DM="DM1", Model_local_dir=model_local_dir, silence=silence)
+        self.dm2 = DeformableMirror(model_config, dm_config, Name_DM="DM2", Model_local_dir=model_local_dir, silence=silence)
+        self.corono = Coronagraph(model_config, corona_config, Model_local_dir=model_local_dir, silence=silence)
 
         self.config_file = config
 
         # Concatenate into the full testbed optical system
-        super().__init__([entrance_pupil, dm1, dm2, corono], ["entrancepupil", "DM1", "DM2", "corono"])
+        super().__init__([self.entrance_pupil, self.dm1, self.dm2, self.corono], ["entrancepupil", "DM1", "DM2", "corono"])
 
 
 def runthd2(parameter_file_path,

--- a/notebooks/pupils_THD2_HLC.ipynb
+++ b/notebooks/pupils_THD2_HLC.ipynb
@@ -46,7 +46,7 @@
     "\n",
     "# Concatenate into the full testbed optical system\n",
     "thd2 = main_THD.THD2(config, model_local_dir)\n",
-    "original_dm = thd2.dm3.DM_pushact"
+    "original_dm = thd2.dm2.DM_pushact"
    ]
   },
   {
@@ -57,8 +57,8 @@
    "outputs": [],
    "source": [
     "pupil = thd2.entrance_pupil.pup\n",
-    "dm3 = np.sum(thd2.dm3.DM_pushact, axis=0)\n",
-    "dm_ref = thd2.dm3.DM_pushact[518] + thd2.dm3.DM_pushact[519] + thd2.dm3.DM_pushact[780]\n",
+    "dm2 = np.sum(thd2.dm2.DM_pushact, axis=0)\n",
+    "dm_ref = thd2.dm2.DM_pushact[518] + thd2.dm2.DM_pushact[519] + thd2.dm2.DM_pushact[780]\n",
     "ls = thd2.corono.lyot_pup.pup"
    ]
   },
@@ -74,14 +74,14 @@
     "plt.imshow(pupil, origin='lower', cmap='Greys_r')\n",
     "plt.title('Entrance pupil')\n",
     "plt.subplot(2, 2, 2)\n",
-    "plt.imshow(dm3, origin='lower', cmap='Greys_r')\n",
-    "plt.title('DM3 (in pupil)')\n",
+    "plt.imshow(dm2, origin='lower', cmap='Greys_r')\n",
+    "plt.title('DM2 (in pupil)')\n",
     "plt.subplot(2, 2, 3)\n",
     "plt.imshow(ls, origin='lower', cmap='Greys_r')\n",
     "plt.title('Lyot stop')\n",
     "plt.subplot(2, 2, 4)\n",
     "plt.imshow(dm_ref, origin='lower', cmap='Greys_r')\n",
-    "plt.title('DM3 actuators 518, 519 and 780')\n",
+    "plt.title('DM2 actuators 518, 519 and 780')\n",
     "\n",
     "#plt.savefig('/Users/ilaginja/THD2_HLC_pupils.pdf')"
    ]
@@ -113,7 +113,7 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(10, 10))\n",
-    "plt.imshow(dm3, origin='lower', cmap='Greys_r')\n",
+    "plt.imshow(dm2, origin='lower', cmap='Greys_r')\n",
     "plt.imshow(ls, origin='lower', cmap='Greys_r')#, alpha=0.3)\n",
     "#plt.imshow(ls_mask, origin='lower', cmap='Greys_r')#, alpha=0.3)\n",
     "plt.imshow(dm_ref, origin='lower', cmap='Reds', alpha=0.5)\n",

--- a/notebooks/pupils_THD2_HLC.ipynb
+++ b/notebooks/pupils_THD2_HLC.ipynb
@@ -1,0 +1,156 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "769233ff",
+   "metadata": {},
+   "source": [
+    "# Testbed pupils in Asterix\n",
+    "\n",
+    "Time to detangle the pupil orientations inside of Asterix. They're all self-consistend, otherwise things wouldn't be working on hardware, but it's very murky how to tap into that from the outside."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a716029",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from astropy.io import fits\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from Asterix import main_THD, Asterix_root\n",
+    "from Asterix.utils import get_data_dir, read_parameter_file\n",
+    "from Asterix.optics import Pupil, Coronagraph, DeformableMirror, Testbed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "257bec7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Instantiate a THD2 object\n",
+    "your_directory = Asterix_root\n",
+    "your_parameter_file_name = 'thd2_setups/roman_637nm.ini'\n",
+    "parameter_file_path = os.path.join(your_directory, your_parameter_file_name)\n",
+    "\n",
+    "config = read_parameter_file(parameter_file_path)\n",
+    "\n",
+    "data_dir = get_data_dir(config_in=config[\"Data_dir\"])\n",
+    "model_local_dir = os.path.join(data_dir, \"Model_local\")\n",
+    "\n",
+    "# Concatenate into the full testbed optical system\n",
+    "thd2 = main_THD.THD2(config, model_local_dir)\n",
+    "original_dm = thd2.dm3.DM_pushact"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f85331d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pupil = thd2.entrance_pupil.pup\n",
+    "dm3 = np.sum(thd2.dm3.DM_pushact, axis=0)\n",
+    "dm_ref = thd2.dm3.DM_pushact[518] + thd2.dm3.DM_pushact[519] + thd2.dm3.DM_pushact[780]\n",
+    "ls = thd2.corono.lyot_pup.pup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "001ca0b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 10))\n",
+    "plt.subplot(2, 2, 1)\n",
+    "plt.imshow(pupil, origin='lower', cmap='Greys_r')\n",
+    "plt.title('Entrance pupil')\n",
+    "plt.subplot(2, 2, 2)\n",
+    "plt.imshow(dm3, origin='lower', cmap='Greys_r')\n",
+    "plt.title('DM3 (in pupil)')\n",
+    "plt.subplot(2, 2, 3)\n",
+    "plt.imshow(ls, origin='lower', cmap='Greys_r')\n",
+    "plt.title('Lyot stop')\n",
+    "plt.subplot(2, 2, 4)\n",
+    "plt.imshow(dm_ref, origin='lower', cmap='Greys_r')\n",
+    "plt.title('DM3 actuators 518, 519 and 780')\n",
+    "\n",
+    "#plt.savefig('/Users/ilaginja/THD2_HLC_pupils.pdf')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77af3b49",
+   "metadata": {},
+   "source": [
+    "I am mostly interested in the free space in the Lyot stop, so I will be ignoring the pupil."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3201fbed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create optional masked array for LS\n",
+    "ls_mask = np.ma.masked_where(ls != 0, ls)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66ccef21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 10))\n",
+    "plt.imshow(dm3, origin='lower', cmap='Greys_r')\n",
+    "plt.imshow(ls, origin='lower', cmap='Greys_r')#, alpha=0.3)\n",
+    "#plt.imshow(ls_mask, origin='lower', cmap='Greys_r')#, alpha=0.3)\n",
+    "plt.imshow(dm_ref, origin='lower', cmap='Reds', alpha=0.5)\n",
+    "plt.xlim(40, 160)\n",
+    "plt.ylim(40, 160)\n",
+    "\n",
+    "#plt.savefig('/Users/ilaginja/THD2_HLC_LS_and_pokes_518-519-780.pdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fff707cf",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This saves the already existing optical elements that build the THD2 optical system into actual class attributes so that they can be accessed from the outside.

Also adding a notebook that pulls the pupil array information out in a meaningful manner.