### PR TITLE
minor error in sigma_probe parameter

### DIFF
--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -284,7 +284,7 @@ onbench=True
     probes_shape = 'actu'
     
     #Sigma value of the gaussian function when using probe actuators
-    sigma_probe = 1.4. #1.4 for 48x48
+    sigma_probe = 1.4 #1.4 for 48x48
     
     # Threshold to remove pixels with bad
     # estimation of the electric field

--- a/Asterix/Param_configspec.ini
+++ b/Asterix/Param_configspec.ini
@@ -90,7 +90,7 @@ onbench = boolean(default=False)
     amplitudePW = float(default=34.)
     posprobes = int_list(default=list(466,498))
     probes_shape = string(default='actu')
-    Sigma_probe = float(default=1.4)
+    sigma_probe = float(default=1.4)
     cut = float(default=5.e4)
 
 [Correctionconfig]

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -371,7 +371,7 @@ def generate_probe_voltages(testbed: Testbed, posprobes, amplitudePW, name_DM_to
 
     elif probe_type == "gaussian":
         Nact_across = testbed.config_file["DMconfig"][name_DM_to_probe_in_PW + "_Nact1D"]
-        sigma_probe = float(testbed.config_file["Estimationconfig"]["Sigma_probe"])
+        sigma_probe = float(testbed.config_file["Estimationconfig"]["sigma_probe"])
         # Euclidian distance to 0,0
         y, x = np.ogrid[:Nact_across, :Nact_across]
         cy, cx = Nact_across // 2, Nact_across // 2

--- a/docs/estimation.rst
+++ b/docs/estimation.rst
@@ -109,7 +109,7 @@ The Pair wise probing estimation version we used is defined in
 `Potier et al. (2020) <http://adsabs.harvard.edu/abs/2020A%26A...635A.192P>`_ 
 
 ``probes_shape`` parameter allows the changement of the probe shape: "actu", "sinc", "gaussian".
-If gaussian, thw width of the gaussian can be changed usgin the parameter ``Sigma_probe``.
+If gaussian, thw width of the gaussian can be changed usgin the parameter ``sigma_probe``.
 
 The position of the probes (number of the actuator on which is centered the probe)
 can be chosen using ``posprobes`` parameter.

--- a/docs/run_asterix.rst
+++ b/docs/run_asterix.rst
@@ -217,7 +217,7 @@ If ``estimation`` = 'pwp' or 'btp':
 
     - ``name_DM_to_probe_in_PW`` : str, Name of the DM used for PWP.
     - ``probes_shape`` : str, shape of the probes. can be "actu", "sinc", "gaussian"
-    - ``Sigma_probe`` : float, Sigma value in pitch value of the gaussian (if probes_shape = "gaussian")
+    - ``sigma_probe`` : float, Sigma value in pitch value of the gaussian (if probes_shape = "gaussian")
     - ``amplitudePW`` : float, Amplitude of PWP probes or BTP (in nm).
     - ``posprobes`` : list of int, Actuators used for PWP or BTP (DM in pupil plane).
     - ``cut`` : float, Threshold to remove pixels with bad estimation of the electric field.


### PR DESCRIPTION
The sigma_probe paramater introduce in the last PR was wrongly defined in the parameter file. 
There was a mismatch between its use : sometime Sigma_probe, sometimes sigma_probe