### PR TITLE
Clarify dm command units and normalize EFC matrix to nm

### DIFF
--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -343,7 +343,7 @@ onbench=True
 
     #EFC parameters
     Nbmodes_OnTestbed = 600#330
-    amplitudeEFC = 17
+    amplitudeEFC = 17 # in nanometer
     regularization='tikhonov' # 'truncation' or 'tikhonov'
 
 [Loopconfig]

--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -343,7 +343,7 @@ onbench=True
 
     #EFC parameters
     Nbmodes_OnTestbed = 600#330
-    amplitudeEFC = 17 # in nanometer
+    amplitudeEFC = 1 # in nanometer
     regularization='tikhonov' # 'truncation' or 'tikhonov'
 
 [Loopconfig]

--- a/Asterix/Param_file_roman.ini
+++ b/Asterix/Param_file_roman.ini
@@ -337,7 +337,7 @@ onbench=False
 
     #EFC parameters
     Nbmodes_OnTestbed = 600#330
-    amplitudeEFC = 17
+    amplitudeEFC = 1 # in nanometer
     regularization='tikhonov' # 'truncation' or 'tikhonov'
 
 [Loopconfig]

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -211,7 +211,7 @@ def runthd2(parameter_file_path,
                               SIMUconfig,
                               input_wavefront=input_wavefront,
                               EF_aberrations_introduced_in_LS=wavefront_in_LS,
-                              initial_DM_voltage=0,
+                              initial_DM_command=0,
                               silence=silence,
                               probe_dir=probe_dir,
                               **kwargs)

--- a/Asterix/optics/deformable_mirror.py
+++ b/Asterix/optics/deformable_mirror.py
@@ -181,12 +181,12 @@ class DeformableMirror(optsy.OpticalSystem):
         return EF_after_DM
 
     def creatingpushact(self, DMconfig, silence=False):
-        """OPD map induced in the DM plane for each actuator (i.e. actuator influence
+        """OPD maps in the DM plane for each actuator (i.e. actuator influence
         function rescaled to the right size and shifted at each actuator position).
         Influence functions of each actuator are normalized to 1 before supixel shift.
 
         This large array is initialized at the beginning and will be use
-        to transform a DM command in nm into a DM opd for each DM. This is saved
+        to transform a DM command in nm into a DM opd in nm for each DM. This is saved
         in .fits to save times if the parameter have not changed
 
         In case of "misregistration = True" we measure it once for
@@ -206,7 +206,7 @@ class DeformableMirror(optsy.OpticalSystem):
         Returns
         --------
         pushact : 3D numpy arrayof size [self.number_act, self.dim_overpad_pupil, self.dim_overpad_pupil]
-            DM OPD maps induced in the DM plane for each actuator.
+            OPD maps in the DM plane for each actuator.
         """
         start_time = time.time()
         Name_pushact_fits = "PushAct_" + self.Name_DM

--- a/Asterix/optics/deformable_mirror.py
+++ b/Asterix/optics/deformable_mirror.py
@@ -525,6 +525,7 @@ class DeformableMirror(optsy.OpticalSystem):
         --------
         basis: 2d numpy array
             Basis [Size basis, Number of active act in the DM].
+            All basis vector must be normalized to 1 (nm).
         """
         if basis_type == 'actuator':
             # no need to remove the inactive actuators,
@@ -546,7 +547,7 @@ class DeformableMirror(optsy.OpticalSystem):
 
             for i in range(basis_size):
                 vec = cossinbasis[i].flatten()[self.active_actuators]
-                basis[i] = vec
+                basis[i] = vec / np.max(vec)
 
             # This is a very time consuming part of the code.
             # from N DM commands with the sine and cosine value, we go N times through the

--- a/Asterix/optics/deformable_mirror.py
+++ b/Asterix/optics/deformable_mirror.py
@@ -181,10 +181,12 @@ class DeformableMirror(optsy.OpticalSystem):
         return EF_after_DM
 
     def creatingpushact(self, DMconfig, silence=False):
-        """OPD map induced in the DM plane for each actuator.
+        """OPD map induced in the DM plane for each actuator (i.e. actuator influence
+        function rescaled to the right size and shifted at each actuator position).
+        Influence functions of each actuator are normalized to 1 before supixel shift.
 
         This large array is initialized at the beginning and will be use
-        to transorm a voltage into a phase for each DM. This is saved
+        to transform a DM vector in nm into a DM opd for each DM. This is saved
         in .fits to save times if the parameter have not changed
 
         In case of "misregistration = True" we measure it once for
@@ -297,15 +299,17 @@ class DeformableMirror(optsy.OpticalSystem):
         dim_even = int(np.ceil(np.max(resizeactshape.shape) / 2 + 1)) * 2
         resizeactshape = crop_or_pad_image(resizeactshape, dim_even)
 
+        # Normalize infl function to 1 nm
+        resizeactshape = resizeactshape / np.amax(resizeactshape)
+
         # Gauss2Dfit for centering the rescaled influence function
         Gaussian_fit_param = gauss.gauss2Dfit(resizeactshape)
         dx = Gaussian_fit_param[3]
         dy = Gaussian_fit_param[4]
         xycent = len(resizeactshape) / 2
 
-        # Center the actuator shape on a pixel and normalize
-        resizeactshape = ft_subpixel_shift(resizeactshape, xshift=xycent - dx,
-                                           yshift=xycent - dy) / np.amax(resizeactshape)
+        # Center the actuator shape on a pixel
+        resizeactshape = ft_subpixel_shift(resizeactshape, xshift=xycent - dx, yshift=xycent - dy)
 
         # Put the centered influence function inside an array (self.dim_overpad_pupil x self.dim_overpad_pupil)
         actshapeinpupil = crop_or_pad_image(resizeactshape, dim_array)
@@ -464,8 +468,8 @@ class DeformableMirror(optsy.OpticalSystem):
         return EF_back_in_pup_plane
 
     def voltage_to_phase(self, actu_vect, einstein_sum=False):
-        """Generate the phase applied on one DM for a give vector of actuator
-        amplitude We decided to do it without matrix multiplication to save
+        """Generate the phase applied on one DM for a given vector of actuator
+        amplitude in nm. We decided to do it without matrix multiplication to save
         time because a lot of the time we have lot of zeros in it.
 
         The phase is define at the reference wl and multiply by wl_ratio in DM.EF_through
@@ -475,7 +479,7 @@ class DeformableMirror(optsy.OpticalSystem):
         Parameters
         ----------
         actu_vect : 1D array
-            Values of the amplitudes for each actuator.
+            Values of the amplitudes for each actuator in nm.
         einstein_sum : boolean, default false
             Use numpy Einstein sum to sum the pushact[i]*actu_vect[i]
             gives the same results as normal sum. Seems ot be faster for unique actuator
@@ -484,15 +488,15 @@ class DeformableMirror(optsy.OpticalSystem):
         Returns
         --------
         DM_phase: 2D array
-            phase map in the same unit as actu_vect * DM_pushact.
+            phase map in radians.
         """
 
         where_non_zero_voltage = np.where(actu_vect != 0)
         if len(where_non_zero_voltage[0]) == 0:
             return np.zeros((self.dim_overpad_pupil, self.dim_overpad_pupil))
 
-        # opd is in nanometer
-        # DM_pushact is in opd nanometer
+        # actu_vect are in nanometer
+        # DM_pushact are influence functions normalized to 1.
         opd_to_phase = 2 * np.pi * 1e-9 / self.wavelength_0
 
         if einstein_sum or len(where_non_zero_voltage[0]) < 3:

--- a/Asterix/optics/deformable_mirror.py
+++ b/Asterix/optics/deformable_mirror.py
@@ -186,7 +186,7 @@ class DeformableMirror(optsy.OpticalSystem):
         Influence functions of each actuator are normalized to 1 before supixel shift.
 
         This large array is initialized at the beginning and will be use
-        to transform a DM vector in nm into a DM opd for each DM. This is saved
+        to transform a DM command in nm into a DM opd for each DM. This is saved
         in .fits to save times if the parameter have not changed
 
         In case of "misregistration = True" we measure it once for
@@ -467,7 +467,7 @@ class DeformableMirror(optsy.OpticalSystem):
 
         return EF_back_in_pup_plane
 
-    def voltage_to_phase(self, actu_vect, einstein_sum=False):
+    def dmcommand_to_phase(self, dm_command, einstein_sum=False):
         """Generate the phase applied on one DM for a given vector of actuator
         amplitude in nm. We decided to do it without matrix multiplication to save
         time because a lot of the time we have lot of zeros in it.
@@ -478,10 +478,10 @@ class DeformableMirror(optsy.OpticalSystem):
 
         Parameters
         ----------
-        actu_vect : 1D array
+        dm_command : 1D array
             Values of the amplitudes for each actuator in nm.
         einstein_sum : boolean, default false
-            Use numpy Einstein sum to sum the pushact[i]*actu_vect[i]
+            Use numpy Einstein sum to sum the pushact[i]*dm_command[i]
             gives the same results as normal sum. Seems ot be faster for unique actuator
             but slower for more complex phases.
 
@@ -491,21 +491,21 @@ class DeformableMirror(optsy.OpticalSystem):
             phase map in radians.
         """
 
-        where_non_zero_voltage = np.where(actu_vect != 0)
-        if len(where_non_zero_voltage[0]) == 0:
+        where_non_zero_actu = np.where(dm_command != 0)
+        if len(where_non_zero_actu[0]) == 0:
             return np.zeros((self.dim_overpad_pupil, self.dim_overpad_pupil))
 
-        # actu_vect are in nanometer
+        # dm_command are in nanometer
         # DM_pushact are influence functions normalized to 1.
         opd_to_phase = 2 * np.pi * 1e-9 / self.wavelength_0
 
-        if einstein_sum or len(where_non_zero_voltage[0]) < 3:
-            phase_on_DM = np.einsum('i,ijk->jk', actu_vect[where_non_zero_voltage],
-                                    self.DM_pushact[where_non_zero_voltage]) * opd_to_phase
+        if einstein_sum or len(where_non_zero_actu[0]) < 3:
+            phase_on_DM = np.einsum('i,ijk->jk', dm_command[where_non_zero_actu],
+                                    self.DM_pushact[where_non_zero_actu]) * opd_to_phase
         else:
             phase_on_DM = np.zeros((self.dim_overpad_pupil, self.dim_overpad_pupil))
-            for i in where_non_zero_voltage[0]:
-                phase_on_DM += self.DM_pushact[i, :, :] * actu_vect[i] * opd_to_phase
+            for i in where_non_zero_actu[0]:
+                phase_on_DM += self.DM_pushact[i, :, :] * dm_command[i] * opd_to_phase
 
         return phase_on_DM
 
@@ -549,8 +549,8 @@ class DeformableMirror(optsy.OpticalSystem):
                 basis[i] = vec
 
             # This is a very time consuming part of the code.
-            # from N voltage vectors with the sine and cosine value, we go N times through the
-            # voltage_to_phase functions. For this reason we save the Fourrier base 2D phases on each DMs
+            # from N DM commands with the sine and cosine value, we go N times through the
+            # dmcommand_to_phase function. For this reason we save the Fourrier base 2D phases on each DMs
             # in a specific .fits file that is read during the creation of the matrix in
             # wf_control_functions.create_singlewl_interaction_matrix.py
 
@@ -588,7 +588,7 @@ class DeformableMirror(optsy.OpticalSystem):
                 if not silence:
                     print("Start " + Name_FourrierBasis_fits + " (wait a few 10s of seconds)")
                 for i in range(basis_size):
-                    phasesFourrier[i] = self.voltage_to_phase(basis[i])
+                    phasesFourrier[i] = self.dmcommand_to_phase(basis[i])
                     if i % 10:
                         progress(i, basis_size, status='')
                 fits.writeto(os.path.join(self.Model_local_dir, Name_FourrierBasis_fits + '.fits'),

--- a/Asterix/optics/testbed.py
+++ b/Asterix/optics/testbed.py
@@ -122,9 +122,9 @@ class Testbed(optsy.OpticalSystem):
         if 'DMphase' in known_keywords:
             known_keywords.remove('DMphase')
         if self.number_DMs > 0:
-            # there is at least a DM, we add voltage_vector as an authorize kw
-            known_keywords.append('voltage_vector')
-            self.EF_through = _control_testbed_with_voltages(self, self.EF_through)
+            # there is at least a DM, we add dm_command as an authorize kw
+            known_keywords.append('dm_command')
+            self.EF_through = _control_testbed_with_dmcommands(self, self.EF_through)
 
         # to avoid mis-use we only use specific keywords.
         known_keywords.remove('kwargs')
@@ -134,115 +134,113 @@ class Testbed(optsy.OpticalSystem):
         # initialize the max and sum of PSFs for the normalization to contrast
         self.measure_normalization()
 
-    def voltage_to_phases(self, actu_vect, einstein_sum=False):
+    def dmcommands_to_phases(self, dm_command, einstein_sum=False):
         """Generate the phase applied on each DMs of the testbed from a given
-        vector of actuator amplitude. I split theactu_vect and  then for each
-        DM, it uses DM.voltage_to_phase (no s)
+        dm command for the testbed. I split the dm_command into individual DM dm_command
+        then for each DM, it uses DM.dmcommand_to_phase (no s)
 
         AUTHOR : Johan Mazoyer
 
         Parameters
         ----------
-        actu_vect : float or 1D array of size testbed.number_act
-            Values of the amplitudes for each actuator and each DM.
+        dm_command : float or 1D array of size testbed.number_act
+            Values of the amplitudes for each actuator and each DM in nm.
         einstein_sum : boolean. default False
-            Use numpy Einstein sum to sum the pushact[i]*actu_vect[i]
+            Use numpy Einstein sum to sum the pushact[i]*dm_command[i]
             gives the same results as normal sum. Seems ot be faster for unique actuator
             but slower for more complex phases.
 
         Returns
         --------
         phases : 3D array of size [testbed.number_DMs, testbed.dim_overpad_pupil,testbed.dim_overpad_pupil]
-            Phase maps for each DMs by order of light path in the same unit as actu_vect * DM_pushact.
+            Phase maps for each DMs by order of light path in radians.
         """
         DMphases = np.zeros((self.number_DMs, self.dim_overpad_pupil, self.dim_overpad_pupil))
         indice_acum_number_act = 0
 
-        if isinstance(actu_vect, (int, float)):
-            return np.zeros(self.number_DMs) + float(actu_vect)
+        if isinstance(dm_command, (int, float)):
+            return np.zeros(self.number_DMs) + float(dm_command)
 
-        if len(actu_vect) != self.number_act:
-            raise ValueError("voltage vector must be 0 or array of dimension testbed.number_act," +
+        if len(dm_command) != self.number_act:
+            raise ValueError("dm_command must be 0 or array of dimension testbed.number_act," +
                              "sum of all DM.number_act")
 
         for i, DM_name in enumerate(self.name_of_DMs):
 
             DM: deformable_mirror.DeformableMirror = vars(self)[DM_name]
             if DM.active:
-                actu_vect_DM = actu_vect[indice_acum_number_act:indice_acum_number_act + DM.number_act]
-                DMphases[i] = DM.voltage_to_phase(actu_vect_DM, einstein_sum=einstein_sum)
+                dm_command_DM = dm_command[indice_acum_number_act:indice_acum_number_act + DM.number_act]
+                DMphases[i] = DM.dmcommand_to_phase(dm_command_DM, einstein_sum=einstein_sum)
 
             indice_acum_number_act += DM.number_act
 
         return DMphases
 
-    def basis_vector_to_act_vector(self, vector_basis_voltage):
-        """transform a vector of voltages on the mode of a basis in a  vector
-        of voltages of the actuators of the DMs of the system.
+    def basis_vector_to_dmcommand(self, vector_basis_command):
+        """transform a vector of command on the modes of a basis in a command
+        of the DMs of the testbed.
 
         AUTHOR : Johan Mazoyer
 
         Parameters
         ----------
-        vector_basis_voltage : 1D-array real
-            Vector of voltages of size (total(basisDM sizes)) on the mode of the basis for all
-            DMs by order of the light path.
+        vector_basis_command : 1D-array real
+            Command of size (total(basisDM sizes)) on the mode of the basis.
 
         Returns
         --------
-        vector_actuator_voltage : 1D-array real
-            Vector of base coefficients for all actuators of the DMs by order of the light path
-            size (total(DM actuators)).
+        dm_command : 1D-array real
+            dm command in nm by order of the light path (size :total(DM actuators)).
         """
 
         indice_acum_basis_size = 0
         indice_acum_number_act = 0
 
-        vector_actuator_voltage = np.zeros(self.number_act)
+        dm_command = np.zeros(self.number_act)
         for DM_name in self.name_of_DMs:
 
             # we access each DM object individually
             DM: deformable_mirror.DeformableMirror = vars(self)[DM_name]
             if DM.active:
-                # we extract the voltages for this DM
-                # this voltages are in the DM basis
-                vector_basis_voltage_for_DM = vector_basis_voltage[indice_acum_basis_size:indice_acum_basis_size +
+                # we extract the command for this DM
+                # this command are in the DM basis
+                vector_basis_command_for_DM = vector_basis_command[indice_acum_basis_size:indice_acum_basis_size +
                                                                    DM.basis_size]
 
                 # we change to the actuator basis
-                vector_actu_voltage_for_DM = np.dot(np.transpose(DM.basis), vector_basis_voltage_for_DM)
+                command_for_DM = np.dot(np.transpose(DM.basis), vector_basis_command_for_DM)
 
-                # we concatenate DM voltages to obtain a single vector of voltages, but for the testbed
-                vector_actuator_voltage[indice_acum_number_act:indice_acum_number_act +
-                                        DM.number_act] = vector_actu_voltage_for_DM
+                # we concatenate DM commands to obtain a single command for the testbed
+                dm_command[indice_acum_number_act:indice_acum_number_act +
+                                        DM.number_act] = command_for_DM
 
                 indice_acum_basis_size += DM.basis_size
             indice_acum_number_act += DM.number_act
 
-        return vector_actuator_voltage
+        return dm_command
 
-    def indiv_DM_voltage_to_testbed_voltage(self, voltage_indiv, DM_name):
-        """Transform a vector of voltages on a single DM vector
-            of voltages of the actuators of the tesbted using zeros on the other DMs.
+    def indiv_DM_command_to_testbed_command(self, dmcommand_indiv, DM_name):
+        """Transform a command on a single DM to command of all
+        tesbted DMs using zeros on the other DMs.
 
         Parameters:
         --------
-        voltage_indiv : 1D-array real
-            the individual DM voltage vector.
+        dmcommand_indiv : 1D-array real
+            the individual DM command in nm.
         DM_name : string
-            The name of the DM you which to apply the voltages to.
+            The name of the DM you which to apply the command to.
 
         Returns
         --------
-        testbed_voltage : 1D-array real of dim testbed.number_act
-            the vector of voltages on the testbed with voltage_indiv at the
+        testbed_command : 1D-array real of dim testbed.number_act
+            the commands of the testbed DM with dmcommand_indiv at the
             position of DM DM_name and zero elsewhere.
         """
 
         if DM_name not in self.name_of_DMs:
             raise ValueError("DM_name must be in the list of DMs")
 
-        testbed_voltage = np.zeros(self.number_act)
+        testbed_command = np.zeros(self.number_act)
         indice_acum_number_act = 0
         for DM_name_here in self.name_of_DMs:
 
@@ -253,28 +251,28 @@ class Testbed(optsy.OpticalSystem):
                 if not DM.active:
                     raise ValueError("DM_name must be active to send commands.")
 
-                if len(voltage_indiv) != DM.number_act:
-                    raise ValueError(f"voltage_indiv must be of size the number_act of DM {DM_name} : {DM.number_act}")
+                if len(dmcommand_indiv) != DM.number_act:
+                    raise ValueError(f"dmcommand_indiv must be of size the number_act of DM {DM_name} : {DM.number_act}")
 
-                testbed_voltage[indice_acum_number_act:indice_acum_number_act + DM.number_act] = voltage_indiv
-                return testbed_voltage
+                testbed_command[indice_acum_number_act:indice_acum_number_act + DM.number_act] = dmcommand_indiv
+                return testbed_command
             else:
                 indice_acum_number_act += DM.number_act
 
-    def testbed_voltage_to_indiv_DM_voltage(self, testbed_voltage, DM_name):
-        """Extract the voltage of DM DM_name from a vector of voltages of the full tesbted.
+    def testbed_command_to_indiv_DM_command(self, testbed_command, DM_name):
+        """Extract the commands of DM DM_name from a command of the full tesbted.
 
         Parameters:
         --------
-        testbed_voltage : 1D-array of dim testbed.number_act
-            the testbed voltage vector (all DMs voltage vectors concatenated)
+        testbed_command : 1D-array of dim testbed.number_act
+            the testbed command (all DM commands concatenated)
         DM_name : string
-            The name of the DM to which you want to extract the individual voltage.
+            The name of the DM to which you want to extract the individual command.
 
         Returns
         --------
-        voltage_indiv : 1D-array real
-            the individual DM voltage vector.
+        dmcommand_indiv : 1D-array real
+            the individual DM command.
 
         """
         indice_acum_number_act = 0
@@ -286,8 +284,8 @@ class Testbed(optsy.OpticalSystem):
             DM: deformable_mirror.DeformableMirror = vars(self)[DM_name_here]
 
             if DM_name_here == DM_name:
-                voltage_indiv = testbed_voltage[indice_acum_number_act:indice_acum_number_act + DM.number_act]
-                return voltage_indiv
+                dmcommand_indiv = testbed_command[indice_acum_number_act:indice_acum_number_act + DM.number_act]
+                return dmcommand_indiv
 
             else:
                 indice_acum_number_act += DM.number_act
@@ -387,16 +385,16 @@ def _clean_EF_through(testbed_EF_through, known_keywords):
     return wrapper
 
 
-def _control_testbed_with_voltages(testbed: Testbed, testbed_EF_through):
+def _control_testbed_with_dmcommands(testbed: Testbed, testbed_EF_through):
     """A function to go from a testbed_EF_through with several DMXX_phase
     parameters (one for each DM), to a testbed_EF_through with a unique
-    voltage_vector parameter of size testbed.number_act (or a single float,
+    dm_command parameter of size testbed.number_act (or a single float,
     like 0.)
 
     the problem with DMXX_phase parameters is that it cannot be automated since it requires
     to know the name/number of the DMs in advance.
 
-    DMXX_phase parameters can still be used, but are overridden by voltage_vector parameter
+    DMXX_phase parameters can still be used, but are overridden by dm_command parameter
     if present.
 
     AUTHOR : Johan Mazoyer
@@ -411,13 +409,13 @@ def _control_testbed_with_voltages(testbed: Testbed, testbed_EF_through):
     Returns
     --------
     the_new_function : function
-        the EF_through function with voltage_vector as a parameters
+        the EF_through function with dm_command as a parameters
     """
 
     def wrapper(**kwargs):
-        if 'voltage_vector' in kwargs:
-            voltage_vector = kwargs['voltage_vector']
-            DM_phase = testbed.voltage_to_phases(voltage_vector)
+        if 'dm_command' in kwargs:
+            dm_command = kwargs['dm_command']
+            DM_phase = testbed.dmcommands_to_phases(dm_command)
             for i, DM_name in enumerate(testbed.name_of_DMs):
                 name_phase = DM_name + "phase"
                 kwargs[name_phase] = DM_phase[i]

--- a/Asterix/tests/test_wfsc.py
+++ b/Asterix/tests/test_wfsc.py
@@ -61,7 +61,7 @@ def quick_run_no_save(config, data_dir):
                               Loopconfig,
                               SIMUconfig,
                               input_wavefront=input_wavefront,
-                              initial_DM_voltage=0,
+                              initial_DM_command=0,
                               silence=silence)
 
     best_contrast = np.min(results["MeanDHContrast"])

--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -22,7 +22,7 @@ def correction_loop(testbed: Testbed,
                     Loopconfig,
                     SIMUconfig,
                     input_wavefront=1.,
-                    initial_DM_voltage=0.,
+                    initial_DM_command=0.,
                     silence=False,
                     probe_dir=None,
                     **kwargs):
@@ -56,8 +56,8 @@ def correction_loop(testbed: Testbed,
             method inside the Corrector allows it. Currently, each matrix is measured with a flat field in
             the entrance of the testbed (input_wavefront = 1).
             'input_wavefront' is only used in the loop once the matrix is calculated. This can be changed but be careful.
-    initial_DM_voltage : float or 1D array
-        Initial DM voltages at the beginning of this loop. The Matrix is measured using these initial DM voltages.
+    initial_DM_command : float or 1D array
+        Initial DM command at the beginning of this loop. The Matrix is measured using the initial DM command.
         Can be:
             float 0 if flat DMs (default)
             or 1D array of size testbed.number_act
@@ -73,7 +73,7 @@ def correction_loop(testbed: Testbed,
     CorrectionLoopResult = dict()
     CorrectionLoopResult["nb_total_iter"] = 0
     CorrectionLoopResult["Nb_iter_per_mat"] = []
-    CorrectionLoopResult["voltage_DMs"] = []
+    CorrectionLoopResult["command_DMs"] = []
     CorrectionLoopResult["FP_Intensities"] = []
     CorrectionLoopResult["EF_estim"] = []
     CorrectionLoopResult["MeanDHContrast"] = []
@@ -117,15 +117,15 @@ def correction_loop(testbed: Testbed,
     for i in range(Number_matrix):
 
         if i > 0:
-            corrector.update_matrices(testbed, initial_DM_voltage=initial_DM_voltage, silence=silence)
+            corrector.update_matrices(testbed, initial_DM_command=initial_DM_command, silence=silence)
 
             if estimator.technique in ["pairwise", "pw", "pwp", "btp"]:
                 estimator.PWMatrix = wfs.create_pw_matrix(testbed,
-                                                          estimator.voltage_probes,
+                                                          estimator.dmcommand_probes,
                                                           estimator.dimEstim,
                                                           estimator.cutsvdPW,
                                                           estimator.wav_vec_estim,
-                                                          initial_DM_voltage=initial_DM_voltage,
+                                                          initial_DM_command=initial_DM_command,
                                                           silence=silence)
 
         Resultats_correction_loop = correction_loop_1matrix(testbed,
@@ -138,7 +138,7 @@ def correction_loop(testbed: Testbed,
                                                             Nbmode_corr=Nbmode_corr,
                                                             Linesearch=Linesearch,
                                                             input_wavefront=input_wavefront,
-                                                            initial_DM_voltage=initial_DM_voltage,
+                                                            initial_DM_command=initial_DM_command,
                                                             nb_photons=nb_photons,
                                                             silence=silence,
                                                             probe_dir=probe_dir,
@@ -146,7 +146,7 @@ def correction_loop(testbed: Testbed,
 
         min_contrast = min(CorrectionLoopResult["MeanDHContrast"])
         min_index = CorrectionLoopResult["MeanDHContrast"].index(min_contrast)
-        initial_DM_voltage = Resultats_correction_loop["voltage_DMs"][min_index]
+        initial_DM_command = Resultats_correction_loop["command_DMs"][min_index]
         if not silence:
             if i != Number_matrix - 1:
                 print("end Matrix ", i)
@@ -168,7 +168,7 @@ def correction_loop_1matrix(testbed: Testbed,
                             Linesearch=False,
                             Search_best_Mode=False,
                             input_wavefront=1.,
-                            initial_DM_voltage=0.,
+                            initial_DM_command=0.,
                             nb_photons=0,
                             silence=False,
                             probe_dir=None,
@@ -211,8 +211,8 @@ def correction_loop_1matrix(testbed: Testbed,
             float=1 if no phase/amplitude aberrations present (default)
             2D complex array, of size phase_abb.shape if monochromatic
             or 3D complex array of size [self.nb_wav,phase_abb.shape] if polychromatic
-    initial_DM_voltage : float or 1D array
-        Initial DM voltages at the beginning of this loop. The Matrix is measured using this initial DM voltages.
+    initial_DM_command : float or 1D array
+        Initial DM command at the beginning of this loop. The Matrix is measured using this initial DM command.
         Can be:
             float 0 if flat DMs (default)
             or 1D array of size testbed.number_act
@@ -242,13 +242,13 @@ def correction_loop_1matrix(testbed: Testbed,
                 modevector = modevector + [Nbmode_corr[i]] * Nbiter_corr[i]
 
     initialFP = testbed.todetector_intensity(entrance_EF=input_wavefront,
-                                             voltage_vector=initial_DM_voltage,
+                                             dm_command=initial_DM_command,
                                              nb_photons=0,
                                              **kwargs)
 
     initialFP_contrast = np.mean(initialFP[np.where(mask_dh != 0)])
 
-    thisloop_voltages_DMs = []
+    thisloop_command_DMs = []
     thisloop_FP_Intensities = []
     thisloop_FP_Intensities_phot = []
     thisloop_MeanDHContrast = []
@@ -258,7 +258,7 @@ def correction_loop_1matrix(testbed: Testbed,
     thisloop_Probes_images = []
     thisloop_Var_Err_estim = []
 
-    thisloop_voltages_DMs.append(initial_DM_voltage)
+    thisloop_command_DMs.append(initial_DM_command)
     thisloop_FP_Intensities.append(initialFP)
     thisloop_MeanDHContrast.append(initialFP_contrast)
 
@@ -302,7 +302,7 @@ def correction_loop_1matrix(testbed: Testbed,
                                                                  Search_best_Mode=True,
                                                                  nb_photons=0,
                                                                  input_wavefront=input_wavefront,
-                                                                 initial_DM_voltage=thisloop_voltages_DMs[iteration],
+                                                                 initial_DM_command=thisloop_command_DMs[iteration],
                                                                  silence=silence,
                                                                  **kwargs)
 
@@ -329,7 +329,7 @@ def correction_loop_1matrix(testbed: Testbed,
                 print("Iteration number " + corrector.correction_algorithm + ": ", iteration + 1)
 
         probed_images = estimator.probe(testbed,
-                                        voltage_vector=thisloop_voltages_DMs[-1],
+                                        dm_command=thisloop_command_DMs[-1],
                                         entrance_EF=input_wavefront,
                                         perfect_estimation=Search_best_Mode,
                                         nb_photons=nb_photons,
@@ -346,7 +346,7 @@ def correction_loop_1matrix(testbed: Testbed,
             thisloop_Probes_images.append(probed_images)
 
             perf_probed_images = estimator.probe(testbed,
-                                                 voltage_vector=thisloop_voltages_DMs[-1],
+                                                 dm_command=thisloop_command_DMs[-1],
                                                  entrance_EF=input_wavefront,
                                                  perfect_estimation=True,
                                                  nb_photons=nb_photons,
@@ -358,7 +358,7 @@ def correction_loop_1matrix(testbed: Testbed,
                                                 testbed=testbed,
                                                 **kwargs)
 
-        solution = corrector.toDM_voltage(testbed,
+        solution = corrector.toDM_command(testbed,
                                           resultatestimation,
                                           mode=mode,
                                           ActualCurrentContrast=thisloop_MeanDHContrast[-1],
@@ -366,24 +366,24 @@ def correction_loop_1matrix(testbed: Testbed,
 
         if isinstance(solution, str) and solution == "StopTheLoop":
             # for each correction algorithm, we can break the loop by
-            # the string "StopTheLoop" instead of a correction vector
+            # the string "StopTheLoop" instead of a correction command
             if not silence:
                 print("we stop the correction")
             break
 
         if isinstance(solution, str) and solution == "RebootTheLoop":
             # for each correction algorithm, we can break the loop by
-            # the string "RebootTheLoop" instead of a correction vector
+            # the string "RebootTheLoop" instead of a correction command
             if not silence:
                 print("we go back to last best correction")
             ze_arg_of_ze_best = np.argmin(thisloop_MeanDHContrast)
-            new_voltage = thisloop_voltages_DMs[ze_arg_of_ze_best]
+            new_dmcommand = thisloop_command_DMs[ze_arg_of_ze_best]
 
         else:
-            new_voltage = thisloop_voltages_DMs[-1] + gain * solution
+            new_dmcommand = thisloop_command_DMs[-1] + gain * solution
 
         thisloop_FP_Intensities.append(
-            testbed.todetector_intensity(entrance_EF=input_wavefront, voltage_vector=new_voltage, nb_photons=0,
+            testbed.todetector_intensity(entrance_EF=input_wavefront, dm_command=new_dmcommand, nb_photons=0,
                                          **kwargs))
         thisloop_FP_Intensities_phot.append(testbed.add_photon_noise(thisloop_FP_Intensities[-1], nb_photons))
         thisloop_EF_estim.append(resultatestimation)
@@ -400,7 +400,7 @@ def correction_loop_1matrix(testbed: Testbed,
         if not Search_best_Mode:
             # if we are only looking for the best mode, we do not update the DM shape
             # for the next iteration
-            thisloop_voltages_DMs.append(new_voltage)
+            thisloop_command_DMs.append(new_dmcommand)
 
         iteration_number += 1
         if not silence:
@@ -424,7 +424,7 @@ def correction_loop_1matrix(testbed: Testbed,
 
         CorrectionLoopResult["SVDmodes"].append(thisloop_actual_modes)
 
-        CorrectionLoopResult["voltage_DMs"].extend(thisloop_voltages_DMs)
+        CorrectionLoopResult["command_DMs"].extend(thisloop_command_DMs)
         CorrectionLoopResult["FP_Intensities"].extend(thisloop_FP_Intensities)
         if nb_photons > 1:
             CorrectionLoopResult["FP_Intensities_phot"].extend(thisloop_FP_Intensities_phot)
@@ -479,7 +479,7 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
 
     FP_Intensities = CorrectionLoopResult["FP_Intensities"]
     meancontrast = CorrectionLoopResult["MeanDHContrast"]
-    voltage_DMs = CorrectionLoopResult["voltage_DMs"]
+    command_DMs = CorrectionLoopResult["command_DMs"]
     nb_total_iter = CorrectionLoopResult["nb_total_iter"]
     EF_estim = CorrectionLoopResult["EF_estim"]
     EF_simul = CorrectionLoopResult["EF_simul"]
@@ -516,17 +516,17 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
 
         fits.writeto(os.path.join(probe_dir, "EF_FP_IM.fits"), np.squeeze(np.imag(np.array(EF_simul))), header, overwrite=True)
 
-    voltage_DMs_nparray = np.zeros((nb_total_iter, testbed.number_act))
+    command_DMs_nparray = np.zeros((nb_total_iter, testbed.number_act))
 
     DM_phases = np.zeros((len(testbed.name_of_DMs), nb_total_iter, testbed.dim_overpad_pupil, testbed.dim_overpad_pupil))
 
-    for i in range(len(voltage_DMs)):
-        allDMphases = testbed.voltage_to_phases(voltage_DMs[i])
+    for i in range(len(command_DMs)):
+        allDMphases = testbed.dmcommands_to_phases(command_DMs[i])
 
-        if isinstance(voltage_DMs[i], (int, float)):
-            voltage_DMs_nparray[i, :] += float(voltage_DMs[i])
+        if isinstance(command_DMs[i], (int, float)):
+            command_DMs_nparray[i, :] += float(command_DMs[i])
         else:
-            voltage_DMs_nparray[i, :] = voltage_DMs[i]
+            command_DMs_nparray[i, :] = command_DMs[i]
 
         for j, DM_name in enumerate(testbed.name_of_DMs):
             DM_phases[j, i, :, :] = allDMphases[j]
@@ -543,10 +543,10 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
 
             fits.writeto(os.path.join(result_dir, f"{DM_name}_strokes.fits"), DMstrokes[j], header, overwrite=True)
 
-            voltage_DMs_tosave = testbed.testbed_voltage_to_indiv_DM_voltage(voltage_DMs_nparray, DM_name)
+            command_DMs_tosave = testbed.testbed_command_to_indiv_DM_command(command_DMs_nparray, DM_name)
 
-            fits.writeto(os.path.join(result_dir, f"{DM_name}_voltages.fits"),
-                         voltage_DMs_tosave,
+            fits.writeto(os.path.join(result_dir, f"{DM_name}_command.fits"),
+                         command_DMs_tosave,
                          header,
                          overwrite=True)
 

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -93,10 +93,7 @@ class Corrector:
         self.correction_algorithm = Correctionconfig["correction_algorithm"].lower()
         self.SmallPhaseHypEFC = Correctionconfig["SmallPhaseHypEFC"]
 
-        if basis_type == 'actuator':
-            self.amplitudeEFC = Correctionconfig["amplitudeEFC"]
-        else:
-            self.amplitudeEFC = 1.
+        self.amplitudeEFC = Correctionconfig["amplitudeEFC"]
 
         if self.correction_algorithm == "sm":
             self.expected_gain_in_contrast = 0.1
@@ -376,7 +373,7 @@ class Corrector:
 
             #     indice_acum_number_act += DM.number_act
 
-            return -self.amplitudeEFC * solutionefc
+            return - solutionefc
 
         if self.correction_algorithm == "sm":
             # see Mazoyer et al 2018 ACAD-OSM I paper to understand algorithm
@@ -442,7 +439,7 @@ class Corrector:
 
             #     indice_acum_number_act += DM.number_act
 
-            return -self.amplitudeEFC * solutionSM
+            return - solutionSM
 
         if self.correction_algorithm == "em":
 
@@ -450,10 +447,10 @@ class Corrector:
                 self.previousmode = mode
                 _, _, self.invertM0 = invert_svd(self.M0, mode, goal="c", regul=self.regularization, silence=True)
 
-            return -self.amplitudeEFC * wfc.calc_em_solution(self.MaskEstim, estimate, self.invertM0, self.G, testbed)
+            return - wfc.calc_em_solution(self.MaskEstim, estimate, self.invertM0, self.G, testbed)
 
         if self.correction_algorithm == "steepest":
 
-            return -self.amplitudeEFC * wfc.calc_steepest_solution(self.MaskEstim, estimate, self.M0, self.G, testbed)
+            return - wfc.calc_steepest_solution(self.MaskEstim, estimate, self.M0, self.G, testbed)
         else:
             raise NotImplementedError("This correction algorithm is not yet implemented")

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -22,7 +22,7 @@ class Corrector:
             The initialization requires previous initialization of
             the testbed and of the estimator.
 
-        - a correction function Corrector.toDM_voltage(estimation), which returns the DM Voltage vector
+        - a correction function Corrector.toDM_command(estimation), which returns the DM command
             using as parameter the estimation (2D array or 3D for polychromatic correction).
             It can one DM or more, depending on the testbed.
 
@@ -233,7 +233,7 @@ class Corrector:
         # Adding error on the DM model. Now that the matrix is measured, we can
         # introduce a small movememnt on one DM or the other. By changing DM_pushact
         # we are changing the position of the actuator and therfore the phase of the
-        # DM for a given voltage when using DM.voltage_to_phase
+        # DM for a given command when using DM.dmcommand_to_phase
 
         for DM_name in testbed.name_of_DMs:
             DM: DeformableMirror = vars(testbed)[DM_name]
@@ -250,7 +250,7 @@ class Corrector:
     def update_matrices(self,
                         testbed: Testbed,
                         maskEstim=None,
-                        initial_DM_voltage=0.,
+                        initial_DM_command=0.,
                         initial_estimated_wavefront=1.,
                         silence=False):
         """Measure the interaction matrices needed for the correction Is launch
@@ -266,8 +266,8 @@ class Corrector:
         maskEstim : 2d numpy array
             binary array of size [dimEstim, dimEstim] : dark hole mask. If undefined, it
             will use the self.MaskEstim attribute defined in the Corrector initialization.
-        initial_DM_voltage : 1D-array real
-            a vector voltage (for all DMs) around which the basis modes will be pushed to create the matrix.
+        initial_DM_command : 1D-array real
+            a command (for all DMs) around which the basis modes will be pushed to create the matrix.
         initial_estimated_wavefront : 2D complex array or complex scalar. Default is 1 (flat WF)
             a wavefront in pupil plane (likely estimated using some phase diversity) around
             which the basis modes will be pushed to create the matrix.
@@ -292,7 +292,7 @@ class Corrector:
                                                      self.dimEstim,
                                                      self.amplitudeEFC,
                                                      self.matrix_dir,
-                                                     initial_DM_voltage=initial_DM_voltage,
+                                                     initial_DM_command=initial_DM_command,
                                                      initial_estimated_wavefront=initial_estimated_wavefront,
                                                      SmallPhaseHypEFC=self.SmallPhaseHypEFC,
                                                      wav_vec_estim=self.wav_vec_estim,
@@ -320,8 +320,8 @@ class Corrector:
         else:
             raise NotImplementedError("This correction algorithm is not yet implemented")
 
-    def toDM_voltage(self, testbed: Testbed, estimate, mode=1, ActualCurrentContrast=1., silence=False, **kwargs):
-        """Run a correction from a estimate, and return the DM voltage
+    def toDM_command(self, testbed: Testbed, estimate, mode=1, ActualCurrentContrast=1., silence=False, **kwargs):
+        """Run a correction from a estimate, and return the DM command
         compatible with the testbed.
 
         AUTHOR : Johan Mazoyer
@@ -348,7 +348,7 @@ class Corrector:
         Return
         ----------
         solution : 1d numpy real float array
-            a voltage vector to be applied to the testbed
+            a command to be applied to the DMS of the testbed.
         """
 
         if self.correction_algorithm == "efc":

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -318,8 +318,7 @@ class Corrector:
             raise NotImplementedError("This correction algorithm is not yet implemented")
 
     def toDM_command(self, testbed: Testbed, estimate, mode=1, ActualCurrentContrast=1., silence=False, **kwargs):
-        """Run a correction from a estimate, and return the DM command
-        compatible with the testbed.
+        """ Measure and return appropriate tesbed DM command from an estimate.
 
         AUTHOR : Johan Mazoyer
 

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -65,7 +65,7 @@ class Corrector:
         save_for_bench : bool default: false
             should we save for the real testbed in realtestbed_dir
         realtestbed_dir : string
-            path to directory to save all the files the real testbed need
+            path to directory to save all the files the real testbed needs
         silence : boolean, default False.
             Whether to silence print outputs.
         """
@@ -264,7 +264,7 @@ class Corrector:
             binary array of size [dimEstim, dimEstim] : dark hole mask. If undefined, it
             will use the self.MaskEstim attribute defined in the Corrector initialization.
         initial_DM_command : 1D-array real
-            a command (for all DMs) around which the basis modes will be pushed to create the matrix.
+            a command (for all testbed DMs) around which the basis modes will be pushed to create the matrix.
         initial_estimated_wavefront : 2D complex array or complex scalar. Default is 1 (flat WF)
             a wavefront in pupil plane (likely estimated using some phase diversity) around
             which the basis modes will be pushed to create the matrix.
@@ -325,7 +325,7 @@ class Corrector:
         Parameters
         ----------
         testbed : OpticalSystem.Testbed
-            Testbed object which describe your testbed
+            Testbed object which describes your testbed
         estimate : list of 2D complex array
             list is the number of wl in the estimation, usually 1 or testbed.nb_wav
             Each arrays are of size of sixe [dimEstim, dimEstim].

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -20,8 +20,8 @@ class Estimator:
                 The estimator initialization requires previous initialization of the testbed.
 
             - an probe function Estimator.probe(), with parameters:
-                    - the entrance EF
-                    - DM voltages
+                    - the entrance EF at the time ot probing
+                    - the DM command at the time ot probing
                     - the estimation wavelengths
                 It returns the probed images as a list (of length nb_wav_estim) of
                 3d arrays (nprobes,dimEstim,dimEstim).
@@ -172,11 +172,11 @@ class Estimator:
 
             name_DM_to_probe_in_PW = Estimationconfig["name_DM_to_probe_in_PW"]
 
-            self.voltage_probes = wfs.generate_probe_voltages(testbed, posprobes, amplitudePW,
+            self.dmcommand_probes = wfs.generate_probe_command(testbed, posprobes, amplitudePW,
                                                                    name_DM_to_probe_in_PW)
 
             self.PWMatrix = wfs.create_pw_matrix(testbed,
-                                                 self.voltage_probes,
+                                                 self.dmcommand_probes,
                                                  self.dimEstim,
                                                  self.cutsvdPW,
                                                  wav_vec_estim=self.wav_vec_estim,
@@ -204,9 +204,9 @@ class Estimator:
                     for i in np.arange(len(posprobes)):
                         # TODO WTH is the hardcoded 17. @Raphael @Axel
                         if name_DM_to_probe_in_PW == 'DM1':
-                            probes[i, :] = self.voltage_probes[i][0:952] / 17
+                            probes[i, :] = self.dmcommand_probes[i][0:952] / 17
                         if name_DM_to_probe_in_PW == 'DM2':
-                            probes[i, :] = self.voltage_probes[i][952:] / 17
+                            probes[i, :] = self.dmcommand_probes[i][952:] / 17
                         vectorPW[0, i * self.dimEstim * self.dimEstim:(i + 1) * self.dimEstim *
                                  self.dimEstim] = self.PWMatrix[k][:, 0, i].flatten()
                         vectorPW[1, i * self.dimEstim * self.dimEstim:(i + 1) * self.dimEstim *
@@ -244,7 +244,7 @@ class Estimator:
         else:
             raise NotImplementedError("This estimation algorithm is not yet implemented")
 
-    def probe(self, testbed: Testbed, entrance_EF=1., voltage_vector=0., perfect_estimation=False, **kwargs):
+    def probe(self, testbed: Testbed, entrance_EF=1., dm_command=0., perfect_estimation=False, **kwargs):
         """Use the DM or the testbed to probe the aberrations with a given input wavefront and a
         state of the DMs.
 
@@ -256,8 +256,8 @@ class Estimator:
                 Testbed object which describe your testbed
         entrance_EF : complex float or 2D array, default 1.
             initial EF field
-        voltage_vector : 1D float array
-            vector of voltages vectors for each DMs
+        dm_command : 1D float array
+            dm_commands for the testbed when probing
         perfect_estimation : bool, default = False
             if true This is equivalent to have self.technique = "perfect"
             but even if we are using another technique, we sometimes
@@ -301,7 +301,7 @@ class Estimator:
                 for i, wavei in enumerate(self.wav_vec_estim):
                     resultatestimation = testbed.todetector(
                         entrance_EF=entrance_EF[testbed.wav_vec.tolist().index(wavei)],
-                        voltage_vector=voltage_vector,
+                        dm_command=dm_command,
                         wavelength=wavei)
                     probed_fp_images.append(resizing(resultatestimation, self.dimEstim))
 
@@ -313,7 +313,7 @@ class Estimator:
             elif self.polychrom == 'singlewl':
                 resultatestimation = testbed.todetector(entrance_EF=entrance_EF[testbed.wav_vec.tolist().index(
                     self.wav_vec_estim[0])],
-                                                        voltage_vector=voltage_vector,
+                                                        dm_command=dm_command,
                                                         wavelength=self.wav_vec_estim[0])
                 probed_fp_images.append(resizing(resultatestimation, self.dimEstim))
 
@@ -340,8 +340,8 @@ class Estimator:
                 for i, wavei in enumerate(self.wav_vec_estim):
                     probed_fp_images_i = wfs.simulate_pw_probes(entrance_EF[testbed.wav_vec.tolist().index(wavei)],
                                                                 testbed,
-                                                                self.voltage_probes,
-                                                                voltage_vector=voltage_vector,
+                                                                self.dmcommand_probes,
+                                                                dm_command=dm_command,
                                                                 wavelengths=wavei,
                                                                 pwp_or_btp=self.technique,
                                                                 **kwargs)
@@ -351,8 +351,8 @@ class Estimator:
                 probed_fp_images_i = wfs.simulate_pw_probes(entrance_EF[testbed.wav_vec.tolist().index(
                     self.wav_vec_estim[0])],
                                                             testbed,
-                                                            self.voltage_probes,
-                                                            voltage_vector=voltage_vector,
+                                                            self.dmcommand_probes,
+                                                            dm_command=dm_command,
                                                             wavelengths=self.wav_vec_estim[0],
                                                             pwp_or_btp=self.technique,
                                                             **kwargs)
@@ -361,8 +361,8 @@ class Estimator:
             elif self.polychrom == 'broadband_pwprobes':
                 probed_fp_images_i = wfs.simulate_pw_probes(entrance_EF,
                                                             testbed,
-                                                            self.voltage_probes,
-                                                            voltage_vector=voltage_vector,
+                                                            self.dmcommand_probes,
+                                                            dm_command=dm_command,
                                                             wavelengths=testbed.wav_vec,
                                                             pwp_or_btp=self.technique,
                                                             **kwargs)
@@ -412,7 +412,7 @@ class Estimator:
 
                 for i, wavei in enumerate(self.wav_vec_estim):
                     if self.technique in ["btp"]:
-                        differences = wfs.btp_difference(probed_fp_images[i], testbed, self.voltage_probes, wavei)
+                        differences = wfs.btp_difference(probed_fp_images[i], testbed, self.dmcommand_probes, wavei)
                     else:
                         differences = wfs.pw_difference(probed_fp_images[i])
 
@@ -429,7 +429,7 @@ class Estimator:
 
             elif self.polychrom in ['singlewl', 'broadband_pwprobes']:
                 if self.technique in ["btp"]:
-                    differences = wfs.btp_difference(probed_fp_images[0], testbed, self.voltage_probes,
+                    differences = wfs.btp_difference(probed_fp_images[0], testbed, self.dmcommand_probes,
                                                      self.wav_vec_estim[0])
                 else:
                     differences = wfs.pw_difference(probed_fp_images[0])

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -21,7 +21,7 @@ class Estimator:
 
             - an probe function Estimator.probe(), with parameters:
                     - the entrance EF at the time ot probing
-                    - the DM command at the time ot probing
+                    - the tesbed DM command at the time ot probing
                     - the estimation wavelengths
                 It returns the probed images as a list (of length nb_wav_estim) of
                 3d arrays (nprobes,dimEstim,dimEstim).
@@ -257,7 +257,7 @@ class Estimator:
         entrance_EF : complex float or 2D array, default 1.
             initial EF field
         dm_command : 1D float array
-            dm_commands for the testbed when probing
+            dm_commands for the testbed DMs when probing
         perfect_estimation : bool, default = False
             if true This is equivalent to have self.technique = "perfect"
             but even if we are using another technique, we sometimes
@@ -371,7 +371,7 @@ class Estimator:
         return probed_fp_images
 
     def estimate(self, probed_fp_images, perfect_estimation=False, dtype_complex='complex128', testbed=None, **kwargs):
-        """Run an estimation from a testbed, with a given input the probed images.
+        """Measure an estimation from a testbed, with a given input the probed images.
         For some estimation algorithms (btp) we need to use a model of the testbed.
 
         AUTHOR : Johan Mazoyer

--- a/Asterix/wfsc/estimator.py
+++ b/Asterix/wfsc/estimator.py
@@ -202,11 +202,11 @@ class Estimator:
                     vectorPW = np.zeros((2, self.dimEstim * self.dimEstim * len(posprobes)), dtype=np.float32)
 
                     for i in np.arange(len(posprobes)):
-                        # TODO WTH is the hardcoded 17. @Raphael @Axel
+
                         if name_DM_to_probe_in_PW == 'DM1':
-                            probes[i, :] = self.dmcommand_probes[i][0:952] / 17
+                            probes[i, :] = self.dmcommand_probes[i][0:952]
                         if name_DM_to_probe_in_PW == 'DM2':
-                            probes[i, :] = self.dmcommand_probes[i][952:] / 17
+                            probes[i, :] = self.dmcommand_probes[i][952:]
                         vectorPW[0, i * self.dimEstim * self.dimEstim:(i + 1) * self.dimEstim *
                                  self.dimEstim] = self.PWMatrix[k][:, 0, i].flatten()
                         vectorPW[1, i * self.dimEstim * self.dimEstim:(i + 1) * self.dimEstim *

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -18,7 +18,7 @@ def create_interaction_matrix(testbed: Testbed,
                               dimEstim,
                               amplitudeEFC,
                               matrix_dir,
-                              initial_DM_voltage=0.,
+                              initial_DM_command=0.,
                               initial_estimated_wavefront=1.,
                               SmallPhaseHypEFC=True,
                               wav_vec_estim=None,
@@ -55,12 +55,12 @@ def create_interaction_matrix(testbed: Testbed,
     SmallPhaseHypEFC : Bool, default True
         If True : when applying modes on the DMs we, do a small phase assumption : exp(i phi) = 1+ i.phi
         If False we keep exp(i phi).
-        In both case, if the DMs are not initially flat (non zero initial_DM_voltage),
+        In both case, if the DMs are not initially flat (non zero initial_DM_command),
         we do not make the small phase assumption for initial DM phase
     wav_vec_estim : list of wavelengths, default: [testbed.wavelength_0]
             vector of wavelengths for polychromatic correction
-    initial_DM_voltage : 1D-array real, default 1.0 (flat WF)
-        a vector voltage (for all DMs) around which the basis modes will be pushed to create the matrix.
+    initial_DM_command : 1D-array real, default 1.0 (flat WF)
+        a command (for all DMs in testbed) around which the basis modes will be pushed to create the matrix.
     initial_estimated_wavefront : complex scalar (uniform WF) or 2d complex array (monochromatic) or 3d complex array (polychromatic), default 1.
         a wavefront in pupil plane (likely estimated using some phase diversity) around
         which the basis modes will be pushed to create the matrix.
@@ -105,7 +105,7 @@ def create_interaction_matrix(testbed: Testbed,
                 amplitudeEFC,
                 wave_i,
                 matrix_dir,
-                initial_DM_voltage=initial_DM_voltage,
+                initial_DM_command=initial_DM_command,
                 initial_estimated_wavefront=initial_estimated_wavefront[testbed.wav_vec.tolist().index(wave_i)],
                 SmallPhaseHypEFC=SmallPhaseHypEFC,
                 dir_save_all_planes=dir_save_all_planes,
@@ -119,7 +119,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
                                        amplitudeEFC,
                                        wavelength,
                                        matrix_dir,
-                                       initial_DM_voltage=0.,
+                                       initial_DM_command=0.,
                                        initial_estimated_wavefront=1.,
                                        SmallPhaseHypEFC=True,
                                        dir_save_all_planes=None,
@@ -155,10 +155,10 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
     SmallPhaseHypEFC : Bool, default True
         If True : when applying modes on the DMs we, do a small phase assumption : exp(i phi) = 1+ i.phi
         If False we keep exp(i phi).
-        In both case, if the DMs are not initially flat (non zero initial_DM_voltage),
+        In both case, if the DMs are not initially flat (non zero initial_DM_command),
         we do not make the small phase assumption for initial DM phase
-    initial_DM_voltage : 1D-array real
-        a vector voltage (for all DMs) around which the basis modes will be pushed to create the matrix.
+    initial_DM_command : 1D-array real
+        a command (for all DMs in testbed) around which the basis modes will be pushed to create the matrix.
     initial_estimated_wavefront : 2D complex array or complex scalar. Default is 1 (flat WF)
         a wavefront in pupil plane (likely estimated using some phase diversity) around
         which the basis modes will be pushed to create the matrix.
@@ -175,15 +175,15 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
     InterMat : 2D array of size [total(DM.basis_size), 2*dimEstim^2]
         jacobian matrix for Electric Field Conjugation.
     """
-    if isinstance(initial_DM_voltage, (int, float)):
-        initial_DM_voltage = np.zeros(testbed.number_act) + float(initial_DM_voltage)
+    if isinstance(initial_DM_command, (int, float)):
+        initial_DM_command = np.zeros(testbed.number_act) + float(initial_DM_command)
 
     # wavelength = testbed.wavelength_0
     normalisation_testbed_EF_contrast = np.sqrt(testbed.norm_monochrom[testbed.wav_vec.tolist().index(wavelength)])
 
-    # This is for the case we take a non zero DM vectors already, we need to calculate
+    # This is for the case we take a non zero DM command already, we need to calculate
     # the initial phase for each DM
-    DM_phase_init = testbed.voltage_to_phases(initial_DM_voltage)
+    DM_phase_init = testbed.dmcommands_to_phases(initial_DM_command)
 
     # First run throught the DMs to :
     #   - string matrix to create a name for the matrix
@@ -215,12 +215,12 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
 
         DM.fnameDirectMatrix = os.path.join(matrix_dir, fileDirectMatrix + ".fits")
 
-        # We only save the 'first' matrix meaning the one with no initial DM voltages
-        # Matrix is saved/loaded for each DM independetly which allow quick switch
+        # We only save the 'first' matrix meaning the one with no initial DM command
+        # Matrix is saved/loaded for each DM independently which allow quick switch
         # For 1DM test / 2DM test
         # Matrix is saved/loaded for all the FP and then crop at the good size later
 
-        if bool_already_existing_matrix and (initial_DM_voltage == 0.).all():
+        if bool_already_existing_matrix and (initial_DM_command == 0.).all():
             if not silence:
                 print("Load " + fileDirectMatrix + ".fits file")
 
@@ -235,10 +235,10 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
             # We checked that this is the same normalization as in Gvector
             G0 = resizing(
                 testbed.todetector(entrance_EF=initial_estimated_wavefront,
-                                   voltage_vector=initial_DM_voltage,
+                                   dm_command=initial_DM_command,
                                    dir_save_all_planes=dir_save_all_planes), dimEstim)
             if not silence:
-                if (initial_DM_voltage == 0.).all():
+                if (initial_DM_command == 0.).all():
                     print("")
                     print("The matrix " + fileDirectMatrix + " does not exists")
 
@@ -256,7 +256,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
             else:
                 phasesBasis = np.zeros((DM.basis_size, DM.dim_overpad_pupil, DM.dim_overpad_pupil))
                 for i in range(DM.basis_size):
-                    phasesBasis[i] = DM.voltage_to_phase(DM.basis[i]) * amplitudeEFC
+                    phasesBasis[i] = DM.dmcommand_to_phase(DM.basis[i]) * amplitudeEFC
 
             if dir_save_all_planes is not None:
                 # save the basis phase to check what is happening
@@ -427,7 +427,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
 
                 # TODO Should we remove the intial FP field G0 in all casese ? For ideal
                 # corono and flat DMs, this is 0, but it's not for non ideal coronagraph
-                # or if we have a strong initial DM voltages. This needs
+                # or if we have a strong initial DM command. This needs
                 # to be investigated, in simulation and on the testbed
                 Gvector = Gvector - G0
 
@@ -451,7 +451,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
                 plt.close()
                 plt.ioff()
             # We save the interaction matrix:
-            if (initial_DM_voltage == 0.).all():
+            if (initial_DM_command == 0.).all():
                 fits.writeto(os.path.join(matrix_dir, fileDirectMatrix + ".fits"),
                              InterMat[:, pos_in_matrix:pos_in_matrix + DM.basis_size],
                              header=header_expected,
@@ -612,7 +612,7 @@ def crop_interaction_matrix_to_dh(FullInteractionMatrix: np.ndarray, mask: np.nd
 
 
 def calc_efc_solution(mask, Result_Estimate, inversed_jacobian, testbed: Testbed):
-    """Voltages to apply on the deformable mirrors in order to minimize the
+    """Command to apply on the deformable mirrors in order to minimize the
     speckle intensity in the dark hole region.
 
     AUTHOR : Axel Potier
@@ -633,7 +633,7 @@ def calc_efc_solution(mask, Result_Estimate, inversed_jacobian, testbed: Testbed
     Returns
     --------
     solution : 1D array
-        voltage to apply on each deformable mirror actuator
+        command to apply on the deformable mirrors (nm)
     """
     EF_vector = np.zeros(2 * int(np.sum(mask)) * len(Result_Estimate))
 
@@ -646,11 +646,11 @@ def calc_efc_solution(mask, Result_Estimate, inversed_jacobian, testbed: Testbed
 
     produit_mat = np.dot(inversed_jacobian, EF_vector)
 
-    return testbed.basis_vector_to_act_vector(produit_mat)
+    return testbed.basis_vector_to_dmcommand(produit_mat)
 
 
 def calc_em_solution(mask, Result_Estimate, Hessian_Matrix, Jacobian, testbed: Testbed):
-    """Voltage to apply on the deformable mirror in order to minimize the
+    """Command to apply on the deformable mirrors in order to minimize the
     speckle intensity in the dark hole region.
 
     AUTHOR : Axel Potier
@@ -673,7 +673,7 @@ def calc_em_solution(mask, Result_Estimate, Hessian_Matrix, Jacobian, testbed: T
     Returns
     --------
     solution : 1D array
-        Voltage to apply on each deformable mirror actuator.
+        Command to apply on the deformable mirrors (nm).
     """
     if len(Result_Estimate) > 1:
         raise ValueError("EM correction is not working in polychromatic mode.")
@@ -683,7 +683,7 @@ def calc_em_solution(mask, Result_Estimate, Hessian_Matrix, Jacobian, testbed: T
     realb0 = np.real(np.dot(np.transpose(np.conjugate(Jacobian)), Eab)).flatten()
     produit_mat = np.dot(Hessian_Matrix, realb0)
 
-    return testbed.basis_vector_to_act_vector(produit_mat)
+    return testbed.basis_vector_to_dmcommand(produit_mat)
 
 
 def calc_strokemin_solution(mask,
@@ -694,7 +694,7 @@ def calc_strokemin_solution(mask,
                             last_best_alpha,
                             testbed: Testbed,
                             silence=False):
-    """Voltage to apply on the deformable mirror in order to minimize the
+    """Command to apply on the deformable mirrors in order to minimize the
     speckle intensity in the dark hole region in the stroke min solution See
     Axel Potier Phd for notation and Mazoyer et al. 2018a for alpha search
     improvement.
@@ -725,7 +725,7 @@ def calc_strokemin_solution(mask,
     Returns
     --------
     solution : 1D array
-        Voltage to apply on each deformable mirror actuator.
+        Command to apply on the deformable mirrors (nm).
     lasbestalpha : float
         The last best alpha. This avoid to recalculate the best alpha from scratch
         at each iteration since it's often a very close value.
@@ -797,11 +797,11 @@ def calc_strokemin_solution(mask,
             TestSMfailed = False
     if not silence:
         print(f"Number of iterations in this stroke min (number of tested alpha): {iteralpha:d}")
-    return testbed.basis_vector_to_act_vector(DMSurfaceCoeff), alpha
+    return testbed.basis_vector_to_dmcommand(DMSurfaceCoeff), alpha
 
 
 def calc_steepest_solution(mask, Result_Estimate, Hessian_Matrix, Jacobian, testbed: Testbed):
-    """Voltage to apply on the deformable mirror in order to minimize the
+    """Command to apply on the deformable mirrors in order to minimize the
     speckle intensity in the dark hole region.
 
     AUTHOR : Axel Potier
@@ -824,7 +824,7 @@ def calc_steepest_solution(mask, Result_Estimate, Hessian_Matrix, Jacobian, test
     Returns
     --------
     solution : 1D array
-        Voltage to apply on each deformable mirror actuator.
+        Command to apply on the deformable mirrors (nm).
     """
     if len(Result_Estimate) > 1:
         raise ValueError("Steepest correction is not working in polychromatic mode.")
@@ -835,7 +835,7 @@ def calc_steepest_solution(mask, Result_Estimate, Hessian_Matrix, Jacobian, test
     pas = 2e3
     solution = pas * 2 * Eab
 
-    return testbed.basis_vector_to_act_vector(solution)
+    return testbed.basis_vector_to_dmcommand(solution)
 
 
 # def concat_flat_real_imag(complex_arr):

--- a/Asterix/wfsc/wf_control_functions.py
+++ b/Asterix/wfsc/wf_control_functions.py
@@ -49,7 +49,7 @@ def create_interaction_matrix(testbed: Testbed,
     dimEstim : int
         size of the output image in teh estimator
     amplitudeEFC : float
-        amplitude of the EFC probe on the DM
+        amplitude of the DM basis vector maximum during EFC matrix measure (nm).
     matrix_dir : string
         path to directory to save all the matrices here
     SmallPhaseHypEFC : Bool, default True
@@ -147,7 +147,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
     dimEstim: int
         size of the output image in teh estimator
     amplitudeEFC: float
-        amplitude of the EFC probe on the DM
+        amplitude of the DM basis vector maximum during EFC matrix measure (nm).
     wavelength : float
         wavelength in m.
     matrix_dir : string
@@ -256,7 +256,7 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
             else:
                 phasesBasis = np.zeros((DM.basis_size, DM.dim_overpad_pupil, DM.dim_overpad_pupil))
                 for i in range(DM.basis_size):
-                    phasesBasis[i] = DM.dmcommand_to_phase(DM.basis[i]) * amplitudeEFC
+                    phasesBasis[i] = DM.dmcommand_to_phase(DM.basis[i] * amplitudeEFC)
 
             if dir_save_all_planes is not None:
                 # save the basis phase to check what is happening
@@ -429,7 +429,9 @@ def create_singlewl_interaction_matrix(testbed: Testbed,
                 # corono and flat DMs, this is 0, but it's not for non ideal coronagraph
                 # or if we have a strong initial DM command. This needs
                 # to be investigated, in simulation and on the testbed
-                Gvector = Gvector - G0
+                # normalise the matrix by the amplitude of the push so that the resulting
+                # dm command are in nm.
+                Gvector = (Gvector - G0) / amplitudeEFC
 
                 if dir_save_all_planes is not None:
                     name_plane = 'Gvector_in_matrix_' + osname + f'_wl{int(wavelength * 1e9)}'

--- a/Asterix/wfsc/wf_sensing_functions.py
+++ b/Asterix/wfsc/wf_sensing_functions.py
@@ -11,12 +11,12 @@ import Asterix.optics.propagation_functions as prop
 
 
 def create_pw_matrix(testbed: Testbed,
-                     voltage_probes,
+                     dmcommand_probes,
                      dimEstim,
                      cutsvd,
                      wav_vec_estim=None,
                      matrix_dir=None,
-                     initial_DM_voltage=0.,
+                     initial_DM_command=0.,
                      initial_estimated_wavefront=1.,
                      SmallPhaseHypPWP=True,
                      silence=False,
@@ -33,16 +33,16 @@ def create_pw_matrix(testbed: Testbed,
         a testbed with one or more DM
     amplitude : float
         amplitude of the actuator pokes for pair(wise probing in nm
-    voltage_probes : 2D float array of size [len(posprobes), testbed.number_actuators]
-        Array of voltages vectors for each probes
+    dmcommand_probes : 2D float array of size [len(posprobes), testbed.number_actuators]
+        Array of dm commands for each probe
     dimEstim :  int
         size of the output image after resizing in pixels
     cutsvd : float
         value not to exceed for the inverse eigeinvalues at each pixels
     matrix_dir : string, default None
         path to directory to save all the matrices here. If None, matrix is not saved.
-    initial_DM_voltage : 1D-array real, default 1.0 (flat WF)
-        a vector voltage (for all DMs) around which the probes will be pushed to create the matrix.
+    initial_DM_command : 1D-array real, default 1.0 (flat WF)
+        a command (for all DMs in testbed) around which the probes will be pushed to create the matrix.
     initial_estimated_wavefront : complex scalar (uniform WF) or 2d complex array (monochromatic) or 3d complex array (polychromatic), default 1.
         a wavefront in pupil plane (likely estimated using some phase diversity) around
         which the probes will be pushed to create the matrix.
@@ -51,7 +51,7 @@ def create_pw_matrix(testbed: Testbed,
     SmallPhaseHypPWP : Bool, default True
         If True : when applying probe on the DMs we, do a small phase assumption : exp(i phi_probe) = 1+ i.phi_probe
         If False (we keep exp(i phi_probe)).
-        In both case, if the DMs are not initially flat (non zero initial_DM_voltage/initial_estimated_wavefront),
+        In both case, if the DMs are not initially flat (non zero initial_DM_command/initial_estimated_wavefront),
         we do not make the small phase assumption for initial DM phase
     silence : boolean, default False.
         Whether to silence print outputs.
@@ -70,12 +70,12 @@ def create_pw_matrix(testbed: Testbed,
     for wave_i in wav_vec_estim:
         return_matrix.append(
             create_singlewl_pw_matrix(testbed,
-                                      voltage_probes,
+                                      dmcommand_probes,
                                       dimEstim,
                                       cutsvd,
                                       wave_i,
                                       matrix_dir=matrix_dir,
-                                      initial_DM_voltage=initial_DM_voltage,
+                                      initial_DM_command=initial_DM_command,
                                       initial_estimated_wavefront=initial_estimated_wavefront,
                                       SmallPhaseHypPWP=SmallPhaseHypPWP,
                                       silence=silence,
@@ -85,12 +85,12 @@ def create_pw_matrix(testbed: Testbed,
 
 
 def create_singlewl_pw_matrix(testbed: Testbed,
-                              voltage_probes,
+                              dmcommand_probes,
                               dimEstim,
                               cutsvd,
                               wavelength,
                               matrix_dir=None,
-                              initial_DM_voltage=0.,
+                              initial_DM_command=0.,
                               initial_estimated_wavefront=1.,
                               SmallPhaseHypPWP=True,
                               silence=False,
@@ -108,8 +108,8 @@ def create_singlewl_pw_matrix(testbed: Testbed,
         a testbed with one or more DM
     amplitude : float
         amplitude of the actuator pokes for pair(wise probing in nm
-    voltage_probes : 2D float array of size [len(posprobes), testbed.number_actuators]
-        Array of voltages vectors for each probes
+    dmcommand_probes : 2D float array of size [len(posprobes), testbed.number_actuators]
+        Array of dm commands for each probe
     dimEstim : int
         size of the output image after resizing in pixels
     cutsvd : float
@@ -118,15 +118,15 @@ def create_singlewl_pw_matrix(testbed: Testbed,
         wavelength in m.
     matrix_dir : string, default None
         path to directory to save all the matrices here. If None, matrix is not saved.
-    initial_DM_voltage : 1D-array real, default 1.0 (flat WF)
-        a vector voltage (for all DMs) around which the probes will be pushed to create the matrix.
+    initial_DM_command : 1D-array real, default 1.0 (flat WF)
+        a command (for all DMs in testbed) around which the probes will be pushed to create the matrix.
     initial_estimated_wavefront : complex scalar (uniform WF) or 2d complex array (monochromatic) or 3d complex array (polychromatic), default 1.
         a wavefront in pupil plane (likely estimated using some phase diversity) around
         which the probes will be pushed to create the matrix.
     SmallPhaseHypPWP : Bool, default True
         If True : when applying probe on the DMs we, do a small phase assumption : exp(i phi_probe) = 1+ i.phi_probe
         If False (we keep exp(i phi_probe)).
-        In both case, if the DMs are not initially flat (non zero initial_DM_voltage/initial_estimated_wavefront),
+        In both case, if the DMs are not initially flat (non zero initial_DM_command/initial_estimated_wavefront),
         we do not make the small phase assumption for initial DM phase
     silence : boolean, default False.
         Whether to silence print outputs.
@@ -146,7 +146,7 @@ def create_singlewl_pw_matrix(testbed: Testbed,
         print("The PWmatrix " + filePW)
         print("Start PWP matrix" + ' at ' + str(int(wavelength * 1e9)) + "nm (wait a few seconds)")
 
-    numprobe = len(voltage_probes)
+    numprobe = len(dmcommand_probes)
     deltapsik = np.zeros((numprobe, dimEstim, dimEstim), dtype=testbed.dtype_complex)
     matrix = np.zeros((numprobe, 2))
     PWMatrix = np.zeros((dimEstim**2, 2, numprobe))
@@ -154,20 +154,20 @@ def create_singlewl_pw_matrix(testbed: Testbed,
 
     psi0 = testbed.todetector(entrance_EF=initial_estimated_wavefront,
                               wavelength=wavelength,
-                              voltage_vector=initial_DM_voltage,
+                              dm_command=initial_DM_command,
                               in_contrast=True)
 
     k = 0
 
-    for voltage_probe in voltage_probes:
+    for dmcommand_probe in dmcommand_probes:
 
         if not SmallPhaseHypPWP:
             # easy case, we just send the probe phase to the DM by changing the
-            # testbed voltage.
+            # testbed DM command.
             # **kwarg is here to send dir_save_all_planes
             deltapsik[k] = resizing(
                 testbed.todetector(entrance_EF=initial_estimated_wavefront,
-                                   voltage_vector=initial_DM_voltage + voltage_probe,
+                                   dm_command=initial_DM_command + dmcommand_probe,
                                    wavelength=wavelength,
                                    in_contrast=True,
                                    **kwargs) - psi0, dimEstim)
@@ -176,13 +176,13 @@ def create_singlewl_pw_matrix(testbed: Testbed,
             # to identify the right plane and therefore the DM used to probe
             for DM_name in testbed.name_of_DMs:
                 DM: DeformableMirror = vars(testbed)[DM_name]
-                indiv_DM_voltage_probe = testbed.testbed_voltage_to_indiv_DM_voltage(voltage_probe, DM_name)
-                if (indiv_DM_voltage_probe == 0).all():
+                indiv_DM_dmcommand_probe = testbed.testbed_command_to_indiv_DM_command(dmcommand_probe, DM_name)
+                if (indiv_DM_dmcommand_probe == 0).all():
                     # this is not the probing DM, going to next DM
                     continue
                 else:
                     # this is the probing DM
-                    indiv_DM_phase_probe = DM.voltage_to_phase(indiv_DM_voltage_probe)
+                    indiv_DM_phase_probe = DM.dmcommand_to_phase(indiv_DM_dmcommand_probe)
                     if DM.z_position == 0:
                         # probing DM is in PP, easy
                         # I tried to remove "1+"". It breaks the code
@@ -190,7 +190,7 @@ def create_singlewl_pw_matrix(testbed: Testbed,
                         deltapsik[k] = resizing(
                             testbed.todetector(
                                 entrance_EF=(1 + 1j * indiv_DM_phase_probe) * initial_estimated_wavefront,
-                                voltage_vector=initial_DM_voltage,
+                                dm_command=initial_DM_command,
                                 wavelength=wavelength,
                                 in_contrast=True,
                                 **kwargs) - psi0, dimEstim)
@@ -199,13 +199,13 @@ def create_singlewl_pw_matrix(testbed: Testbed,
                         # but there is really no simple way to introduce an EF in this plane
                         # with the current formalism, unless we use the fresnel prop directly.
 
-                        # we isolate the phase introduced by the probing DM initial voltage
-                        if isinstance(initial_DM_voltage, (int, float)):
-                            initial_probingDM_voltage = np.zeros(DM.number_act) + float(initial_DM_voltage)
+                        # we isolate the phase introduced by the probing DM initial command
+                        if isinstance(initial_DM_command, (int, float)):
+                            initial_probingDM_command = np.zeros(DM.number_act) + float(initial_DM_command)
                         else:
-                            initial_probingDM_voltage = testbed.testbed_voltage_to_indiv_DM_voltage(
-                                initial_DM_voltage, DM_name)
-                        initial_probingDM_phase = DM.voltage_to_phase(initial_probingDM_voltage)
+                            initial_probingDM_command = testbed.testbed_command_to_indiv_DM_command(
+                                initial_DM_command, DM_name)
+                        initial_probingDM_phase = DM.dmcommand_to_phase(initial_probingDM_command)
 
                         wf_probing_DM = crop_or_pad_image(
                             prop.prop_angular_spectrum(
@@ -217,12 +217,12 @@ def create_singlewl_pw_matrix(testbed: Testbed,
                                 DM.prad,
                                 dtype_complex=DM.dtype_complex), DM.dim_overpad_pupil)
 
-                        # We propagate but remove from initial_DM_voltage the part that was already introduced by the probing DM
+                        # We propagate but remove from initial_DM_command the part that was already introduced by the probing DM
                         deltapsik[k] = resizing(
                             testbed.todetector(
                                 entrance_EF=initial_estimated_wavefront * wf_probing_DM,
-                                voltage_vector=initial_DM_voltage -
-                                testbed.indiv_DM_voltage_to_testbed_voltage(initial_probingDM_voltage, DM_name),
+                                dm_command=initial_DM_command -
+                                testbed.indiv_DM_command_to_testbed_command(initial_probingDM_command, DM_name),
                                 wavelength=wavelength,
                                 in_contrast=True,
                                 **kwargs) - psi0, dimEstim)
@@ -421,7 +421,7 @@ def calculate_pw_estimate(Difference,
                          "or 'btp' for Borde Traub Probing")
 
 
-def generate_probe_voltages(testbed: Testbed, posprobes, amplitudePW, name_DM_to_probe_in_PW):
+def generate_probe_command(testbed: Testbed, posprobes, amplitudePW, name_DM_to_probe_in_PW):
     """Generate the DM commands for each probes.
 
     Parameters
@@ -435,8 +435,8 @@ def generate_probe_voltages(testbed: Testbed, posprobes, amplitudePW, name_DM_to
 
     Returns
     --------
-    voltage_probes : 2D float array of size [len(posprobes), testbed.number_actuators]
-        Array of voltages vectors for each probes
+    dmcommand_probes : 2D float array of size [len(posprobes), testbed.number_actuators]
+        Array of testbed dm commands for each probes
     """
 
     # Checking which type of probes is used
@@ -501,18 +501,17 @@ def generate_probe_voltages(testbed: Testbed, posprobes, amplitudePW, name_DM_to
     else:
         raise ValueError(f"Probe type: " + probe_type + " => does not exist")
 
-    voltage_probes = np.zeros((len(posprobes), testbed.number_act))
+    dmcommand_probes = np.zeros((len(posprobes), testbed.number_act))
     for count, num_probe in enumerate(posprobes):
-        voltage_probes[count] = testbed.indiv_DM_voltage_to_testbed_voltage(probes_flatten[count],
-                                                                            name_DM_to_probe_in_PW)
+        dmcommand_probes[count] = testbed.indiv_DM_command_to_testbed_command(probes_flatten[count], name_DM_to_probe_in_PW)
 
-    return voltage_probes
+    return dmcommand_probes
 
 
 def simulate_pw_probes(input_wavefront,
                        testbed: Testbed,
-                       voltage_probes,
-                       voltage_vector=0.,
+                       dmcommand_probes,
+                       dm_command=0.,
                        wavelengths=None,
                        pwp_or_btp="pwp",
                        **kwargs):
@@ -524,10 +523,10 @@ def simulate_pw_probes(input_wavefront,
         Input wavefront in pupil plane.
     testbed : Testbed Optical_element
         Testbed with one or more DM.
-    voltage_probes : 2D float array of size [len(posprobes), testbed.number_actuators]
-        Array of voltages vectors for each probes
-    voltage_vector : 1D float array or float, default 0
-        Vector of voltages vectors for each DMs arounf which we do the difference.
+    dmcommand_probes : 2D float array of size [len(posprobes), testbed.number_actuators]
+        Array of dm commands for each probe
+    dm_command : 1D float array or float, default 0
+        a command (for all DMs in testbed) around which the probes will be pushed/pulled.
     wavelengths : float or list of floats, default None
         Wavelengths of the probes in m.
     pwp_or_btp : string, default 'pwp'
@@ -541,7 +540,7 @@ def simulate_pw_probes(input_wavefront,
         Cube with all probed images. Use for pair-wise probing.
     """
 
-    number_probes = len(voltage_probes)
+    number_probes = len(dmcommand_probes)
 
     if pwp_or_btp == 'btp':
         Probed_images = np.zeros((1 + number_probes, testbed.dimScience, testbed.dimScience))
@@ -554,7 +553,7 @@ def simulate_pw_probes(input_wavefront,
             # It's either a monochromatic correction, or a polychromatic correction with
             # case polychromatic = 'broadband_pwprobes'
             Ik0 = testbed.todetector_intensity(entrance_EF=input_wavefront,
-                                               voltage_vector=voltage_vector,
+                                               dm_command=dm_command,
                                                wavelengths=wavelengths,
                                                **kwargs)
         elif isinstance(wavelengths, (float, int)) and wavelengths in testbed.wav_vec:
@@ -562,7 +561,7 @@ def simulate_pw_probes(input_wavefront,
             # case polychromatic = 'singlewl' or polychromatic = 'multiwl'
             Ik0 = testbed.todetector_intensity(
                 entrance_EF=input_wavefront,
-                voltage_vector=voltage_vector,
+                dm_command=dm_command,
                 wavelengths=wavelengths,
                 in_contrast=False,
                 **kwargs) / testbed.norm_monochrom[testbed.wav_vec.tolist().index(wavelengths)]
@@ -574,7 +573,7 @@ def simulate_pw_probes(input_wavefront,
         raise ValueError("pwp_or_btp parameter can only take 2 values 'pwp', 'pairwise' for"
                          "Pair Wise Probing or 'btp' for Borde Traub Probing")
 
-    for count, Voltage_probe in enumerate(voltage_probes):
+    for count, dmcommand_probe in enumerate(dmcommand_probes):
 
         # If we are in a polychromatic mode but we need monochromatic instensity
         # we have to be careful with the normalization, because
@@ -584,13 +583,13 @@ def simulate_pw_probes(input_wavefront,
             # It's either a monochromatic correction, or a polychromatic correction with
             # case polychromatic = 'broadband_pwprobes'
             Ikplus = testbed.todetector_intensity(entrance_EF=input_wavefront,
-                                                  voltage_vector=voltage_vector + Voltage_probe,
+                                                  dm_command=dm_command + dmcommand_probe,
                                                   wavelengths=wavelengths,
                                                   **kwargs)
 
             if pwp_or_btp in ['pw', "pwp", 'pairwise']:
                 Ikmoins = testbed.todetector_intensity(entrance_EF=input_wavefront,
-                                                       voltage_vector=voltage_vector - Voltage_probe,
+                                                       dm_command=dm_command - dmcommand_probe,
                                                        wavelengths=wavelengths,
                                                        **kwargs)
 
@@ -599,7 +598,7 @@ def simulate_pw_probes(input_wavefront,
             # case polychromatic = 'singlewl' or polychromatic = 'multiwl'
             Ikplus = testbed.todetector_intensity(
                 entrance_EF=input_wavefront,
-                voltage_vector=voltage_vector + Voltage_probe,
+                dm_command=dm_command + dmcommand_probe,
                 wavelengths=wavelengths,
                 in_contrast=False,
                 **kwargs) / testbed.norm_monochrom[testbed.wav_vec.tolist().index(wavelengths)]
@@ -607,7 +606,7 @@ def simulate_pw_probes(input_wavefront,
             if pwp_or_btp in ['pw', "pwp", 'pairwise']:
                 Ikmoins = testbed.todetector_intensity(
                     entrance_EF=input_wavefront,
-                    voltage_vector=voltage_vector - Voltage_probe,
+                    dm_command=dm_command - dmcommand_probe,
                     wavelengths=wavelengths,
                     in_contrast=False,
                     **kwargs) / testbed.norm_monochrom[testbed.wav_vec.tolist().index(wavelengths)]
@@ -626,17 +625,17 @@ def simulate_pw_probes(input_wavefront,
     return Probed_images
 
 
-def btp_difference(Probed_images, testbed: Testbed, voltage_probes, wavelengths=None):
+def btp_difference(Probed_images, testbed: Testbed, dmcommand_probes, wavelengths=None):
     """ make the difference [I(+probe) - I(0) - psi_k_model] for borde and traub probing.
 
     Parameters
     ----------
     testbed : Testbed Optical_element
         Testbed with one or more DM.
-    voltage_probes : 2D float array of size [len(posprobes), testbed.number_actuators]
-        Array of voltages vectors for each probes
-    voltage_vector : 1D float array or float, default 0
-        Vector of voltages vectors for each DMs arounf which we do the difference.
+    dmcommand_probes : 2D float array of size [len(posprobes), testbed.number_actuators]
+        Array of dm commands for each probe
+    dm_command : 1D float array or float, default 0
+        a command (for all DMs in testbed) around which the probes will be pushed/pulled.
     wavelengths : float, default None
         Wavelength of the estimation in m.
 
@@ -646,18 +645,18 @@ def btp_difference(Probed_images, testbed: Testbed, voltage_probes, wavelengths=
         Cube with image difference for each probes. Use for pair-wise probing.
     """
 
-    Difference = np.zeros((len(voltage_probes), testbed.dimScience, testbed.dimScience))
+    Difference = np.zeros((len(dmcommand_probes), testbed.dimScience, testbed.dimScience))
 
-    for count, voltage_probe in enumerate(voltage_probes):
+    for count, dmcommand_probe in enumerate(dmcommand_probes):
 
         # we find the DM used to probe
         for DM_name in testbed.name_of_DMs:
             DM: DeformableMirror = vars(testbed)[DM_name]
-            DMvoltage = testbed.testbed_voltage_to_indiv_DM_voltage(voltage_probe, DM_name)
-            if (DMvoltage == 0).all():
+            dmcommand = testbed.testbed_command_to_indiv_DM_command(dmcommand_probe, DM_name)
+            if (dmcommand == 0).all():
                 continue
             else:
-                probephase = DM.voltage_to_phase(DMvoltage)
+                probephase = DM.dmcommand_to_phase(dmcommand)
                 break
 
         # If we are in a polychromatic mode but we need monochromatic instensity

--- a/docs/correction.rst
+++ b/docs/correction.rst
@@ -7,8 +7,8 @@ This section describes how to correct the electrical field in the focal plane in
 are possible in Asterix:
 
 - an initialization (e.g. Jacobian matrix) ``Corrector.__init__`` : The initialization requires previous initialization of the testbed and of the estimator.
-- a matrix update function ``Corrector.update_matrices`` This function is called once during initialization and then each time we need to recompute the Jacobian in the middle of the correction using different DM voltages as the starting point. It can also be used to update the dark-hole mask.
-- a correction function ``Corrector.toDM_voltage`` which takes the results of an estimation and returns the DM voltages.
+- a matrix update function ``Corrector.update_matrices`` This function is called once during initialization and then each time we need to recompute the Jacobian in the middle of the correction using different DM command as the starting point. It can also be used to update the dark-hole mask.
+- a correction function ``Corrector.toDM_command`` which takes the results of an estimation and returns the DM command (in nm).
 
 Dark Hole Mask Definition
 +++++++++++++++++++++++++++++++
@@ -71,7 +71,7 @@ There are two main parameters for this part:
 - ``SmallPhaseHypEFC`` is defining the if we do the small phase hypothesis for the basis vectors in the EFC matrix. 
     If True : when applying modes on the DMs we, do a small phase assumption : exp(i phi) = 1+ i.phi
     If False : we keep exp(i phi).
-    In both case, if the DMs are not initially flat (non zero initial_DM_voltage),
+    In both case, if the DMs are not initially flat (non zero initial_DM_command),
     we do not make the small phase assumption for initial DM phase
 
 The Matrix calculation is done during initialization:
@@ -97,13 +97,13 @@ The Matrix calculation is done during initialization:
 Once you have initialized, you can update the matrix during the correction
 wihtout re-initializing using ``update_matrices``.
 This can be useful to recalculate the jacobian by pushing the basis mode around a
-non zero DM voltage or an estimated a wavefront in pupil plane (likely estimated using
+non zero DM command or an estimated a wavefront in pupil plane (likely estimated using
 some phase diversity):
 
 .. code-block:: python
     
     corrector.update_matrices(testbed,
-                              initial_DM_voltage=some_DM_voltage,
+                              initial_DM_command=some_DM_command,
                               initial_estimated_wavefront=some_estimated_wavefront)
 
 

--- a/docs/estimation.rst
+++ b/docs/estimation.rst
@@ -9,11 +9,11 @@ are possible in Asterix. Additional details can be found directly in :ref:`the c
 It contains 3 functions at least:
 
 - an initialization ``Estimator.__init__()`` The initialization will require previous initialization of the testbed (see previous section) and the [Estimationconfig] part of the parameter file.  
-It set up everything you need for the estimation (e.g. the probes voltages and the PWP matrix). 
+It set up everything you need for the estimation (e.g. the probes commands and the PWP matrix). 
 
 - an probe function ``Estimator.probe()``, with parameters:
-        - the entrance EF
-        - DM voltages
+        - the entrance EF at the time of probing
+        - DM commands at the time of probing
         - the estimation wavelengths
     It returns the probed images as a list (of length ``nb_wav_estim``) of 3d arrays ([2*nprobes,dimScience,dimScience] if PWP or [1+nprobes,dimScience,dimScience] if BTP).
 
@@ -33,7 +33,7 @@ It set up everything you need for the estimation (e.g. the probes voltages and t
     myestim = Estimator(Estimationconfig, testbed)
 
     probed_images = myestim.probe(testbed,
-                                    voltage_vector=init_voltage,
+                                    dm_command=init_dmcommand,
                                     entrance_EF=input_wavefront,)
 
     resultatestimation = myestim.estimate(probed_images)
@@ -60,7 +60,7 @@ this estimation can be also done wihtout initialization or if another estimation
     Estimationconfig.update({'estimation': "Perfect"})
     myestim = Estimator(Estimationconfig, testbed)
     probed_images = myestim.probe(testbed,
-                                    voltage_vector=init_voltage,
+                                    dm_command=init_dmcommand,
                                     entrance_EF=input_wavefront,)
 
     resultatestimation = myestim.estimate(probed_images)
@@ -71,17 +71,17 @@ this estimation can be also done wihtout initialization or if another estimation
     myestim = Estimator(Estimationconfig, testbed)
 
     probed_images = myestim.probe(testbed,
-                                    voltage_vector=init_voltage,
+                                    dm_command=init_dmcommand,
                                     entrance_EF=input_wavefront)
 
     resultatestimation = myestim.estimate(probed_images)
     # this is a pair-wise FP estimation
 
     probed_images = myestim.probe(testbed,
-                                    voltage_vector=init_voltage,
+                                    dm_command=init_dmcommand,
                                     entrance_EF=input_wavefront,
                                     perfect_estimation=True)
-    resultatestimation = myestim.estimate(voltage_vector=init_voltage,
+    resultatestimation = myestim.estimate(dm_command=init_dmcommand,
                                           entrance_EF=input_wavefront,
                                           perfect_estimation=True)
     # this is also a perfect FP estimation, without 
@@ -95,7 +95,7 @@ resized by the ``Estim_bin_factor``:
     from Asterix.utils import resizing
     # testbed is previously defined
 
-    resultatestimation = resizing(testbed.todetector(voltage_vector=init_voltage,
+    resultatestimation = resizing(testbed.todetector(dm_command=init_dmcommand,
                                   entrance_EF=input_wavefront),myestim.dimEstim) 
 
 
@@ -132,7 +132,7 @@ a difference between positive probe and the unprobed image. For this estimator, 
     myestim = Estimator(Estimationconfig, testbed)
 
     probed_images = myestim.probe(testbed,
-                                    voltage_vector=init_voltage,
+                                    dm_command=init_dmcommand,
                                     entrance_EF=input_wavefront)
 
     resultatestimation = myestim.estimate(probed_images, testbed=testbed)

--- a/docs/run_asterix.rst
+++ b/docs/run_asterix.rst
@@ -250,7 +250,7 @@ Matrix parameters:
 
 If EFC:
 
-    - ``amplitudeEFC`` : float, in nm the value by which actuator is pusched. 
+    - ``amplitudeEFC`` : float, in nm the value by which actuator is pushed when creating the EFC basis. 
     - ``regularization`` : string, regularization when truncated modes in the inversion 'truncation' or 'tikhonov'.
 
 if ``onbench`` is True:

--- a/docs/run_asterix.rst
+++ b/docs/run_asterix.rst
@@ -245,7 +245,7 @@ Matrix parameters:
 
     - ``DM_basis`` : string, Actuator basis. Currently 'fourier' or 'actuator'. Same parameter for all DMs. Not case sensitive.
     - ``SmallPhaseHypEFCEFC`` : Bool, small phase hypothesis. If True : when applying modes on the DMs we, do a small phase assumption : exp(i phi_basis) = 1+ i.phi_basis. If False we keep exp(i phi_basis).
-                        In both case, if the DMs are not initially flat (non zero initial_DM_voltage), we do not make the small phase assumption for initial DM phase.
+                        In both case, if the DMs are not initially flat (non zero initial_DM_command), we do not make the small phase assumption for initial DM phase.
     - ``correction_algorithm`` : 'efc' for Electric Field Conjugation, 'em' for Energy Minimization, 'sm' for Stroke Minimization, or 'steepest'. Not case sensitive.
 
 If EFC:

--- a/notebooks/parity_checks.ipynb
+++ b/notebooks/parity_checks.ipynb
@@ -257,7 +257,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "coro_dh = thd2.todetector_intensity(in_contrast=True, voltage_vector=dm_command, noFPM=True)"
+    "coro_dh = thd2.todetector_intensity(in_contrast=True, dm_command=dm_command, noFPM=True)"
    ]
   },
   {

--- a/notebooks/work_with_DH_images.ipynb
+++ b/notebooks/work_with_DH_images.ipynb
@@ -164,7 +164,7 @@
    "source": [
     "### Coro PSF with applied DH\n",
     "\n",
-    "These are DM voltages from a WFS&C run in which the wrapped vortex FPM was perfectly centered. You can play with FPM shifts by restarting the kernel rerunning the entire notebook after adapting the Asterix scripts and configfile."
+    "These are DM commands from a WFS&C run in which the wrapped vortex FPM was perfectly centered. You can play with FPM shifts by restarting the kernel rerunning the entire notebook after adapting the Asterix scripts and configfile."
    ]
   },
   {
@@ -205,14 +205,14 @@
    "outputs": [],
    "source": [
     "# Read DM commands to apply\n",
-    "dm1_voltages = fits.getdata(os.path.join(experiment_dir, 'DM1_voltages.fits'))[dh_iteration - 1]\n",
-    "dm2_voltages = fits.getdata(os.path.join(experiment_dir, 'DM2_voltages.fits'))[dh_iteration - 1]\n",
+    "dm1_command = fits.getdata(os.path.join(experiment_dir, 'DM1_command.fits'))[dh_iteration - 1]\n",
+    "dm2_command = fits.getdata(os.path.join(experiment_dir, 'DM2_command.fits'))[dh_iteration - 1]\n",
     "\n",
     "# Concatenate into single array\n",
-    "dm_voltages = np.concatenate((dm1_voltages, dm2_voltages))\n",
+    "dm_commands = np.concatenate((dm1_command, dm2_command))\n",
     "\n",
     "print(f'Numer of actuators in testbed: {thd2.number_act}')\n",
-    "print(f'Number of actuators read in: {dm_voltages.shape[0]}')"
+    "print(f'Number of actuators read in: {dm_commands.shape[0]}')"
    ]
   },
   {
@@ -225,7 +225,7 @@
     "# Calculate DH image\n",
     "coro_dh = thd2.todetector_intensity(in_contrast=True, entrance_EF=input_wavefront,\n",
     "                                    EF_aberrations_introduced_in_LS=wavefront_in_LS,\n",
-    "                                    voltage_vector=dm_voltages)\n",
+    "                                    dm_command=dm_commands)\n",
     "\n",
     "plt.figure(figsize=(6, 6))\n",
     "plt.imshow(coro_dh/norm, cmap='inferno', norm=LogNorm(vmin=1e-10, vmax=1e-6))\n",


### PR DESCRIPTION
**Clarify DM command unit:** 
DM command in asterix where mostly called DM voltage vector, which was misleading on their unit.
This PR change all "DM voltage" names to "DM command" names and clarify that that their unit is in nm. 

**Saved Probe vectors:** 
We removed the harcoded 17. The Probe vectors that are saved for the testbed are now in nm (and pushed by amplitudePW nm).

**Normalise EFC matrix:** 
We divide the EFC matrix by amplitudeEFC: the EFC matrix is now in contrast to nm unit. 

In the Asterix simulation, I used to multiply the EFC matrix multiplication resulting command by amplitudeEFC to convert back to nm, I removed that, whole behavior in simulation is unchanged but to be tested on testbed to see if the gain ~1 again. 

If you want to test on your computer, do not forget to erase all existing matrix as the name is unchanged but the matrix did change ! 

