### PR TITLE
Allow loading of initial dm maps in the parameter file

### DIFF
--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -103,7 +103,7 @@ onbench=True
     # This fits must have PITCHV and PITCHH param in the header
     DM1_filename_grid_actu="Estimated_grid_DM1_20230426_opt7.42.fits"
 
-    # use this filename to load an initial DM map (from a previous correction for example) for DM1 
+    # use this filename to load an initial DM map (from a previous correction for example) for DM1
     DM1_filename_initcommand=""
 
     # Error on the model of the DM
@@ -151,7 +151,7 @@ onbench=True
     # This fits must have PITCHV and PITCHH param in the header
     DM2_filename_grid_actu="Estimated_grid_DM3_20230426_opt7.42.fits"
 
-    # use this filename to load an initial DM map (from a previous correction for example) for DM1 
+    # use this filename to load an initial DM map (from a previous correction for example) for DM2
     DM2_filename_initcommand=""
 
     # Error on the model of the DM

--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -152,7 +152,7 @@ onbench=True
     DM2_filename_grid_actu="Estimated_grid_DM3_20230426_opt7.42.fits"
 
     # use this filename to load an initial DM map (from a previous correction for example) for DM1 
-    DM2_filename_initcommand="/Users/jmazoyer/asterix_data/Results/20260727_13-28-36_My_first_experiment/DM2_lastcommand.fits"
+    DM2_filename_initcommand=""
 
     # Error on the model of the DM
     DM2_misregistration = False

--- a/Asterix/Example_param_file.ini
+++ b/Asterix/Example_param_file.ini
@@ -103,6 +103,9 @@ onbench=True
     # This fits must have PITCHV and PITCHH param in the header
     DM1_filename_grid_actu="Estimated_grid_DM1_20230426_opt7.42.fits"
 
+    # use this filename to load an initial DM map (from a previous correction for example) for DM1 
+    DM1_filename_initcommand=""
+
     # Error on the model of the DM
     DM1_misregistration = False
     DM1_xerror=0                #x-direction translation in actuator pitch
@@ -147,6 +150,9 @@ onbench=True
     # filename of the grid of actuator positions in unit of pupil diameter with (0,0)=center of the pupil
     # This fits must have PITCHV and PITCHH param in the header
     DM2_filename_grid_actu="Estimated_grid_DM3_20230426_opt7.42.fits"
+
+    # use this filename to load an initial DM map (from a previous correction for example) for DM1 
+    DM2_filename_initcommand="/Users/jmazoyer/asterix_data/Results/20260727_13-28-36_My_first_experiment/DM2_lastcommand.fits"
 
     # Error on the model of the DM
     DM2_misregistration = False

--- a/Asterix/Param_configspec.ini
+++ b/Asterix/Param_configspec.ini
@@ -36,6 +36,7 @@ onbench = boolean(default=False)
     DM1_filename_grid_actu = string(default="Grid_actu.fits")
     DM1_filename_actu_infl_fct = string(default="Actu_DM32_field=6x6pitch_pitch=22pix.fits")
     DM1_filename_active_actu = string(default="")
+    DM1_filename_initcommand = string(default="")
 
     # Error on the model of the DM
     DM1_misregistration = boolean(default=False)
@@ -53,6 +54,7 @@ onbench = boolean(default=False)
     DM2_filename_grid_actu = string(default="DM2_Grid_actu.fits")
     DM2_filename_actu_infl_fct = string(default="Actu_DM32_field=6x6pitch_pitch=22pix.fits")
     DM2_filename_active_actu = string(default="")
+    DM2_filename_initcommand = string(default="")
 
     # Error on the model of the DM
     DM2_misregistration = boolean(default=False)

--- a/Asterix/Param_file_roman.ini
+++ b/Asterix/Param_file_roman.ini
@@ -100,6 +100,9 @@ onbench=False
     # This fits must have PITCHV and PITCHH param in the header
     DM1_filename_grid_actu="Estimated_grid_DM1_20230426_opt7.42.fits"
 
+    # use this filename to load an initial DM map (from a previous correction for example) for DM1
+    DM1_filename_initcommand=""
+
     # Error on the model of the DM
     DM1_misregistration = False
     DM1_xerror=0                #x-direction translation in actuator pitch
@@ -144,6 +147,9 @@ onbench=False
     # filename of the grid of actuator positions in unit of pupil diameter with (0,0)=center of the pupil
     # This fits must have PITCHV and PITCHH param in the header
     DM2_filename_grid_actu="Estimated_grid_DM3_20230426_opt7.42.fits"
+
+    # use this filename to load an initial DM map (from a previous correction for example) for DM2
+    DM2_filename_initcommand=""
 
     # Error on the model of the DM
     DM2_misregistration = False
@@ -374,8 +380,8 @@ onbench=False
     ampl_abb_filename=''#Amplitude_THD2' # 'Amplitude_THD2' or '' for generic name or full fits path
 
     #Upstream Phase aberrations
-    set_UPphase_abb = True
-    set_UPrandom_phase = True
+    set_UPphase_abb = False
+    set_UPrandom_phase = False
     UPopd_rms = 5.0e-9 #in meter
     UPphase_rhoc = 4.3
     UPphase_slope = 3

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -146,7 +146,7 @@ def runthd2(parameter_file_path,
     for DM_name in thd2.name_of_DMs:
         if thd2.config_file["DMconfig"][DM_name + "_filename_initcommand"] != "":
             thisDM_initcommand = fits.getdata(config["DMconfig"][DM_name + "_filename_initcommand"])
-            DMs_initcommand += thd2.testbed_command_to_indiv_DM_command(thisDM_initcommand, DM_name)
+            DMs_initcommand += thd2.indiv_DM_command_to_testbed_command(thisDM_initcommand, DM_name)
 
     # Initialize the estimation
     estimator = Estimator(Estimationconfig,

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -146,8 +146,7 @@ def runthd2(parameter_file_path,
     for DM_name in thd2.name_of_DMs:
         if thd2.config_file["DMconfig"][DM_name + "_filename_initcommand"] != "":
             thisDM_initcommand = fits.getdata(config["DMconfig"][DM_name + "_filename_initcommand"])
-            DMs_initcommand += thd2.indiv_DM_voltage_to_testbed_voltage(thisDM_initcommand, DM_name)
-
+            DMs_initcommand += thd2.testbed_command_to_indiv_DM_command(thisDM_initcommand, DM_name)
 
     # Initialize the estimation
     estimator = Estimator(Estimationconfig,

--- a/Asterix/main_THD.py
+++ b/Asterix/main_THD.py
@@ -1,5 +1,6 @@
 import os
 import numpy as np
+from astropy.io import fits
 
 from Asterix.utils import create_experiment_dir, get_data_dir, get_git_description, read_parameter_file
 from Asterix.optics import Pupil, Coronagraph, DeformableMirror, Testbed
@@ -140,6 +141,14 @@ def runthd2(parameter_file_path,
     # Concatenate into the full testbed optical system
     thd2 = THD2(config, model_local_dir, silence=silence)
 
+    # Read if there was DM initial command
+    DMs_initcommand = np.zeros(thd2.number_act)
+    for DM_name in thd2.name_of_DMs:
+        if thd2.config_file["DMconfig"][DM_name + "_filename_initcommand"] != "":
+            thisDM_initcommand = fits.getdata(config["DMconfig"][DM_name + "_filename_initcommand"])
+            DMs_initcommand += thd2.indiv_DM_voltage_to_testbed_voltage(thisDM_initcommand, DM_name)
+
+
     # Initialize the estimation
     estimator = Estimator(Estimationconfig,
                           thd2,
@@ -168,6 +177,8 @@ def runthd2(parameter_file_path,
                           estimator.dimEstim,
                           maskEstim=estim_mask_dh,
                           wav_vec_estim=estimator.wav_vec_estim,
+                          initial_estimated_wavefront=1.,
+                          initial_DM_command=DMs_initcommand,
                           matrix_dir=matrix_dir,
                           save_for_bench=onbench,
                           realtestbed_dir=hardware_dir,
@@ -211,7 +222,7 @@ def runthd2(parameter_file_path,
                               SIMUconfig,
                               input_wavefront=input_wavefront,
                               EF_aberrations_introduced_in_LS=wavefront_in_LS,
-                              initial_DM_command=0,
+                              initial_DM_command=DMs_initcommand,
                               silence=silence,
                               probe_dir=probe_dir,
                               **kwargs)

--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -543,9 +543,11 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
 
             fits.writeto(os.path.join(result_dir, f"{DM_name}_strokes.fits"), DMstrokes[j], header, overwrite=True)
 
-            command_DMs_tosave = testbed.testbed_command_to_indiv_DM_command(command_DMs_nparray, DM_name)
+            command_DMs_tosave = np.zeros((nb_total_iter, DM.number_act))
+            for i in np.arange(nb_total_iter):
+                command_DMs_tosave[i] = testbed.testbed_voltage_to_indiv_DM_voltage(command_DMs_nparray[i], DM_name)
 
-            fits.writeto(os.path.join(result_dir, f"{DM_name}_command.fits"),
+            fits.writeto(os.path.join(result_dir, f"{DM_name}_voltages.fits"),
                          command_DMs_tosave,
                          header,
                          overwrite=True)

--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -552,6 +552,11 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
                          header,
                          overwrite=True)
 
+            fits.writeto(os.path.join(result_dir, f"{DM_name}_lastcommand.fits"),
+                                     command_DMs_tosave[-1],
+                                     header,
+                                     overwrite=True)
+
             plt.plot(np.std(DMstrokes[j], axis=(1, 2)), label=DM_name + " RMS")
             plt.plot(np.max(DMstrokes[j], axis=(1, 2)) - np.min(DMstrokes[j], axis=(1, 2)), label=DM_name + " PV")
 

--- a/Asterix/wfsc/correction_loop.py
+++ b/Asterix/wfsc/correction_loop.py
@@ -545,9 +545,9 @@ def save_loop_results(CorrectionLoopResult, config, testbed: Testbed, MaskScienc
 
             command_DMs_tosave = np.zeros((nb_total_iter, DM.number_act))
             for i in np.arange(nb_total_iter):
-                command_DMs_tosave[i] = testbed.testbed_voltage_to_indiv_DM_voltage(command_DMs_nparray[i], DM_name)
+                command_DMs_tosave[i] = testbed.testbed_command_to_indiv_DM_command(command_DMs_nparray[i], DM_name)
 
-            fits.writeto(os.path.join(result_dir, f"{DM_name}_voltages.fits"),
+            fits.writeto(os.path.join(result_dir, f"{DM_name}_command.fits"),
                          command_DMs_tosave,
                          header,
                          overwrite=True)

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -35,6 +35,8 @@ class Corrector:
                  dimEstim,
                  maskEstim=None,
                  wav_vec_estim=None,
+                 initial_estimated_wavefront=1.,
+                 initial_DM_command=0.,
                  matrix_dir=None,
                  save_for_bench=False,
                  realtestbed_dir='',
@@ -60,6 +62,21 @@ class Corrector:
             binary array of size [dimEstim, dimEstim] : dark hole mask
         wav_vec_estim : list of wavelengths, default: [testbed.wavelength_0]
             vector of wavelengths for polychromatic correction
+        input_wavefront : float or 2d complex array or 3d complex array
+            Initial wavefront at the beginning of this loop.
+            Electrical Field which can be a:
+                float=1 if there are no phase/amplitude aberrations (default)
+                2D complex array, of size phase_abb.shape if monochromatic
+                or 3D complex array of size [self.nb_wav,phase_abb.shape] if polychromatic
+            !!CAREFUL!!: Right now we do not use this wf to measure the matrix, although the update_matrices()
+                method inside the Corrector allows it. Currently, each matrix is measured with a flat field in
+                the entrance of the testbed (input_wavefront = 1).
+                'input_wavefront' is only used in the loop once the matrix is calculated. This can be changed but be careful.
+        initial_DM_command : float or 1D array
+            Initial DM command at the beginning of this loop. The Matrix is measured using the initial DM command.
+            Can be:
+                float 0 if flat DMs (default)
+                or 1D array of size testbed.number_act
         matrix_dir : string, default: None
             path to directory to save interraction matrices
         save_for_bench : bool default: false
@@ -114,7 +131,10 @@ class Corrector:
             self.MaskEstim = np.zeros((self.dimEstim, self.dimEstim))
 
         self.matrix_dir = matrix_dir
-        self.update_matrices(testbed, silence=silence)
+        self.update_matrices(testbed,
+                             initial_DM_voltage=initial_DM_command,
+                             initial_estimated_wavefront=initial_estimated_wavefront,
+                             silence=silence)
 
         if self.correction_algorithm == "efc" and save_for_bench:
             if not os.path.exists(realtestbed_dir):

--- a/Asterix/wfsc/corrector.py
+++ b/Asterix/wfsc/corrector.py
@@ -132,7 +132,7 @@ class Corrector:
 
         self.matrix_dir = matrix_dir
         self.update_matrices(testbed,
-                             initial_DM_voltage=initial_DM_command,
+                             initial_DM_command=initial_DM_command,
                              initial_estimated_wavefront=initial_estimated_wavefront,
                              silence=silence)
 


### PR DESCRIPTION
- add DM1_filename_initcommand and DM2_filename_initcommand to load initial DM command
- commands are used as basis when we create the EFC matrix
- When saving the loop result, I corrected a small error in the saving of all the loop DM commands that was not done properly. I also added another file "DM*_last_command.fits" that only contains the last DM command, so that can it be used directly in the parameter file if we want to restart the correction were it was stopped.

