### PR TITLE
Shorten matrix names to avoid OS specific issues

### DIFF
--- a/Asterix/optics/coronagraph.py
+++ b/Asterix/optics/coronagraph.py
@@ -136,14 +136,12 @@ class Coronagraph(optsy.OpticalSystem):
 
         elif self.corona_type in ("classiclyot", "hlc"):
 
-            self.string_os += '_' + "iwa" + str(round(self.rad_lyot_fpm, 2))
             self.perfect_coro = False
             if self.corona_type == "classiclyot":
                 self.FPmsk = self.ClassicalLyot()
             else:
                 self.transmission_fpm = coroconfig["transmission_fpm"]
                 self.phase_fpm = coroconfig["phase_fpm"]
-                self.string_os += '_' + f"trans{self.transmission_fpm:.1e}_pha{round(self.phase_fpm, 2)}"
                 self.FPmsk = self.HLC()
                 if self.achrom_phase_coro:
                     self.string_os += '_' + "achrom"
@@ -152,7 +150,7 @@ class Coronagraph(optsy.OpticalSystem):
             self.coro_position = coroconfig["knife_coro_position"].lower()
             self.knife_coro_offset = coroconfig["knife_coro_offset"]
             self.FPmsk = self.KnifeEdgeCoro()
-            self.string_os += '_' + self.coro_position + "_iwa" + str(round(self.knife_coro_offset, 2))
+            self.string_os += '_' + self.coro_position
             self.perfect_coro = False
 
         elif self.corona_type == "vortex":

--- a/Asterix/optics/optical_systems.py
+++ b/Asterix/optics/optical_systems.py
@@ -130,7 +130,7 @@ class OpticalSystem:
             self.riemannn_intervals_lengths = np.array([self.Delta_wav])
             self.nb_wav = 1
 
-        self.string_os = '_dimPP' + str(int(self.dim_overpad_pupil)) + "_dimFP" + str(int(self.dimScience))
+        self.string_os = '_PP' + str(int(self.dim_overpad_pupil)) + "_FP" + str(int(self.dimScience))
 
         grey_pup_bool = modelconfig["grey_pupils"]
         if grey_pup_bool:

--- a/Asterix/optics/pupil.py
+++ b/Asterix/optics/pupil.py
@@ -74,43 +74,43 @@ class Pupil(optsy.OpticalSystem):
             self.pup = phase_ampl.roundpupil(self.dim_overpad_pupil, prad, grey_pup_bin_factor=self.grey_pup_bin_factor)
             angle_rotation = 0
             if isinstance(prad, int) or prad.is_integer():
-                self.string_os += '_RoundPup' + str(int(prad))
+                self.string_os += '_RoPup' + str(int(prad))
             else:
-                self.string_os += '_RoundPup' + str(round(prad, 1))
+                self.string_os += '_RoPup' + str(round(prad, 1))
 
         # Clear (in case we want to define an empty pupil plane)
         elif PupType == "Clear":
             self.pup = np.ones((self.dim_overpad_pupil, self.dim_overpad_pupil))
             angle_rotation = 0
-            self.string_os += '_ClearPlane'
+            self.string_os += '_Clear'
 
         elif PupType == "VLTPup":
             self.pup = phase_ampl.make_VLT_pup(self.dim_overpad_pupil, prad, pupangle=angle_rotation, spiders=True)
             self.string_os += '_VLTPup'
         elif PupType == "SphereLyot":
             self.pup = phase_ampl.make_sphere_lyot(self.dim_overpad_pupil, prad, pupangle=angle_rotation, spiders=True)
-            self.string_os += '_SphereLyot'
+            self.string_os += '_SphereLS'
         elif PupType == "SphereApod":
             self.pup = phase_ampl.make_sphere_apodizer(self.dim_overpad_pupil, prad)
-            self.string_os += '_SphereApod'
+            self.string_os += '_SphereAp'
         else:
             # In those cases, we are using a fits to create the pupil
             # in these first cases, we use a known .fits with hardcoded file name
             if PupType == "RomanPup":
                 pup_fits = fits.getdata(os.path.join(model_dir, "roman_pup_500pix_center4pixels.fits"))
-                self.string_os += '_RomanPup' + str(int(prad))
+                self.string_os += '_RomanP' + str(int(prad))
 
-            elif PupType == "RomanPupTHD2":
+            elif PupType == "RomanPTHD2":
                 pup_fits = fits.getdata(os.path.join(model_dir, "roman_pup_thd2_500pix_center4pixels.fits"))
-                self.string_os += '_RomanPupTHD2' + str(int(prad))
+                self.string_os += '_RomanPTHD2' + str(int(prad))
 
             elif PupType == "RomanLyot":
                 pup_fits = fits.getdata(os.path.join(model_dir, "roman_lyot_500pix_center4pixels.fits"))
-                self.string_os += '_RomanLyot'
+                self.string_os += '_RomanLS'
 
             elif PupType == "RomanLyotTHD2":
                 pup_fits = fits.getdata(os.path.join(model_dir, "roman_lyot_thd2_500pix_center4pixels.fits"))
-                self.string_os += '_RomanLyotTHD2'
+                self.string_os += '_RomanLSTHD2'
 
             # finally in this last case, we use an unknown .fits defined by user
             else:
@@ -170,8 +170,6 @@ class Pupil(optsy.OpticalSystem):
 
             self.pup = crop_or_pad_image(pup_fits_right_size, self.dim_overpad_pupil)
 
-        if self.grey_pup_bin_factor > 1 and (not PupType == "Clear"):
-            self.string_os += 'grey'
 
         # initialize the max and sum of PSFs for the normalization to contrast
         self.measure_normalization()

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -520,13 +520,13 @@ def name_header_efc_matrix(testbed: Testbed, DM: DeformableMirror, amplitudeEFC,
         pass
     elif DM.basis_type == 'actuator':
         basis_type_str = 'Actu'
-        headfile += "_EFCampl" + str(amplitudeEFC)
+        headfile += "_Ampl" + str(amplitudeEFC)
     else:
         raise ValueError("This basis type does not exist ([Correctionconfig]['DM_basis'] parameter).")
 
     DM_small_str = "_" + "_".join(DM.string_os.split("_")[3:])
-    basis_str = DM_small_str + "_" + basis_type_str + "Basis" + str(DM.basis_size)
-    fileDirectMatrix = headfile + basis_str + '_binEstim' + str(int(np.round(
+    basis_str = DM_small_str + "_" + basis_type_str + "Bas" + str(DM.basis_size)
+    fileDirectMatrix = headfile + basis_str + '_bin' + str(int(np.round(
         testbed.dimScience / dimEstim))) + testbed.string_testbed_without_DMS + "_resFP" + str(
             round(DM.Science_sampling / DM.wavelength_0 * wavelength, 2)) + '_wl' + str(int(wavelength * 1e9))
 

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -520,7 +520,6 @@ def name_header_efc_matrix(testbed: Testbed, DM: DeformableMirror, amplitudeEFC,
         pass
     elif DM.basis_type == 'actuator':
         basis_type_str = 'Actu'
-        headfile += "_Ampl" + str(amplitudeEFC)
     else:
         raise ValueError("This basis type does not exist ([Correctionconfig]['DM_basis'] parameter).")
 

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -294,9 +294,8 @@ def name_header_pwp_matrix(testbed: Testbed, dimEstim, cutsvd, wavelength, matri
     amplitudePW = testbed.config_file["Estimationconfig"]["amplitudePW"]
     SmallPhaseHypPWP = testbed.config_file["Estimationconfig"]["SmallPhaseHypPWP"]
 
-    string_dims_PWMatrix = name_DM_to_probe_in_PW + "Prob_" + probe_type + "_" + "_".join(map(
-        str, posprobes)) + "_PWampl" + str(int(amplitudePW)) + "_cut" + str(int(
-            cutsvd // 1000)) + "k_dimEstim" + str(dimEstim) + testbed.string_os + "_resFP" + str(
+    string_dims_PWMatrix = name_DM_to_probe_in_PW + "_" + probe_type + "_" + "_".join(map(
+        str, posprobes)) + "_Ampl" + str(int(amplitudePW)) + "_Estim" + str(dimEstim) + testbed.string_os + "_resFP" + str(
                 round(testbed.Science_sampling / testbed.wavelength_0 * wavelength, 2)) + '_wl' + str(
                     int(wavelength * 1e9))
 


### PR DESCRIPTION
Shorten Matrix names as they began to be too long for Windows OS on the THD. 
Tested on Asterix main file that matrices were correctly reloaded if config not changed.
However, be careful as we removed a few parameters from the name, it is now possible that matrices are over-written if you change this parameter.

A few example below : 

**Before:** 
MatPW_SmallPha_DM2Prob_actu_466_498_PWampl34_cut50k_dimEstim200_dimPP200_dimFP800_RoundPup50grey_DM1_z230_Nact952_DM2_z0_Nact1024_Apod_ClearPlane_fqpm_LS_RoundPup48.1grey_resFP13.95_wl783.fits
**After:**
MatPW_SmallPha_DM2_actu_466_498_Ampl34_Estim200_PP200_FP800_RoPup50_DM1_z230_Nact952_DM2_z0_Nact1024_Apod_Clear_fqpm_LS_RoPup48.1_resFP13.95_wl783.fits

**Before:** 
DirectMat_SmallPha_EFCampl17.0_DM2_z0_Nact1024_ActuBasis1024_binEstim4_dimPP200_dimFP800_RoundPup50grey_Apod_ClearPlane_fqpm_LS_RoundPup48.1grey_resFP13.95_wl783.fits
**After:**
DirectMat_SmallPha_DM2_z0_Nact1024_ActuBas1024_bin4_PP200_FP800_RoPup50_Apod_Clear_fqpm_LS_RoPup48.1_resFP13.95_wl783.fits


