### PR TITLE
Vectorize pw estimate calculation to improve speed

### DIFF
--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -322,17 +322,10 @@ def calculate_pw_estimate(Difference,
     for i in range(Difference.shape[0]):
         Difference_resized[i] = resizing(Difference[i], dimimages)
 
-    numprobe = len(Vectorprobes[0, 0])
-    Differenceij = np.zeros((numprobe))
-    Resultat = np.zeros((dimimages, dimimages), dtype=dtype_complex)
-    l_ind = 0
-    for i in np.arange(dimimages):
-        for j in np.arange(dimimages):
-            Differenceij[:] = Difference_resized[:, i, j]
-            Resultatbis = np.dot(Vectorprobes[l_ind], Differenceij)
-            Resultat[i, j] = Resultatbis[0] + 1j * Resultatbis[1]
-
-            l_ind = l_ind + 1
+    Difference_resized = Difference_resized.reshape((Difference.shape[0], dimimages ** 2))
+    Resultat_ = np.einsum('ijk,ik->ij', Vectorprobes, Difference_resized.T)
+    Resultat = Resultat_[:, 0] + 1j * Resultat_[:, 1]
+    Resultat = Resultat.reshape(dimimages, dimimages)
 
     if pwp_or_btp in ['pw', "pwp", 'pairwise']:
         if dir_save_all_planes is not None:


### PR DESCRIPTION
Change function `calculate_pw_estimate` in `Asterix/wfsc/wf_sensing_functions.py` to use `np.einsum` 
instead of a nested `for` loop. The aim is to both clean up the code and improve the speed of the PW estimation.