### PR TITLE
Fits comparison errors

### DIFF
--- a/Asterix/optics/deformable_mirror.py
+++ b/Asterix/optics/deformable_mirror.py
@@ -225,6 +225,7 @@ class DeformableMirror(optsy.OpticalSystem):
                 necessary_dm_param[key] = self.DMconfig[key]
         necessary_dm_param["prad"] = self.prad
         necessary_dm_param["dim_overpad_pupil"] = self.dim_overpad_pupil
+        necessary_dm_param["diam_pup_in_m"] = self.diam_pup_in_m
         header = from_param_to_header(necessary_dm_param, header)
 
         # Loading any existing matrix and comparing their headers to make sure they are created

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,10 @@
 name: asterix
 dependencies:
-  - astropy=>7.0
+  - astropy>=7.0
   - configobj
   - matplotlib
   - numpy
-  - python=>3.9
+  - python>=3.9
   - scikit-image
   - scipy
   - IPython

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: asterix
 dependencies:
-  - astropy
+  - astropy=>7.0
   - configobj
   - matplotlib
   - numpy

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     keywords='Exoplanets imaging high-contrast coronagraphy',
     install_requires=[
-        "astropy=>7.0",
+        "astropy>=7.0",
         "configobj",
         "ipython",
         "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     keywords='Exoplanets imaging high-contrast coronagraphy',
     install_requires=[
-        "astropy",
+        "astropy=>7.0",
         "configobj",
         "ipython",
         "matplotlib",


### PR DESCRIPTION
Some errors in the fits comparison that I use to estimate if I need to recompute the fits files:
- for the pushact, I add the physical size of the pupil as a parameter
- Apparently older version of pushact had an error (small letter / cap problem) in diff-fits. I have added a requirement for astropy >7
